### PR TITLE
feat(project-discovery): migrate clean/list/show to session defaults

### DIFF
--- a/docs/session-aware-migration-todo.md
+++ b/docs/session-aware-migration-todo.md
@@ -5,11 +5,11 @@ _Audit date: October 6, 2025_
 Reference: `docs/session_management_plan.md`
 
 ## Utilities
-- [ ] `src/mcp/tools/utilities/clean.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`.
+- [x] `src/mcp/tools/utilities/clean.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`.
 
 ## Project Discovery
-- [ ] `src/mcp/tools/project-discovery/list_schemes.ts` — session defaults: `projectPath`, `workspacePath`.
-- [ ] `src/mcp/tools/project-discovery/show_build_settings.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`.
+- [x] `src/mcp/tools/project-discovery/list_schemes.ts` — session defaults: `projectPath`, `workspacePath`.
+- [x] `src/mcp/tools/project-discovery/show_build_settings.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`.
 
 ## Device Workflows
 - [ ] `src/mcp/tools/device/build_device.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`.

--- a/src/mcp/tools/project-discovery/show_build_settings.ts
+++ b/src/mcp/tools/project-discovery/show_build_settings.ts
@@ -11,7 +11,7 @@ import type { CommandExecutor } from '../../../utils/execution/index.ts';
 import { getDefaultCommandExecutor } from '../../../utils/execution/index.ts';
 import { createTextResponse } from '../../../utils/responses/index.ts';
 import { ToolResponse } from '../../../types/common.ts';
-import { createTypedTool } from '../../../utils/typed-tool-factory.ts';
+import { createSessionAwareTool } from '../../../utils/typed-tool-factory.ts';
 import { nullifyEmptyStrings } from '../../../utils/schema-helpers.ts';
 
 // Unified schema: XOR between projectPath and workspacePath
@@ -102,14 +102,24 @@ export async function showBuildSettingsLogic(
   }
 }
 
+const publicSchemaObject = baseSchemaObject.omit({
+  projectPath: true,
+  workspacePath: true,
+  scheme: true,
+} as const);
+
 export default {
   name: 'show_build_settings',
-  description:
-    "Shows build settings from either a project or workspace using xcodebuild. Provide exactly one of projectPath or workspacePath, plus scheme. Example: show_build_settings({ projectPath: '/path/to/MyProject.xcodeproj', scheme: 'MyScheme' })",
-  schema: baseSchemaObject.shape,
-  handler: createTypedTool<ShowBuildSettingsParams>(
-    showBuildSettingsSchema as z.ZodType<ShowBuildSettingsParams>,
-    showBuildSettingsLogic,
-    getDefaultCommandExecutor,
-  ),
+  description: 'Shows xcodebuild build settings.',
+  schema: publicSchemaObject.shape,
+  handler: createSessionAwareTool<ShowBuildSettingsParams>({
+    internalSchema: showBuildSettingsSchema as unknown as z.ZodType<ShowBuildSettingsParams>,
+    logicFunction: showBuildSettingsLogic,
+    getExecutor: getDefaultCommandExecutor,
+    requirements: [
+      { allOf: ['scheme'], message: 'scheme is required' },
+      { oneOf: ['projectPath', 'workspacePath'], message: 'Provide a project or workspace' },
+    ],
+    exclusivePairs: [['projectPath', 'workspacePath']],
+  }),
 };

--- a/src/utils/typed-tool-factory.ts
+++ b/src/utils/typed-tool-factory.ts
@@ -92,7 +92,9 @@ export function createSessionAwareTool<TParams>(opts: {
       // Sanitize args: treat null/undefined as "not provided" so they don't override session defaults
       const sanitizedArgs: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(rawArgs)) {
-        if (v !== null && v !== undefined) sanitizedArgs[k] = v;
+        if (v === null || v === undefined) continue;
+        if (typeof v === 'string' && v.trim() === '') continue;
+        sanitizedArgs[k] = v;
       }
 
       // Factory-level mutual exclusivity check: if user provides multiple explicit values


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates `clean`, `list_schemes`, and `show_build_settings` to session-aware handlers, hiding path/scheme params from public schemas and tightening validation/messages; updates tests and docs accordingly.
> 
> - **Tools (session-aware migration)**
>   - `src/mcp/tools/utilities/clean.ts`: switch to `createSessionAwareTool`, hide `projectPath`/`workspacePath`/`scheme`/`configuration` from public schema, shorten description, enforce oneOf project/workspace and mutual exclusivity.
>   - `src/mcp/tools/project-discovery/list_schemes.ts`: use `createSessionAwareTool`, hide path params from public schema, shorten description, add session requirements (project/workspace) and exclusivity.
>   - `src/mcp/tools/project-discovery/show_build_settings.ts`: use `createSessionAwareTool`, hide path/scheme from public schema, shorten description, require `scheme` and project/workspace via session, enforce exclusivity.
> - **Validation/behavior**
>   - Improved error messaging: "Missing required session defaults", "Provide a project or workspace", "Mutually exclusive parameters provided"; ignore empty-string args when merging with session defaults.
> - **Factory**
>   - `src/utils/typed-tool-factory.ts`: enhance arg sanitization (skip empty strings), add requirement checks and exclusivity handling for session-aware tools; include user-friendly hints in errors.
> - **Tests**
>   - Update tests to expect empty public schemas, new descriptions/messages, and session behavior; clear `sessionStore` in `beforeEach`.
> - **Docs**
>   - `docs/session-aware-migration-todo.md`: check off `clean`, `list_schemes`, `show_build_settings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b32d9b6076db6ce6d9c062a1575c536d6e4cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tools now session-aware for cleaner inputs and context-driven defaults (Clean, List Schemes, Show Build Settings).
  - Public schemas simplified to hide project/workspace/scheme parameters from the UI.
  - Shorter, clearer tool descriptions.

- Bug Fixes
  - Empty string arguments no longer override session defaults, preventing misconfiguration.

- Behavior Changes
  - More precise validation with mutually exclusive project/workspace and clearer guidance when session defaults are missing.

- Documentation
  - Updated checklist to reflect completed utilities and project discovery tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->