### PR TITLE
feat: migrate macOS tools to session-aware defaults

### DIFF
--- a/docs/session-aware-migration-todo.md
+++ b/docs/session-aware-migration-todo.md
@@ -23,10 +23,10 @@ Reference: `docs/session_management_plan.md`
 - [ ] `src/mcp/tools/logging/start_device_log_cap.ts` — session defaults: `deviceId`.
 
 ## macOS Workflows
-- [ ] `src/mcp/tools/macos/build_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
-- [ ] `src/mcp/tools/macos/build_run_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
-- [ ] `src/mcp/tools/macos/test_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`.
-- [ ] `src/mcp/tools/macos/get_mac_app_path.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
+- [x] `src/mcp/tools/macos/build_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
+- [x] `src/mcp/tools/macos/build_run_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
+- [x] `src/mcp/tools/macos/test_macos.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`.
+- [x] `src/mcp/tools/macos/get_mac_app_path.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `configuration`, `arch`.
 
 ## Simulator Build/Test/Path
 - [x] `src/mcp/tools/simulator/test_sim.ts` — session defaults: `projectPath`, `workspacePath`, `scheme`, `simulatorId`, `simulatorName`, `configuration`, `useLatestOS`.


### PR DESCRIPTION
## Summary
- migrate macOS build/test/path tools to the session-aware handler and trim public schemas to non-session fields
- update macOS tool specs/tests to exercise session requirements and exclusive pairs
- check off macOS entries in the migration tracker

## Background/Details
- aligns macOS workflow tools with the session defaults plan so clients rely on shared session state rather than repeating parameters per tool
- consolidates schema exposure to match the public/session split outlined in docs/session_management_plan.md

## Solution
- swap macOS tool exports to use createSessionAwareTool with requirement and exclusive-pair guards while preserving internal logic
- reduce exported schemas/descriptions to non-session fields and refresh vitest coverage for new error messaging
- update the migration TODO to reflect completed macOS tasks

## Testing
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm run test
- npx mcpli session-set-defaults --projectPath "/Volumes/Developer/XcodeBuildMCP/example_projects/macOS/MCPTest.xcodeproj" --scheme MCPTest --configuration Debug --arch arm64 -- node build/index.js
- npx mcpli --tool-timeout=600 build-macos -- node build/index.js
- npx mcpli get-mac-app-path -- node build/index.js
- npx mcpli --tool-timeout=600 build-run-macos -- node build/index.js
- npx mcpli --tool-timeout=600 test-macos -- node build/index.js (fails: MCPTest scheme lacks test action in sample project)

## Notes
- test-macos failure mirrors current sample project configuration; no regression introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates macOS build/test/path tools to session-aware handlers with session-backed defaults, exposes only non-session schema fields, updates tests and docs checklist.
> 
> - **macOS Tools (session-aware migration)**:
>   - Swap to `createSessionAwareTool` in `build_macos.ts`, `build_run_macos.ts`, `test_macos.ts`, `get_mac_app_path.ts` with `requirements` and `exclusivePairs` guards.
>   - Trim exported `schema` to public (non-session) fields via `publicSchemaObject`; simplify `description`s.
>   - Preserve internal logic; enforce XOR and session-required errors with updated messages.
> - **Tests**:
>   - Update specs in `src/mcp/tools/macos/__tests__/*` to validate public schemas, session requirements, mutual exclusivity, and new error messages; add `sessionStore.clear()` setup.
> - **Docs**:
>   - Mark macOS migration items as complete in `docs/session-aware-migration-todo.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6eba46a9c973ac31169d876b2fdb0f891736156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS build, run, and test tools now support session-aware defaults, allowing configuration to persist across commands.

* **Bug Fixes**
  * Enhanced parameter validation with clearer error messages for mutually exclusive options and missing required parameters.

* **Chores**
  * Completed macOS tool infrastructure migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->