### PR TITLE
feat: Add MCP tool annotations to all tools

### DIFF
--- a/src/core/plugin-types.ts
+++ b/src/core/plugin-types.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
+import { ToolAnnotations } from '@camsoft/mcp-sdk/types.js';
 import { ToolResponse } from '../types/common.ts';
 
 export interface PluginMeta {
   readonly name: string; // Verb used by MCP
   readonly schema: Record<string, z.ZodTypeAny>; // Zod validation schema (object schema)
   readonly description?: string; // One-liner shown in help
+  readonly annotations?: ToolAnnotations; // MCP tool annotations for LLM behavior hints
   handler(params: Record<string, unknown>): Promise<ToolResponse>;
 }
 

--- a/src/mcp/tools/device/build_device.ts
+++ b/src/mcp/tools/device/build_device.ts
@@ -78,6 +78,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Build Device',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BuildDeviceParams>({
     internalSchema: buildDeviceSchema as unknown as z.ZodType<BuildDeviceParams>,
     logicFunction: buildDeviceLogic,

--- a/src/mcp/tools/device/get_device_app_path.ts
+++ b/src/mcp/tools/device/get_device_app_path.ts
@@ -161,6 +161,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Get Device App Path',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<GetDeviceAppPathParams>({
     internalSchema: getDeviceAppPathSchema as unknown as z.ZodType<GetDeviceAppPathParams>,
     logicFunction: get_device_app_pathLogic,

--- a/src/mcp/tools/device/install_app_device.ts
+++ b/src/mcp/tools/device/install_app_device.ts
@@ -92,6 +92,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: installAppDeviceSchema,
   }),
+  annotations: {
+    title: 'Install App Device',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<InstallAppDeviceParams>({
     internalSchema: installAppDeviceSchema as unknown as z.ZodType<InstallAppDeviceParams>,
     logicFunction: install_app_deviceLogic,

--- a/src/mcp/tools/device/launch_app_device.ts
+++ b/src/mcp/tools/device/launch_app_device.ts
@@ -151,6 +151,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: launchAppDeviceSchema,
   }),
+  annotations: {
+    title: 'Launch App Device',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<LaunchAppDeviceParams>({
     internalSchema: launchAppDeviceSchema as unknown as z.ZodType<LaunchAppDeviceParams>,
     logicFunction: launch_app_deviceLogic,

--- a/src/mcp/tools/device/list_devices.ts
+++ b/src/mcp/tools/device/list_devices.ts
@@ -431,5 +431,9 @@ export default {
   description:
     'Lists connected physical Apple devices (iPhone, iPad, Apple Watch, Apple TV, Apple Vision Pro) with their UUIDs, names, and connection status. Use this to discover physical devices for testing.',
   schema: listDevicesSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'List Devices',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(listDevicesSchema, list_devicesLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/device/stop_app_device.ts
+++ b/src/mcp/tools/device/stop_app_device.ts
@@ -94,6 +94,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: stopAppDeviceSchema,
   }),
+  annotations: {
+    title: 'Stop App Device',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<StopAppDeviceParams>({
     internalSchema: stopAppDeviceSchema as unknown as z.ZodType<StopAppDeviceParams>,
     logicFunction: stop_app_deviceLogic,

--- a/src/mcp/tools/device/test_device.ts
+++ b/src/mcp/tools/device/test_device.ts
@@ -291,6 +291,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Test Device',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TestDeviceParams>({
     internalSchema: testDeviceSchema as unknown as z.ZodType<TestDeviceParams>,
     logicFunction: (params: TestDeviceParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/discovery/discover_tools.ts
+++ b/src/mcp/tools/discovery/discover_tools.ts
@@ -384,6 +384,10 @@ export default {
   description:
     'Analyzes a natural language task description and enables the most relevant development workflow. Prioritizes project/workspace workflows (simulator/device/macOS) and also supports task-based workflows (simulator-management, logging) and Swift packages.',
   schema: discoverToolsSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Discover Tools',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(
     discoverToolsSchema,
     (params: DiscoverToolsParams, executor) => {

--- a/src/mcp/tools/doctor/doctor.ts
+++ b/src/mcp/tools/doctor/doctor.ts
@@ -273,6 +273,10 @@ export default {
   description:
     'Provides comprehensive information about the MCP server environment, available dependencies, and configuration status.',
   schema: doctorSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Doctor',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(doctorSchema, doctorMcpHandler, getDefaultCommandExecutor),
 };
 

--- a/src/mcp/tools/logging/start_device_log_cap.ts
+++ b/src/mcp/tools/logging/start_device_log_cap.ts
@@ -688,6 +688,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: startDeviceLogCapSchema,
   }),
+  annotations: {
+    title: 'Start Device Log Capture',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<StartDeviceLogCapParams>({
     internalSchema: startDeviceLogCapSchema as unknown as z.ZodType<StartDeviceLogCapParams>,
     logicFunction: start_device_log_capLogic,

--- a/src/mcp/tools/logging/start_sim_log_cap.ts
+++ b/src/mcp/tools/logging/start_sim_log_cap.ts
@@ -68,6 +68,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: startSimLogCapSchema,
   }),
+  annotations: {
+    title: 'Start Simulator Log Capture',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<StartSimLogCapParams>({
     internalSchema: startSimLogCapSchema as unknown as z.ZodType<StartSimLogCapParams>,
     logicFunction: start_sim_log_capLogic,

--- a/src/mcp/tools/logging/stop_device_log_cap.ts
+++ b/src/mcp/tools/logging/stop_device_log_cap.ts
@@ -312,6 +312,10 @@ export default {
   name: 'stop_device_log_cap',
   description: 'Stops an active Apple device log capture session and returns the captured logs.',
   schema: stopDeviceLogCapSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Stop Device Log Capture',
+    destructiveHint: true,
+  },
   handler: createTypedTool(
     stopDeviceLogCapSchema,
     (params: StopDeviceLogCapParams) => {

--- a/src/mcp/tools/logging/stop_sim_log_cap.ts
+++ b/src/mcp/tools/logging/stop_sim_log_cap.ts
@@ -44,5 +44,9 @@ export default {
   name: 'stop_sim_log_cap',
   description: 'Stops an active simulator log capture session and returns the captured logs.',
   schema: stopSimLogCapSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Stop Simulator Log Capture',
+    destructiveHint: true,
+  },
   handler: createTypedTool(stopSimLogCapSchema, stop_sim_log_capLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/macos/build_macos.ts
+++ b/src/mcp/tools/macos/build_macos.ts
@@ -105,6 +105,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Build macOS',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BuildMacOSParams>({
     internalSchema: buildMacOSSchema as unknown as z.ZodType<BuildMacOSParams>,
     logicFunction: buildMacOSLogic,

--- a/src/mcp/tools/macos/build_run_macos.ts
+++ b/src/mcp/tools/macos/build_run_macos.ts
@@ -223,6 +223,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Build Run macOS',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BuildRunMacOSParams>({
     internalSchema: buildRunMacOSSchema as unknown as z.ZodType<BuildRunMacOSParams>,
     logicFunction: buildRunMacOSLogic,

--- a/src/mcp/tools/macos/get_mac_app_path.ts
+++ b/src/mcp/tools/macos/get_mac_app_path.ts
@@ -195,6 +195,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Get macOS App Path',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<GetMacosAppPathParams>({
     internalSchema: getMacosAppPathSchema as unknown as z.ZodType<GetMacosAppPathParams>,
     logicFunction: get_mac_app_pathLogic,

--- a/src/mcp/tools/macos/launch_mac_app.ts
+++ b/src/mcp/tools/macos/launch_mac_app.ts
@@ -79,5 +79,9 @@ export default {
   description:
     "Launches a macOS application. IMPORTANT: You MUST provide the appPath parameter. Example: launch_mac_app({ appPath: '/path/to/your/app.app' }) Note: In some environments, this tool may be prefixed as mcp0_launch_macos_app.",
   schema: launchMacAppSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Launch macOS App',
+    destructiveHint: true,
+  },
   handler: createTypedTool(launchMacAppSchema, launch_mac_appLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -82,5 +82,9 @@ export default {
   name: 'stop_mac_app',
   description: 'Stops a running macOS application. Can stop by app name or process ID.',
   schema: stopMacAppSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Stop macOS App',
+    destructiveHint: true,
+  },
   handler: createTypedTool(stopMacAppSchema, stop_mac_appLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/macos/test_macos.ts
+++ b/src/mcp/tools/macos/test_macos.ts
@@ -333,6 +333,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Test macOS',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TestMacosParams>({
     internalSchema: testMacosSchema as unknown as z.ZodType<TestMacosParams>,
     logicFunction: (params, executor) =>

--- a/src/mcp/tools/project-discovery/discover_projs.ts
+++ b/src/mcp/tools/project-discovery/discover_projs.ts
@@ -274,6 +274,10 @@ export default {
   description:
     'Scans a directory (defaults to workspace root) to find Xcode project (.xcodeproj) and workspace (.xcworkspace) files.',
   schema: discoverProjsSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Discover Projects',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(
     discoverProjsSchema,
     (params: DiscoverProjsParams) => {

--- a/src/mcp/tools/project-discovery/get_app_bundle_id.ts
+++ b/src/mcp/tools/project-discovery/get_app_bundle_id.ts
@@ -128,6 +128,10 @@ export default {
   description:
     "Extracts the bundle identifier from an app bundle (.app) for any Apple platform (iOS, iPadOS, watchOS, tvOS, visionOS). IMPORTANT: You MUST provide the appPath parameter. Example: get_app_bundle_id({ appPath: '/path/to/your/app.app' })",
   schema: getAppBundleIdSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Get App Bundle ID',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(
     getAppBundleIdSchema,
     (params: GetAppBundleIdParams) =>

--- a/src/mcp/tools/project-discovery/get_mac_bundle_id.ts
+++ b/src/mcp/tools/project-discovery/get_mac_bundle_id.ts
@@ -125,6 +125,10 @@ export default {
   description:
     "Extracts the bundle identifier from a macOS app bundle (.app). IMPORTANT: You MUST provide the appPath parameter. Example: get_mac_bundle_id({ appPath: '/path/to/your/app.app' }) Note: In some environments, this tool may be prefixed as mcp0_get_macos_bundle_id.",
   schema: getMacBundleIdSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Get Mac Bundle ID',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(
     getMacBundleIdSchema,
     (params: GetMacBundleIdParams) =>

--- a/src/mcp/tools/project-discovery/list_schemes.ts
+++ b/src/mcp/tools/project-discovery/list_schemes.ts
@@ -124,6 +124,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'List Schemes',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<ListSchemesParams>({
     internalSchema: listSchemesSchema as unknown as z.ZodType<ListSchemesParams>,
     logicFunction: listSchemesLogic,

--- a/src/mcp/tools/project-discovery/show_build_settings.ts
+++ b/src/mcp/tools/project-discovery/show_build_settings.ts
@@ -118,6 +118,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Show Build Settings',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<ShowBuildSettingsParams>({
     internalSchema: showBuildSettingsSchema as unknown as z.ZodType<ShowBuildSettingsParams>,
     logicFunction: showBuildSettingsLogic,

--- a/src/mcp/tools/project-scaffolding/scaffold_ios_project.ts
+++ b/src/mcp/tools/project-scaffolding/scaffold_ios_project.ts
@@ -501,6 +501,10 @@ export default {
   description:
     'Scaffold a new iOS project from templates. Creates a modern Xcode project with workspace structure, SPM package for features, and proper iOS configuration.',
   schema: ScaffoldiOSProjectSchema.shape,
+  annotations: {
+    title: 'Scaffold iOS Project',
+    destructiveHint: true,
+  },
   async handler(args: Record<string, unknown>): Promise<ToolResponse> {
     const params = ScaffoldiOSProjectSchema.parse(args);
     return scaffold_ios_projectLogic(

--- a/src/mcp/tools/project-scaffolding/scaffold_macos_project.ts
+++ b/src/mcp/tools/project-scaffolding/scaffold_macos_project.ts
@@ -407,6 +407,10 @@ export default {
   description:
     'Scaffold a new macOS project from templates. Creates a modern Xcode project with workspace structure, SPM package for features, and proper macOS configuration.',
   schema: ScaffoldmacOSProjectSchema.shape,
+  annotations: {
+    title: 'Scaffold macOS Project',
+    destructiveHint: true,
+  },
   async handler(args: Record<string, unknown>): Promise<ToolResponse> {
     // Validate the arguments against the schema before processing
     const validatedArgs = ScaffoldmacOSProjectSchema.parse(args);

--- a/src/mcp/tools/session-management/session_clear_defaults.ts
+++ b/src/mcp/tools/session-management/session_clear_defaults.ts
@@ -33,5 +33,9 @@ export default {
   name: 'session-clear-defaults',
   description: 'Clear selected or all session defaults.',
   schema: schemaObj.shape,
+  annotations: {
+    title: 'Clear Session Defaults',
+    destructiveHint: true,
+  },
   handler: createTypedTool(schemaObj, sessionClearDefaultsLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/session-management/session_set_defaults.ts
+++ b/src/mcp/tools/session-management/session_set_defaults.ts
@@ -57,5 +57,9 @@ export default {
   description:
     'Set the session defaults needed by many tools. Most tools require one or more session defaults to be set before they can be used. Agents should set all relevant defaults up front in a single call (e.g., project/workspace, scheme, simulator or device ID, useLatestOS) to avoid iterative prompts; only set the keys your workflow needs.',
   schema: baseSchema.shape,
+  annotations: {
+    title: 'Set Session Defaults',
+    destructiveHint: true,
+  },
   handler: createTypedTool(schemaObj, sessionSetDefaultsLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/session-management/session_show_defaults.ts
+++ b/src/mcp/tools/session-management/session_show_defaults.ts
@@ -5,6 +5,10 @@ export default {
   name: 'session-show-defaults',
   description: 'Show current session defaults.',
   schema: {},
+  annotations: {
+    title: 'Show Session Defaults',
+    readOnlyHint: true,
+  },
   handler: async (): Promise<ToolResponse> => {
     const current = sessionStore.getAll();
     return { content: [{ type: 'text', text: JSON.stringify(current, null, 2) }], isError: false };

--- a/src/mcp/tools/simulator-management/erase_sims.ts
+++ b/src/mcp/tools/simulator-management/erase_sims.ts
@@ -90,6 +90,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: eraseSimsSchema,
   }),
+  annotations: {
+    title: 'Erase Simulators',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<EraseSimsParams>({
     internalSchema: eraseSimsSchema as unknown as z.ZodType<EraseSimsParams>,
     logicFunction: erase_simsLogic,

--- a/src/mcp/tools/simulator-management/reset_sim_location.ts
+++ b/src/mcp/tools/simulator-management/reset_sim_location.ts
@@ -99,6 +99,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: resetSimulatorLocationSchema,
   }),
+  annotations: {
+    title: 'Reset Simulator Location',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<ResetSimulatorLocationParams>({
     internalSchema:
       resetSimulatorLocationSchema as unknown as z.ZodType<ResetSimulatorLocationParams>,

--- a/src/mcp/tools/simulator-management/set_sim_appearance.ts
+++ b/src/mcp/tools/simulator-management/set_sim_appearance.ts
@@ -99,6 +99,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: setSimAppearanceSchema,
   }),
+  annotations: {
+    title: 'Set Simulator Appearance',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<SetSimAppearanceParams>({
     internalSchema: setSimAppearanceSchema as unknown as z.ZodType<SetSimAppearanceParams>,
     logicFunction: set_sim_appearanceLogic,

--- a/src/mcp/tools/simulator-management/set_sim_location.ts
+++ b/src/mcp/tools/simulator-management/set_sim_location.ts
@@ -127,6 +127,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: setSimulatorLocationSchema,
   }),
+  annotations: {
+    title: 'Set Simulator Location',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<SetSimulatorLocationParams>({
     internalSchema: setSimulatorLocationSchema as unknown as z.ZodType<SetSimulatorLocationParams>,
     logicFunction: set_sim_locationLogic,

--- a/src/mcp/tools/simulator-management/sim_statusbar.ts
+++ b/src/mcp/tools/simulator-management/sim_statusbar.ts
@@ -101,6 +101,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: simStatusbarSchema,
   }), // MCP SDK compatibility
+  annotations: {
+    title: 'Simulator Statusbar',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<SimStatusbarParams>({
     internalSchema: simStatusbarSchema as unknown as z.ZodType<SimStatusbarParams>,
     logicFunction: sim_statusbarLogic,

--- a/src/mcp/tools/simulator/boot_sim.ts
+++ b/src/mcp/tools/simulator/boot_sim.ts
@@ -75,6 +75,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: bootSimSchemaObject,
   }),
+  annotations: {
+    title: 'Boot Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BootSimParams>({
     internalSchema: bootSimSchemaObject,
     logicFunction: boot_simLogic,

--- a/src/mcp/tools/simulator/build_run_sim.ts
+++ b/src/mcp/tools/simulator/build_run_sim.ts
@@ -510,6 +510,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Build Run Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BuildRunSimulatorParams>({
     internalSchema: buildRunSimulatorSchema as unknown as z.ZodType<BuildRunSimulatorParams>,
     logicFunction: build_run_simLogic,

--- a/src/mcp/tools/simulator/build_sim.ts
+++ b/src/mcp/tools/simulator/build_sim.ts
@@ -157,6 +157,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }), // MCP SDK compatibility (public inputs only)
+  annotations: {
+    title: 'Build Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<BuildSimulatorParams>({
     internalSchema: buildSimulatorSchema as unknown as z.ZodType<BuildSimulatorParams>,
     logicFunction: build_simLogic,

--- a/src/mcp/tools/simulator/get_sim_app_path.ts
+++ b/src/mcp/tools/simulator/get_sim_app_path.ts
@@ -310,6 +310,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseGetSimulatorAppPathSchema,
   }),
+  annotations: {
+    title: 'Get Simulator App Path',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<GetSimulatorAppPathParams>({
     internalSchema: getSimulatorAppPathSchema as unknown as z.ZodType<GetSimulatorAppPathParams>,
     logicFunction: get_sim_app_pathLogic,

--- a/src/mcp/tools/simulator/install_app_sim.ts
+++ b/src/mcp/tools/simulator/install_app_sim.ts
@@ -103,6 +103,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: installAppSimSchemaObject,
   }),
+  annotations: {
+    title: 'Install App Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<InstallAppSimParams>({
     internalSchema: installAppSimSchemaObject,
     logicFunction: install_app_simLogic,

--- a/src/mcp/tools/simulator/launch_app_logs_sim.ts
+++ b/src/mcp/tools/simulator/launch_app_logs_sim.ts
@@ -74,6 +74,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: launchAppLogsSimSchemaObject,
   }),
+  annotations: {
+    title: 'Launch App Logs Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<LaunchAppLogsSimParams>({
     internalSchema: launchAppLogsSimSchemaObject,
     logicFunction: launch_app_logs_simLogic,

--- a/src/mcp/tools/simulator/launch_app_sim.ts
+++ b/src/mcp/tools/simulator/launch_app_sim.ts
@@ -207,6 +207,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Launch App Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<LaunchAppSimParams>({
     internalSchema: launchAppSimSchema as unknown as z.ZodType<LaunchAppSimParams>,
     logicFunction: launch_app_simLogic,

--- a/src/mcp/tools/simulator/list_sims.ts
+++ b/src/mcp/tools/simulator/list_sims.ts
@@ -217,5 +217,9 @@ export default {
   name: 'list_sims',
   description: 'Lists available iOS simulators with their UUIDs. ',
   schema: listSimsSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'List Simulators',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(listSimsSchema, list_simsLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/simulator/open_sim.ts
+++ b/src/mcp/tools/simulator/open_sim.ts
@@ -71,5 +71,9 @@ export default {
   name: 'open_sim',
   description: 'Opens the iOS Simulator app.',
   schema: openSimSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Open Simulator',
+    destructiveHint: true,
+  },
   handler: createTypedTool(openSimSchema, open_simLogic, getDefaultCommandExecutor),
 };

--- a/src/mcp/tools/simulator/record_sim_video.ts
+++ b/src/mcp/tools/simulator/record_sim_video.ts
@@ -230,6 +230,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: recordSimVideoSchemaObject,
   }),
+  annotations: {
+    title: 'Record Simulator Video',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<RecordSimVideoParams>({
     internalSchema: recordSimVideoSchema as unknown as z.ZodType<RecordSimVideoParams>,
     logicFunction: record_sim_videoLogic,

--- a/src/mcp/tools/simulator/stop_app_sim.ts
+++ b/src/mcp/tools/simulator/stop_app_sim.ts
@@ -161,6 +161,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Stop App Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<StopAppSimParams>({
     internalSchema: stopAppSimSchema as unknown as z.ZodType<StopAppSimParams>,
     logicFunction: stop_app_simLogic,

--- a/src/mcp/tools/simulator/test_sim.ts
+++ b/src/mcp/tools/simulator/test_sim.ts
@@ -135,6 +135,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Test Simulator',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TestSimulatorParams>({
     internalSchema: testSimulatorSchema as unknown as z.ZodType<TestSimulatorParams>,
     logicFunction: test_simLogic,

--- a/src/mcp/tools/swift-package/swift_package_build.ts
+++ b/src/mcp/tools/swift-package/swift_package_build.ts
@@ -77,6 +77,10 @@ export default {
   name: 'swift_package_build',
   description: 'Builds a Swift Package with swift build',
   schema: swiftPackageBuildSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package Build',
+    destructiveHint: true,
+  },
   handler: createTypedTool(
     swiftPackageBuildSchema,
     swift_package_buildLogic,

--- a/src/mcp/tools/swift-package/swift_package_clean.ts
+++ b/src/mcp/tools/swift-package/swift_package_clean.ts
@@ -52,6 +52,10 @@ export default {
   name: 'swift_package_clean',
   description: 'Cleans Swift Package build artifacts and derived data',
   schema: swiftPackageCleanSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package Clean',
+    destructiveHint: true,
+  },
   handler: createTypedTool(
     swiftPackageCleanSchema,
     swift_package_cleanLogic,

--- a/src/mcp/tools/swift-package/swift_package_list.ts
+++ b/src/mcp/tools/swift-package/swift_package_list.ts
@@ -79,6 +79,10 @@ export default {
   name: 'swift_package_list',
   description: 'Lists currently running Swift Package processes',
   schema: swiftPackageListSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package List',
+    readOnlyHint: true,
+  },
   handler: createTypedTool(
     swiftPackageListSchema,
     (params: SwiftPackageListParams) => {

--- a/src/mcp/tools/swift-package/swift_package_run.ts
+++ b/src/mcp/tools/swift-package/swift_package_run.ts
@@ -223,6 +223,10 @@ export default {
   name: 'swift_package_run',
   description: 'Runs an executable target from a Swift Package with swift run',
   schema: swiftPackageRunSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package Run',
+    destructiveHint: true,
+  },
   handler: createTypedTool(
     swiftPackageRunSchema,
     swift_package_runLogic,

--- a/src/mcp/tools/swift-package/swift_package_stop.ts
+++ b/src/mcp/tools/swift-package/swift_package_stop.ts
@@ -105,6 +105,10 @@ export default {
   name: 'swift_package_stop',
   description: 'Stops a running Swift Package executable started with swift_package_run',
   schema: swiftPackageStopSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package Stop',
+    destructiveHint: true,
+  },
   async handler(args: Record<string, unknown>): Promise<ToolResponse> {
     // Validate parameters using Zod
     const parseResult = swiftPackageStopSchema.safeParse(args);

--- a/src/mcp/tools/swift-package/swift_package_test.ts
+++ b/src/mcp/tools/swift-package/swift_package_test.ts
@@ -90,6 +90,10 @@ export default {
   name: 'swift_package_test',
   description: 'Runs tests for a Swift Package with swift test',
   schema: swiftPackageTestSchema.shape, // MCP SDK compatibility
+  annotations: {
+    title: 'Swift Package Test',
+    destructiveHint: true,
+  },
   handler: createTypedTool(
     swiftPackageTestSchema,
     swift_package_testLogic,

--- a/src/mcp/tools/ui-testing/button.ts
+++ b/src/mcp/tools/ui-testing/button.ts
@@ -86,6 +86,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: buttonSchema,
   }),
+  annotations: {
+    title: 'Hardware Button',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<ButtonParams>({
     internalSchema: buttonSchema as unknown as z.ZodType<ButtonParams>,
     logicFunction: (params: ButtonParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/describe_ui.ts
+++ b/src/mcp/tools/ui-testing/describe_ui.ts
@@ -119,6 +119,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: describeUiSchema,
   }),
+  annotations: {
+    title: 'Describe UI',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<DescribeUiParams>({
     internalSchema: describeUiSchema as unknown as z.ZodType<DescribeUiParams>,
     logicFunction: (params: DescribeUiParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/gesture.ts
+++ b/src/mcp/tools/ui-testing/gesture.ts
@@ -163,6 +163,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: gestureSchema,
   }),
+  annotations: {
+    title: 'Gesture',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<GestureParams>({
     internalSchema: gestureSchema as unknown as z.ZodType<GestureParams>,
     logicFunction: (params: GestureParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/key_press.ts
+++ b/src/mcp/tools/ui-testing/key_press.ts
@@ -91,6 +91,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: keyPressSchema,
   }),
+  annotations: {
+    title: 'Key Press',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<KeyPressParams>({
     internalSchema: keyPressSchema as unknown as z.ZodType<KeyPressParams>,
     logicFunction: (params: KeyPressParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/key_sequence.ts
+++ b/src/mcp/tools/ui-testing/key_sequence.ts
@@ -99,6 +99,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: keySequenceSchema,
   }),
+  annotations: {
+    title: 'Key Sequence',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<KeySequenceParams>({
     internalSchema: keySequenceSchema as unknown as z.ZodType<KeySequenceParams>,
     logicFunction: (params: KeySequenceParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/long_press.ts
+++ b/src/mcp/tools/ui-testing/long_press.ts
@@ -119,6 +119,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: longPressSchema,
   }),
+  annotations: {
+    title: 'Long Press',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<LongPressParams>({
     internalSchema: longPressSchema as unknown as z.ZodType<LongPressParams>,
     logicFunction: (params: LongPressParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/screenshot.ts
+++ b/src/mcp/tools/ui-testing/screenshot.ts
@@ -150,6 +150,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: screenshotSchema,
   }),
+  annotations: {
+    title: 'Screenshot',
+    readOnlyHint: true,
+  },
   handler: createSessionAwareTool<ScreenshotParams>({
     internalSchema: screenshotSchema as unknown as z.ZodType<ScreenshotParams>,
     logicFunction: (params: ScreenshotParams, executor: CommandExecutor) => {

--- a/src/mcp/tools/ui-testing/swipe.ts
+++ b/src/mcp/tools/ui-testing/swipe.ts
@@ -130,6 +130,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: swipeSchema,
   }),
+  annotations: {
+    title: 'Swipe',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<SwipeParams>({
     internalSchema: swipeSchema as unknown as z.ZodType<SwipeParams>,
     logicFunction: (params: SwipeParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/tap.ts
+++ b/src/mcp/tools/ui-testing/tap.ts
@@ -186,6 +186,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseTapSchema,
   }),
+  annotations: {
+    title: 'Tap',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TapParams>({
     internalSchema: tapSchema as unknown as z.ZodType<TapParams>,
     logicFunction: (params: TapParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/ui-testing/touch.ts
+++ b/src/mcp/tools/ui-testing/touch.ts
@@ -120,6 +120,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: touchSchema,
   }),
+  annotations: {
+    title: 'Touch',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TouchParams>({
     internalSchema: touchSchema as unknown as z.ZodType<TouchParams>,
     logicFunction: (params: TouchParams, executor: CommandExecutor) => touchLogic(params, executor),

--- a/src/mcp/tools/ui-testing/type_text.ts
+++ b/src/mcp/tools/ui-testing/type_text.ts
@@ -92,6 +92,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: typeTextSchema,
   }),
+  annotations: {
+    title: 'Type Text',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<TypeTextParams>({
     internalSchema: typeTextSchema as unknown as z.ZodType<TypeTextParams>,
     logicFunction: (params: TypeTextParams, executor: CommandExecutor) =>

--- a/src/mcp/tools/utilities/clean.ts
+++ b/src/mcp/tools/utilities/clean.ts
@@ -163,6 +163,10 @@ export default {
     sessionAware: publicSchemaObject,
     legacy: baseSchemaObject,
   }),
+  annotations: {
+    title: 'Clean',
+    destructiveHint: true,
+  },
   handler: createSessionAwareTool<CleanParams>({
     internalSchema: cleanSchema as unknown as z.ZodType<CleanParams>,
     logicFunction: cleanLogic,

--- a/src/utils/tool-registry.ts
+++ b/src/utils/tool-registry.ts
@@ -128,6 +128,7 @@ export async function registerDiscoveryTools(server: McpServer): Promise<void> {
         config: {
           description: plugin.description ?? '',
           inputSchema: plugin.schema,
+          annotations: plugin.annotations,
         },
         // Adapt callback to match SDK's expected signature
         callback: (args: unknown): Promise<ToolResponse> =>
@@ -165,6 +166,7 @@ export async function registerSelectedWorkflows(
           config: {
             description: tool.description ?? '',
             inputSchema: tool.schema,
+            annotations: tool.annotations,
           },
           callback: (args: unknown): Promise<ToolResponse> =>
             tool.handler(args as Record<string, unknown>),
@@ -201,6 +203,7 @@ export async function registerAllToolsStatic(server: McpServer): Promise<void> {
       config: {
         description: plugin.description ?? '',
         inputSchema: plugin.schema,
+        annotations: plugin.annotations,
       },
       // Adapt callback to match SDK's expected signature
       callback: (args: unknown): Promise<ToolResponse> =>


### PR DESCRIPTION
## Summary

- Add MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 66 tools across 13 workflows to help LLMs better understand tool behavior
- Enable clients like Claude Code to auto-approve read-only tools while requiring confirmation for destructive operations

## Changes

**Infrastructure:**
- Update `PluginMeta` interface to include optional `annotations` field
- Modify `tool-registry.ts` to pass annotations to SDK registration

**Tool Annotations Added:**
| Workflow | Tools | Read-Only | Destructive |
|----------|-------|-----------|-------------|
| device | 7 | list_devices, get_device_app_path | build, install, launch, stop, test |
| simulator | 12 | list_sims, get_sim_app_path | boot, build, build_run, install, launch, launch_logs, open, record, stop, test |
| simulator-management | 5 | - | erase, reset_location, set_appearance, set_location, statusbar |
| macos | 6 | get_mac_app_path | build, build_run, launch, stop, test |
| swift-package | 6 | swift_package_list | build, clean, run, stop, test |
| logging | 4 | - | start_device, start_sim, stop_device, stop_sim |
| ui-testing | 11 | describe_ui, screenshot | button, gesture, key_press, key_sequence, long_press, swipe, tap, touch, type_text |
| discovery | 1 | discover_tools | - |
| doctor | 1 | doctor | - |
| project-discovery | 5 | discover_projs, get_app_bundle_id, get_mac_bundle_id, list_schemes, show_build_settings | - |
| project-scaffolding | 2 | - | scaffold_ios, scaffold_macos |
| session-management | 3 | show_defaults | set_defaults, clear_defaults |
| utilities | 1 | - | clean |

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Verify annotations appear in `tools/list` response
- [ ] Test read-only tools are auto-approved by compatible clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces MCP tool annotations to improve client UX (e.g., auto-approve read-only tools, confirm destructive actions) and wires them through registration.
> 
> - **Core types:** Add optional `annotations` to `PluginMeta` (using `ToolAnnotations`) in `src/core/plugin-types.ts`
> - **Registry:** Update `tool-registry.ts` to include `config.annotations` when registering discovery, dynamic (workflow-selected), and static tools
> - **Tools:** Add `annotations` to tools across workflows (device, simulator, simulator-management, macos, swift-package, logging, ui-testing, discovery, doctor, project-discovery, project-scaffolding, session-management, utilities), setting appropriate `title`, `readOnlyHint`, or `destructiveHint`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 591a57b7c04d7351f7f31d204ea4279a3063127b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->