### PR TITLE
Cocoapods build path fix

### DIFF
--- a/src/mcp/tools/device/__tests__/build_device.test.ts
+++ b/src/mcp/tools/device/__tests__/build_device.test.ts
@@ -132,16 +132,16 @@ describe('build_device plugin', () => {
         args: string[];
         logPrefix: string;
         silent: boolean;
-        timeout: number | undefined;
+        opts: { cwd?: string } | undefined;
       }> = [];
 
       const stubExecutor = async (
         args: string[],
         logPrefix: string,
         silent: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
-        commandCalls.push({ args, logPrefix, silent, timeout });
+        commandCalls.push({ args, logPrefix, silent, opts });
         return {
           success: true,
           output: 'Build succeeded',
@@ -175,7 +175,7 @@ describe('build_device plugin', () => {
         ],
         logPrefix: 'iOS Device Build',
         silent: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
     });
 
@@ -184,16 +184,16 @@ describe('build_device plugin', () => {
         args: string[];
         logPrefix: string;
         silent: boolean;
-        timeout: number | undefined;
+        opts: { cwd?: string } | undefined;
       }> = [];
 
       const stubExecutor = async (
         args: string[],
         logPrefix: string,
         silent: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
-        commandCalls.push({ args, logPrefix, silent, timeout });
+        commandCalls.push({ args, logPrefix, silent, opts });
         return {
           success: true,
           output: 'Build succeeded',
@@ -227,7 +227,7 @@ describe('build_device plugin', () => {
         ],
         logPrefix: 'iOS Device Build',
         silent: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
     });
 
@@ -293,16 +293,16 @@ describe('build_device plugin', () => {
         args: string[];
         logPrefix: string;
         silent: boolean;
-        timeout: number | undefined;
+        opts: { cwd?: string } | undefined;
       }> = [];
 
       const stubExecutor = async (
         args: string[],
         logPrefix: string,
         silent: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
-        commandCalls.push({ args, logPrefix, silent, timeout });
+        commandCalls.push({ args, logPrefix, silent, opts });
         return {
           success: true,
           output: 'Build succeeded',
@@ -342,7 +342,7 @@ describe('build_device plugin', () => {
         ],
         logPrefix: 'iOS Device Build',
         silent: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
     });
   });

--- a/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
@@ -82,10 +82,10 @@ describe('build_run_macos', () => {
         command: string[],
         description: string,
         logOutput: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
         callCount++;
-        executorCalls.push({ command, description, logOutput, timeout });
+        executorCalls.push({ command, description, logOutput, opts });
 
         if (callCount === 1) {
           // First call for build
@@ -131,7 +131,7 @@ describe('build_run_macos', () => {
         ],
         description: 'macOS Build',
         logOutput: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
 
       // Verify build settings command was called
@@ -178,10 +178,10 @@ describe('build_run_macos', () => {
         command: string[],
         description: string,
         logOutput: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
         callCount++;
-        executorCalls.push({ command, description, logOutput, timeout });
+        executorCalls.push({ command, description, logOutput, opts });
 
         if (callCount === 1) {
           // First call for build
@@ -227,7 +227,7 @@ describe('build_run_macos', () => {
         ],
         description: 'macOS Build',
         logOutput: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
 
       // Verify build settings command was called
@@ -445,10 +445,10 @@ describe('build_run_macos', () => {
         command: string[],
         description: string,
         logOutput: boolean,
-        timeout?: number,
+        opts?: { cwd?: string },
       ) => {
         callCount++;
-        executorCalls.push({ command, description, logOutput, timeout });
+        executorCalls.push({ command, description, logOutput, opts });
 
         if (callCount === 1) {
           // First call for build
@@ -493,7 +493,7 @@ describe('build_run_macos', () => {
         ],
         description: 'macOS Build',
         logOutput: true,
-        timeout: undefined,
+        opts: { cwd: '/path/to' },
       });
     });
   });

--- a/src/test-utils/mock-executors.ts
+++ b/src/test-utils/mock-executors.ts
@@ -33,6 +33,13 @@ export function createMockExecutor(
         process?: unknown;
         exitCode?: number;
         shouldThrow?: Error;
+        onExecute?: (
+          command: string[],
+          logPrefix?: string,
+          useShell?: boolean,
+          opts?: { env?: Record<string, string>; cwd?: string },
+          detached?: boolean,
+        ) => void;
       }
     | Error
     | string,
@@ -65,13 +72,20 @@ export function createMockExecutor(
     spawnfile: 'sh',
   } as unknown as ChildProcess;
 
-  return async () => ({
-    success: result.success ?? true,
-    output: result.output ?? '',
-    error: result.error,
-    process: (result.process ?? mockProcess) as ChildProcess,
-    exitCode: result.exitCode ?? (result.success === false ? 1 : 0),
-  });
+  return async (command, logPrefix, useShell, opts, detached) => {
+    // Call onExecute callback if provided
+    if (result.onExecute) {
+      result.onExecute(command, logPrefix, useShell, opts, detached);
+    }
+
+    return {
+      success: result.success ?? true,
+      output: result.output ?? '',
+      error: result.error,
+      process: (result.process ?? mockProcess) as ChildProcess,
+      exitCode: result.exitCode ?? (result.success === false ? 1 : 0),
+    };
+  };
 }
 
 /**

--- a/src/utils/__tests__/build-utils.test.ts
+++ b/src/utils/__tests__/build-utils.test.ts
@@ -260,4 +260,89 @@ describe('build-utils Sentry Classification', () => {
       expect(result.content[0].text).toContain('❌ [stderr] Some error without exit code');
     });
   });
+
+  describe('Working Directory (cwd) Handling', () => {
+    it('should pass project directory as cwd for workspace builds', async () => {
+      let capturedOptions: any;
+      const mockExecutor = createMockExecutor({
+        success: true,
+        output: 'BUILD SUCCEEDED',
+        exitCode: 0,
+        onExecute: (_command, _logPrefix, _useShell, opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      await executeXcodeBuildCommand(
+        {
+          scheme: 'TestScheme',
+          configuration: 'Debug',
+          workspacePath: '/path/to/project/MyProject.xcworkspace',
+        },
+        mockPlatformOptions,
+        false,
+        'build',
+        mockExecutor,
+      );
+
+      expect(capturedOptions).toBeDefined();
+      expect(capturedOptions.cwd).toBe('/path/to/project');
+    });
+
+    it('should pass project directory as cwd for project builds', async () => {
+      let capturedOptions: any;
+      const mockExecutor = createMockExecutor({
+        success: true,
+        output: 'BUILD SUCCEEDED',
+        exitCode: 0,
+        onExecute: (_command, _logPrefix, _useShell, opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      await executeXcodeBuildCommand(
+        {
+          scheme: 'TestScheme',
+          configuration: 'Debug',
+          projectPath: '/path/to/project/MyProject.xcodeproj',
+        },
+        mockPlatformOptions,
+        false,
+        'build',
+        mockExecutor,
+      );
+
+      expect(capturedOptions).toBeDefined();
+      expect(capturedOptions.cwd).toBe('/path/to/project');
+    });
+
+    it('should merge cwd with existing execOpts', async () => {
+      let capturedOptions: any;
+      const mockExecutor = createMockExecutor({
+        success: true,
+        output: 'BUILD SUCCEEDED',
+        exitCode: 0,
+        onExecute: (_command, _logPrefix, _useShell, opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      await executeXcodeBuildCommand(
+        {
+          scheme: 'TestScheme',
+          configuration: 'Debug',
+          workspacePath: '/path/to/project/MyProject.xcworkspace',
+        },
+        mockPlatformOptions,
+        false,
+        'build',
+        mockExecutor,
+        { env: { CUSTOM_VAR: 'value' } },
+      );
+
+      expect(capturedOptions).toBeDefined();
+      expect(capturedOptions.cwd).toBe('/path/to/project');
+      expect(capturedOptions.env).toEqual({ CUSTOM_VAR: 'value' });
+    });
+  });
 });

--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -227,7 +227,11 @@ export async function executeXcodeBuildCommand(
       }
     } else {
       // Use standard xcodebuild
-      result = await executor(command, platformOptions.logPrefix, true, execOpts);
+      // Pass projectDir as cwd to ensure CocoaPods relative paths resolve correctly
+      result = await executor(command, platformOptions.logPrefix, true, {
+        ...execOpts,
+        cwd: projectDir,
+      });
     }
 
     // Grep warnings and errors from stdout (build output)


### PR DESCRIPTION
Fix CocoaPods build path resolution by passing the project directory as the current working directory (`cwd`) to the `xcodebuild` command executor.

CocoaPods projects use relative paths in `.xcfilelist` files. Previously, `xcodebuild` was not always executed from the project's root directory, causing these relative paths to fail and leading to build errors like "Unable to load contents of file list." This change ensures `xcodebuild` runs in the correct context, resolving these path issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c7f862b-42ac-4589-a74f-eaa40a5fd931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c7f862b-42ac-4589-a74f-eaa40a5fd931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CocoaPods-relative paths resolve by running `xcodebuild` from the project directory.
> 
> - Update `executeXcodeBuildCommand` to merge `execOpts` with `cwd` set to the project dir before calling the executor
> - Enhance `createMockExecutor` to accept full executor signature and optional `onExecute` callback; propagate `opts`
> - Add `cwd` handling tests in `build-utils.test.ts` (workspace, project, and `execOpts` merge)
> - Adjust device and macOS tests to expect `opts: { cwd: '/path/to' }` instead of `timeout` and validate command generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80f29cc0f17f568b053c93db6d873c9d795f8833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->