### PR TITLE
test: add full test typecheck config

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "format": "prettier --write 'src/**/*.{js,ts}'",
     "format:check": "prettier --check 'src/**/*.{js,ts}'",
     "typecheck": "npx tsc --noEmit",
+    "typecheck:tests": "npx tsc -p tsconfig.tests.json --noEmit",
+    "typecheck:all": "npm run typecheck && npm run typecheck:tests",
     "verify:smithery-bundle": "bash scripts/verify-smithery-bundle.sh",
     "inspect": "npx @modelcontextprotocol/inspector node build/index.js",
     "doctor": "node build/doctor-cli.js",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*.test.ts", "tests-vitest/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "plugins/**/*",
+    "src/core/generated-plugins.ts",
+    "src/core/generated-resources.ts"
+  ]
+}


### PR DESCRIPTION
## Summary 
- add tsconfig.tests.json to typecheck all tests
- add npm scripts for test typechecking
 
## Testing
- not run (config-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces TypeScript typechecking for tests.
> 
> - Adds `tsconfig.tests.json` to typecheck Vitest tests (includes `vitest/globals` types)
> - Adds `typecheck:tests` and `typecheck:all` npm scripts in `package.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a99c952354e048900f3ad18d26d1252ccbb341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->