### PR TITLE
fix: make test assertions cross-platform compatible

### DIFF
--- a/src/mcp/tools/device/__tests__/launch_app_device.test.ts
+++ b/src/mcp/tools/device/__tests__/launch_app_device.test.ts
@@ -96,7 +96,7 @@ describe('launch_app_device plugin (device-shared)', () => {
         '--device',
         'test-device-123',
         '--json-output',
-        expect.stringMatching(/^\/.*\/launch-\d+\.json$/),
+        expect.stringMatching(/launch-\d+\.json$/),
         '--terminate-existing',
         'com.example.app',
       ]);
@@ -136,7 +136,7 @@ describe('launch_app_device plugin (device-shared)', () => {
         '--device',
         '00008030-001E14BE2288802E',
         '--json-output',
-        expect.stringMatching(/^\/.*\/launch-\d+\.json$/),
+        expect.stringMatching(/launch-\d+\.json$/),
         '--terminate-existing',
         'com.apple.mobilesafari',
       ]);

--- a/src/mcp/tools/macos/__tests__/test_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/test_macos.test.ts
@@ -4,6 +4,8 @@
  * Using dependency injection for deterministic testing
  */
 import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
 import * as z from 'zod';
 import {
   createMockCommandResponse,
@@ -14,11 +16,15 @@ import {
 import { sessionStore } from '../../../../utils/session-store.ts';
 import testMacos, { testMacosLogic } from '../test_macos.ts';
 
+// Platform-appropriate temp directory for test assertions
+const testTmpDir = os.tmpdir();
+const testResultPath = path.join(testTmpDir, 'xcodebuild-test-abc123', 'TestResults.xcresult');
+
 const createTestFileSystemExecutor = (overrides: Partial<FileSystemExecutor> = {}) =>
   createMockFileSystemExecutor({
-    mkdtemp: async () => '/tmp/test-123',
+    mkdtemp: async () => path.join(testTmpDir, 'xcodebuild-test-abc123'),
     rm: async () => {},
-    tmpdir: () => '/tmp',
+    tmpdir: () => testTmpDir,
     stat: async () => ({ isDirectory: () => true, mtimeMs: 0 }),
     ...overrides,
   });
@@ -327,7 +333,7 @@ describe('test_macos plugin (unified)', () => {
 
       // Mock file system dependencies using approved utility
       const mockFileSystemExecutor = createTestFileSystemExecutor({
-        mkdtemp: async () => '/tmp/xcodebuild-test-abc123',
+        mkdtemp: async () => path.join(testTmpDir, 'xcodebuild-test-abc123'),
       });
 
       const result = await testMacosLogic(
@@ -353,7 +359,7 @@ describe('test_macos plugin (unified)', () => {
         '-destination',
         'platform=macOS',
         '-resultBundlePath',
-        '/tmp/xcodebuild-test-abc123/TestResults.xcresult',
+        testResultPath,
         'test',
       ]);
       expect(commandCalls[0].logPrefix).toBe('Test Run');
@@ -367,7 +373,7 @@ describe('test_macos plugin (unified)', () => {
         'test-results',
         'summary',
         '--path',
-        '/tmp/xcodebuild-test-abc123/TestResults.xcresult',
+        testResultPath,
       ]);
       expect(commandCalls[1].logPrefix).toBe('Parse xcresult bundle');
 
@@ -428,7 +434,7 @@ describe('test_macos plugin (unified)', () => {
 
       // Mock file system dependencies
       const mockFileSystemExecutor = createTestFileSystemExecutor({
-        mkdtemp: async () => '/tmp/xcodebuild-test-abc123',
+        mkdtemp: async () => path.join(testTmpDir, 'xcodebuild-test-abc123'),
       });
 
       const result = await testMacosLogic(
@@ -492,7 +498,7 @@ describe('test_macos plugin (unified)', () => {
 
       // Mock file system dependencies
       const mockFileSystemExecutor = createTestFileSystemExecutor({
-        mkdtemp: async () => '/tmp/xcodebuild-test-abc123',
+        mkdtemp: async () => path.join(testTmpDir, 'xcodebuild-test-abc123'),
       });
 
       const result = await testMacosLogic(

--- a/src/mcp/tools/project-discovery/__tests__/discover_projs.test.ts
+++ b/src/mcp/tools/project-discovery/__tests__/discover_projs.test.ts
@@ -8,9 +8,13 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
 import * as z from 'zod';
 import plugin, { discover_projsLogic } from '../discover_projs.ts';
 import { createMockFileSystemExecutor } from '../../../../test-utils/mock-executors.ts';
+
+// Platform-appropriate test paths
+const testWorkspacePath = path.join('/workspace');
 
 describe('discover_projs plugin', () => {
   let mockFileSystemExecutor: any;
@@ -99,7 +103,7 @@ describe('discover_projs plugin', () => {
         content: [
           {
             type: 'text',
-            text: 'Failed to access scan path: /workspace. Error: ENOENT: no such file or directory',
+            text: `Failed to access scan path: ${testWorkspacePath}. Error: ENOENT: no such file or directory`,
           },
         ],
         isError: true,
@@ -119,7 +123,7 @@ describe('discover_projs plugin', () => {
       );
 
       expect(result).toEqual({
-        content: [{ type: 'text', text: 'Scan path is not a directory: /workspace' }],
+        content: [{ type: 'text', text: `Scan path is not a directory: ${testWorkspacePath}` }],
         isError: true,
       });
     });
@@ -162,8 +166,8 @@ describe('discover_projs plugin', () => {
       expect(result).toEqual({
         content: [
           { type: 'text', text: 'Discovery finished. Found 1 projects and 1 workspaces.' },
-          { type: 'text', text: 'Projects found:\n - /workspace/MyApp.xcodeproj' },
-          { type: 'text', text: 'Workspaces found:\n - /workspace/MyWorkspace.xcworkspace' },
+          { type: 'text', text: `Projects found:\n - ${path.join(testWorkspacePath, 'MyApp.xcodeproj')}` },
+          { type: 'text', text: `Workspaces found:\n - ${path.join(testWorkspacePath, 'MyWorkspace.xcworkspace')}` },
           {
             type: 'text',
             text: "Hint: Save a default with session-set-defaults { projectPath: '...' } or { workspacePath: '...' }.",
@@ -193,7 +197,7 @@ describe('discover_projs plugin', () => {
         content: [
           {
             type: 'text',
-            text: 'Failed to access scan path: /workspace. Error: Permission denied',
+            text: `Failed to access scan path: ${testWorkspacePath}. Error: Permission denied`,
           },
         ],
         isError: true,
@@ -216,7 +220,7 @@ describe('discover_projs plugin', () => {
 
       expect(result).toEqual({
         content: [
-          { type: 'text', text: 'Failed to access scan path: /workspace. Error: String error' },
+          { type: 'text', text: `Failed to access scan path: ${testWorkspacePath}. Error: String error` },
         ],
         isError: true,
       });
@@ -279,7 +283,7 @@ describe('discover_projs plugin', () => {
 
       expect(result).toEqual({
         content: [
-          { type: 'text', text: 'Failed to access scan path: /workspace. Error: Access denied' },
+          { type: 'text', text: `Failed to access scan path: ${testWorkspacePath}. Error: Access denied` },
         ],
         isError: true,
       });

--- a/src/mcp/tools/simulator/__tests__/screenshot.test.ts
+++ b/src/mcp/tools/simulator/__tests__/screenshot.test.ts
@@ -221,16 +221,17 @@ describe('screenshot plugin', () => {
       expect(firstCommand[2]).toBe('io');
       expect(firstCommand[3]).toBe('test-uuid');
       expect(firstCommand[4]).toBe('screenshot');
-      expect(firstCommand[5]).toMatch(/\/.*\/screenshot_.*\.png/);
+      // Use platform-independent path matching (works on both Unix and Windows)
+      expect(firstCommand[5]).toMatch(/screenshot_.*\.png$/);
 
       // Second command should be sips optimization
       const secondCommand = capturedCommands[1];
       expect(secondCommand[0]).toBe('sips');
       expect(secondCommand[1]).toBe('-Z');
       expect(secondCommand[2]).toBe('800');
-      // Should have proper PNG input and JPG output paths
-      expect(secondCommand[secondCommand.length - 3]).toMatch(/\/.*\/screenshot_.*\.png/);
-      expect(secondCommand[secondCommand.length - 1]).toMatch(/\/.*\/screenshot_optimized_.*\.jpg/);
+      // Should have proper PNG input and JPG output paths (platform-independent matching)
+      expect(secondCommand[secondCommand.length - 3]).toMatch(/screenshot_.*\.png$/);
+      expect(secondCommand[secondCommand.length - 1]).toMatch(/screenshot_optimized_.*\.jpg$/);
     });
   });
 

--- a/src/mcp/tools/swift-package/__tests__/swift_package_build.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_build.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
 import {
   createMockExecutor,
   createMockFileSystemExecutor,
@@ -13,6 +14,9 @@ import {
 } from '../../../../test-utils/mock-executors.ts';
 import swiftPackageBuild, { swift_package_buildLogic } from '../swift_package_build.ts';
 import type { CommandExecutor } from '../../../../utils/execution/index.ts';
+
+// Helper to get platform-appropriate resolved path for test assertions
+const testPackagePath = path.resolve('/test/package');
 
 describe('swift_package_build plugin', () => {
   describe('Export Field Validation (Literal)', () => {
@@ -78,7 +82,7 @@ describe('swift_package_build plugin', () => {
 
       expect(executorCalls).toEqual([
         {
-          args: ['swift', 'build', '--package-path', '/test/package'],
+          args: ['swift', 'build', '--package-path', testPackagePath],
           description: 'Swift Package Build',
           useShell: true,
           cwd: undefined,
@@ -106,7 +110,7 @@ describe('swift_package_build plugin', () => {
 
       expect(executorCalls).toEqual([
         {
-          args: ['swift', 'build', '--package-path', '/test/package', '-c', 'release'],
+          args: ['swift', 'build', '--package-path', testPackagePath, '-c', 'release'],
           description: 'Swift Package Build',
           useShell: true,
           cwd: undefined,
@@ -141,7 +145,7 @@ describe('swift_package_build plugin', () => {
             'swift',
             'build',
             '--package-path',
-            '/test/package',
+            testPackagePath,
             '-c',
             'release',
             '--target',

--- a/src/mcp/tools/swift-package/__tests__/swift_package_clean.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_clean.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import path from 'node:path';
 import {
   createMockExecutor,
   createMockFileSystemExecutor,
@@ -13,6 +14,9 @@ import {
 } from '../../../../test-utils/mock-executors.ts';
 import swiftPackageClean, { swift_package_cleanLogic } from '../swift_package_clean.ts';
 import type { CommandExecutor } from '../../../../utils/execution/index.ts';
+
+// Helper to get platform-appropriate resolved path for test assertions
+const testPackagePath = path.resolve('/test/package');
 
 describe('swift_package_clean plugin', () => {
   describe('Export Field Validation (Literal)', () => {
@@ -68,7 +72,7 @@ describe('swift_package_clean plugin', () => {
 
       expect(calls).toHaveLength(1);
       expect(calls[0]).toEqual({
-        command: ['swift', 'package', '--package-path', '/test/package', 'clean'],
+        command: ['swift', 'package', '--package-path', testPackagePath, 'clean'],
         description: 'Swift Package Clean',
         useShell: true,
         opts: undefined,

--- a/src/mcp/tools/swift-package/__tests__/swift_package_run.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_run.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
 import * as z from 'zod';
 import {
   createMockExecutor,
@@ -13,6 +14,9 @@ import {
 } from '../../../../test-utils/mock-executors.ts';
 import swiftPackageRun, { swift_package_runLogic } from '../swift_package_run.ts';
 import type { CommandExecutor } from '../../../../utils/execution/index.ts';
+
+// Helper to get platform-appropriate resolved path for test assertions
+const testPackagePath = path.resolve('/test/package');
 
 describe('swift_package_run plugin', () => {
   describe('Export Field Validation (Literal)', () => {
@@ -97,7 +101,7 @@ describe('swift_package_run plugin', () => {
       );
 
       expect(executorCalls[0]).toEqual({
-        command: ['swift', 'run', '--package-path', '/test/package'],
+        command: ['swift', 'run', '--package-path', testPackagePath],
         logPrefix: 'Swift Package Run',
         useShell: true,
         opts: undefined,
@@ -125,7 +129,7 @@ describe('swift_package_run plugin', () => {
       );
 
       expect(executorCalls[0]).toEqual({
-        command: ['swift', 'run', '--package-path', '/test/package', '-c', 'release'],
+        command: ['swift', 'run', '--package-path', testPackagePath, '-c', 'release'],
         logPrefix: 'Swift Package Run',
         useShell: true,
         opts: undefined,
@@ -153,7 +157,7 @@ describe('swift_package_run plugin', () => {
       );
 
       expect(executorCalls[0]).toEqual({
-        command: ['swift', 'run', '--package-path', '/test/package', 'MyApp'],
+        command: ['swift', 'run', '--package-path', testPackagePath, 'MyApp'],
         logPrefix: 'Swift Package Run',
         useShell: true,
         opts: undefined,
@@ -181,7 +185,7 @@ describe('swift_package_run plugin', () => {
       );
 
       expect(executorCalls[0]).toEqual({
-        command: ['swift', 'run', '--package-path', '/test/package', '--', 'arg1', 'arg2'],
+        command: ['swift', 'run', '--package-path', testPackagePath, '--', 'arg1', 'arg2'],
         logPrefix: 'Swift Package Run',
         useShell: true,
         opts: undefined,
@@ -213,7 +217,7 @@ describe('swift_package_run plugin', () => {
           'swift',
           'run',
           '--package-path',
-          '/test/package',
+          testPackagePath,
           '-Xswiftc',
           '-parse-as-library',
         ],
@@ -251,7 +255,7 @@ describe('swift_package_run plugin', () => {
           'swift',
           'run',
           '--package-path',
-          '/test/package',
+          testPackagePath,
           '-c',
           'release',
           '-Xswiftc',

--- a/src/mcp/tools/swift-package/__tests__/swift_package_test.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_test.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import path from 'node:path';
 import {
   createMockExecutor,
   createMockFileSystemExecutor,
@@ -13,6 +14,9 @@ import {
 } from '../../../../test-utils/mock-executors.ts';
 import swiftPackageTest, { swift_package_testLogic } from '../swift_package_test.ts';
 import type { CommandExecutor } from '../../../../utils/execution/index.ts';
+
+// Helper to get platform-appropriate resolved path for test assertions
+const testPackagePath = path.resolve('/test/package');
 
 describe('swift_package_test plugin', () => {
   describe('Export Field Validation (Literal)', () => {
@@ -83,7 +87,7 @@ describe('swift_package_test plugin', () => {
 
       expect(calls).toHaveLength(1);
       expect(calls[0]).toEqual({
-        args: ['swift', 'test', '--package-path', '/test/package'],
+        args: ['swift', 'test', '--package-path', testPackagePath],
         name: 'Swift Package Test',
         hideOutput: true,
         opts: undefined,
@@ -125,7 +129,7 @@ describe('swift_package_test plugin', () => {
           'swift',
           'test',
           '--package-path',
-          '/test/package',
+          testPackagePath,
           '-c',
           'release',
           '--test-product',


### PR DESCRIPTION
## Summary
- Fix test failures on Windows by using platform-appropriate path handling
- Replace hardcoded Unix paths with `path.join`/`path.resolve` from Node.js
- Use platform-independent regex patterns for path matching (e.g., `/screenshot_.*\.png$/` instead of `/\/.*\/screenshot_.*\.png/`)
- Use `os.tmpdir()` for temp directory assertions instead of hardcoded `/tmp`

## Files Changed
- `launch_app_device.test.ts` - Platform-independent regex for JSON output path
- `test_macos.test.ts` - Use `os.tmpdir()` and `path.join` for temp paths
- `discover_projs.test.ts` - Use `path.join` for workspace path assertions
- `screenshot.test.ts` - Platform-independent regex for screenshot paths
- `swift_package_build.test.ts` - Use `path.resolve` for package path
- `swift_package_clean.test.ts` - Use `path.resolve` for package path
- `swift_package_run.test.ts` - Use `path.resolve` for package path
- `swift_package_test.test.ts` - Use `path.resolve` for package path

## Test plan
- [x] All 1124 tests pass on Windows
- [ ] Verify tests still pass on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)