### PR TITLE
Fix shared snapshot_ui warning state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update UI automation guard guidance to point at `debug_continue` when paused.
 - Fix tool loading bugs in static tool registration.
 - Fix xcodemake command argument corruption when project directory path appears as substring in non-path arguments.
+- Fix snapshot_ui warning state being isolated per UI automation tool, causing false warnings.
 
 ## [1.16.0] - 2025-12-30
 - Remove dynamic tool discovery (`discover_tools`) and `XCODEBUILDMCP_DYNAMIC_TOOLS`. Use `XCODEBUILDMCP_ENABLED_WORKFLOWS` to limit startup tool registration.

--- a/src/mcp/tools/ui-automation/long_press.ts
+++ b/src/mcp/tools/ui-automation/long_press.ts
@@ -29,6 +29,7 @@ import {
   createSessionAwareTool,
   getSessionAwareToolSchemaShape,
 } from '../../../utils/typed-tool-factory.ts';
+import { getSnapshotUiWarning } from './shared/snapshot-ui-state.ts';
 
 // Define schema as ZodObject
 const longPressSchema = z.object({
@@ -99,7 +100,7 @@ export async function long_pressLogic(
     await executeAxeCommand(commandArgs, simulatorId, 'touch', executor, axeHelpers);
     log('info', `${LOG_PREFIX}/${toolName}: Success for ${simulatorId}`);
 
-    const coordinateWarning = getCoordinateWarning(simulatorId);
+    const coordinateWarning = getSnapshotUiWarning(simulatorId);
     const message = `Long press at (${x}, ${y}) for ${duration}ms simulated successfully.`;
     const warnings = [guard.warningText, coordinateWarning].filter(Boolean).join('\n\n');
 
@@ -152,30 +153,6 @@ export default {
     requirements: [{ allOf: ['simulatorId'], message: 'simulatorId is required' }],
   }),
 };
-
-// Session tracking for snapshot_ui warnings
-interface DescribeUISession {
-  timestamp: number;
-  simulatorId: string;
-}
-
-const snapshotUiTimestamps = new Map<string, DescribeUISession>();
-const SNAPSHOT_UI_WARNING_TIMEOUT = 60000; // 60 seconds
-
-function getCoordinateWarning(simulatorId: string): string | null {
-  const session = snapshotUiTimestamps.get(simulatorId);
-  if (!session) {
-    return 'Warning: snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.';
-  }
-
-  const timeSinceDescribe = Date.now() - session.timestamp;
-  if (timeSinceDescribe > SNAPSHOT_UI_WARNING_TIMEOUT) {
-    const secondsAgo = Math.round(timeSinceDescribe / 1000);
-    return `Warning: snapshot_ui was last called ${secondsAgo} seconds ago. Consider refreshing UI coordinates with snapshot_ui instead of using potentially stale coordinates.`;
-  }
-
-  return null;
-}
 
 // Helper function for executing axe commands (inlined from src/tools/axe/index.ts)
 async function executeAxeCommand(

--- a/src/mcp/tools/ui-automation/shared/snapshot-ui-state.ts
+++ b/src/mcp/tools/ui-automation/shared/snapshot-ui-state.ts
@@ -1,0 +1,22 @@
+const SNAPSHOT_UI_WARNING_TIMEOUT_MS = 60000; // 60 seconds
+
+const snapshotUiTimestamps = new Map<string, number>();
+
+export function recordSnapshotUiCall(simulatorId: string): void {
+  snapshotUiTimestamps.set(simulatorId, Date.now());
+}
+
+export function getSnapshotUiWarning(simulatorId: string): string | null {
+  const timestamp = snapshotUiTimestamps.get(simulatorId);
+  if (!timestamp) {
+    return 'Warning: snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.';
+  }
+
+  const timeSinceDescribe = Date.now() - timestamp;
+  if (timeSinceDescribe > SNAPSHOT_UI_WARNING_TIMEOUT_MS) {
+    const secondsAgo = Math.round(timeSinceDescribe / 1000);
+    return `Warning: snapshot_ui was last called ${secondsAgo} seconds ago. Consider refreshing UI coordinates with snapshot_ui instead of using potentially stale coordinates.`;
+  }
+
+  return null;
+}

--- a/src/mcp/tools/ui-automation/snapshot_ui.ts
+++ b/src/mcp/tools/ui-automation/snapshot_ui.ts
@@ -17,6 +17,7 @@ import {
   createSessionAwareTool,
   getSessionAwareToolSchemaShape,
 } from '../../../utils/typed-tool-factory.ts';
+import { recordSnapshotUiCall } from './shared/snapshot-ui-state.ts';
 
 // Define schema as ZodObject
 const snapshotUiSchema = z.object({
@@ -33,16 +34,6 @@ export interface AxeHelpers {
 }
 
 const LOG_PREFIX = '[AXe]';
-
-// Session tracking for snapshot_ui warnings (shared across UI tools)
-const snapshotUiTimestamps = new Map<string, { timestamp: number; simulatorId: string }>();
-
-function recordSnapshotUICall(simulatorId: string): void {
-  snapshotUiTimestamps.set(simulatorId, {
-    timestamp: Date.now(),
-    simulatorId,
-  });
-}
 
 /**
  * Core business logic for snapshot_ui functionality
@@ -80,7 +71,7 @@ export async function snapshot_uiLogic(
     );
 
     // Record the snapshot_ui call for warning system
-    recordSnapshotUICall(simulatorId);
+    recordSnapshotUiCall(simulatorId);
 
     log('info', `${LOG_PREFIX}/${toolName}: Success for ${simulatorId}`);
     const response: ToolResponse = {

--- a/src/mcp/tools/ui-automation/touch.ts
+++ b/src/mcp/tools/ui-automation/touch.ts
@@ -24,6 +24,7 @@ import {
   createSessionAwareTool,
   getSessionAwareToolSchemaShape,
 } from '../../../utils/typed-tool-factory.ts';
+import { getSnapshotUiWarning } from './shared/snapshot-ui-state.ts';
 
 // Define schema as ZodObject
 const touchSchema = z.object({
@@ -95,7 +96,7 @@ export async function touchLogic(
     await executeAxeCommand(commandArgs, simulatorId, 'touch', executor, axeHelpers);
     log('info', `${LOG_PREFIX}/${toolName}: Success for ${simulatorId}`);
 
-    const coordinateWarning = getCoordinateWarning(simulatorId);
+    const coordinateWarning = getSnapshotUiWarning(simulatorId);
     const message = `Touch event (${actionText}) at (${x}, ${y}) executed successfully.`;
     const warnings = [guard.warningText, coordinateWarning].filter(Boolean).join('\n\n');
 
@@ -146,30 +147,6 @@ export default {
     requirements: [{ allOf: ['simulatorId'], message: 'simulatorId is required' }],
   }),
 };
-
-// Session tracking for snapshot_ui warnings
-interface DescribeUISession {
-  timestamp: number;
-  simulatorId: string;
-}
-
-const snapshotUiTimestamps = new Map<string, DescribeUISession>();
-const SNAPSHOT_UI_WARNING_TIMEOUT = 60000; // 60 seconds
-
-function getCoordinateWarning(simulatorId: string): string | null {
-  const session = snapshotUiTimestamps.get(simulatorId);
-  if (!session) {
-    return 'Warning: snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.';
-  }
-
-  const timeSinceDescribe = Date.now() - session.timestamp;
-  if (timeSinceDescribe > SNAPSHOT_UI_WARNING_TIMEOUT) {
-    const secondsAgo = Math.round(timeSinceDescribe / 1000);
-    return `Warning: snapshot_ui was last called ${secondsAgo} seconds ago. Consider refreshing UI coordinates with snapshot_ui instead of using potentially stale coordinates.`;
-  }
-
-  return null;
-}
 
 // Helper function for executing axe commands (inlined from src/tools/axe/index.ts)
 async function executeAxeCommand(


### PR DESCRIPTION
## Problem
UI automation tools (swipe/tap/long_press/touch) each kept their own in-memory snapshot_ui timestamp, so the warning logic always reported "snapshot_ui has not been called yet" even after a snapshot was taken.

## Fix
- Centralize snapshot_ui timestamp tracking in a shared module.
- Record snapshot_ui calls once, and read the same state in all coordinate-based tools.
- Move the shared helper into a subdirectory so the tool generator doesn’t treat it as a tool.

## Notes
No behavior change to the UI actions themselves; this only fixes the accuracy of warning guidance.

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes inaccurate coordinate warnings by unifying `snapshot_ui` call tracking.
> 
> - New shared module `src/mcp/tools/ui-automation/shared/snapshot-ui-state.ts` with `recordSnapshotUiCall` and `getSnapshotUiWarning`
> - Update `tap`, `swipe`, `long_press`, and `touch` to use `getSnapshotUiWarning` instead of per-tool state
> - Update `snapshot_ui` to call `recordSnapshotUiCall` after successful describe-ui
> - Remove duplicated, isolated timestamp logic from each tool
> - Document fix in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68b5fe207678fd0a736a27135a61f9daf7dda438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->