### PR TITLE
Add MCP setup instructions for Xcode's integrated Claude Code and Codex agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Add XcodeBuildMCP to your MCP client configuration. Most clients use JSON config
   ```
 
   > [!NOTE]
-  > Codex Agent when running in Xcode has a limted PATH by default. The above example should work for most users but if you find the server doesn't start or is not available, it's likely because npx is not found so you might have to adjust the above configuration accordingly.
+  > Codex Agent when running in Xcode has a limited PATH by default. The above example should work for most users but if you find the server doesn't start or is not available, it's likely because npx is not found so you might have to adjust the above configuration accordingly.
 
   <br />
 </details>
@@ -189,7 +189,7 @@ Add XcodeBuildMCP to your MCP client configuration. Most clients use JSON config
   `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/.claude.json`
 
   ```json
-    # rest of file...
+    // ... rest of file ...
     "mcpServers": {
       "XcodeBuildMCP": {
         "command": "/bin/zsh",
@@ -203,7 +203,7 @@ Add XcodeBuildMCP to your MCP client configuration. Most clients use JSON config
   ```
 
   > [!NOTE]
-  > Claude Code Agent when running in Xcode has a limted PATH by default. The above example should work for most users but if you find the server doesn't start or is not available, it's likely because npx is not found so you might have to adjust the above configuration accordingly.
+  > Claude Code Agent when running in Xcode has a limited PATH by default. The above example should work for most users but if you find the server doesn't start or is not available, it's likely because npx is not found so you might have to adjust the above configuration accordingly.
 
   <br />
 </details>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that add new installation guidance and links; no runtime or security-sensitive code is modified.
> 
> **Overview**
> Adds README setup instructions for configuring `XcodeBuildMCP` with Xcode’s integrated *Codex* and *Claude Code* agents, including required Xcode version, config file locations, and `zsh`/`npx` command examples that work around Xcode’s restricted `PATH`.
> 
> Also adds a VS Code quick-install badge link alongside the existing MCP client configuration examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 087a6b96eedf37a894ea98840d9779acfd234f58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->