### PR TITLE
Fix outdated tool names and parameters in CLI skill

### DIFF
--- a/skills/xcodebuildmcp-cli/SKILL.md
+++ b/skills/xcodebuildmcp-cli/SKILL.md
@@ -38,14 +38,14 @@ Notes:
 
 If app and project details are not known:
 ```bash
-xcodebuildmcp simulator discover-projs --workspace-root .
+xcodebuildmcp simulator discover-projects --workspace-root .
 xcodebuildmcp simulator list-schemes --project-path ./MyApp.xcodeproj
-xcodebuildmcp simulator list-sims
+xcodebuildmcp simulator list
 ```
 
 To build, install and launch the app in one command:
 ```bash
-xcodebuildmcp simulator build-run-sim --scheme MyApp --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
+xcodebuildmcp simulator build-and-run --scheme MyApp --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
 ```
 
 ### Build only
@@ -53,33 +53,33 @@ xcodebuildmcp simulator build-run-sim --scheme MyApp --project-path ./MyApp.xcod
 When you only need to check that there are no build errors, you can build without running the app.
 
 ```bash
-xcodebuildmcp simulator build-sim --scheme MyApp --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
+xcodebuildmcp simulator build --scheme MyApp --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
 ```
 
 ### Run Tests
 
-When you need to run tests, you can do so with the `test-sim` tool.
+When you need to run tests, you can do so with the `test` tool.
 
 ```bash
-xcodebuildmcp simulator test-sim --scheme MyAppTests --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
+xcodebuildmcp simulator test --scheme MyAppTests --project-path ./MyApp.xcodeproj --simulator-name "iPhone 17 Pro"
 ```
 
 ### Install And Launch On Physical Device
 
 ```bash
-xcodebuildmcp device list-devices
-xcodebuildmcp device build-device --scheme MyApp --project-path ./MyApp.xcodeproj
-xcodebuildmcp device get-device-app-path --scheme MyApp --project-path ./MyApp.xcodeproj
+xcodebuildmcp device list
+xcodebuildmcp device build --scheme MyApp --project-path ./MyApp.xcodeproj
+xcodebuildmcp device get-app-path --scheme MyApp --project-path ./MyApp.xcodeproj
 xcodebuildmcp device get-app-bundle-id --app-path /path/to/MyApp.app
-xcodebuildmcp device install-app-device --device-id DEVICE_UDID --app-path /path/to/MyApp.app
-xcodebuildmcp device launch-app-device --device-id DEVICE_UDID --bundle-id io.sentry.MyApp --app-path /path/to/MyApp.app
+xcodebuildmcp device install --device-id DEVICE_UDID --app-path /path/to/MyApp.app
+xcodebuildmcp device launch --device-id DEVICE_UDID --bundle-id io.sentry.MyApp
 ```
 
 ### Capture Logs On Simulator
 
 ```bash
-xcodebuildmcp logging start-sim-log-cap --simulator-id SIMULATOR_UDID --bundle-id io.sentry.MyApp
-xcodebuildmcp logging stop-sim-log-cap --log-session-id LOG_SESSION_ID
+xcodebuildmcp logging start-simulator-log-capture --simulator-id SIMULATOR_UDID --bundle-id io.sentry.MyApp
+xcodebuildmcp logging stop-simulator-log-capture --log-session-id LOG_SESSION_ID
 ```
 
 ### Debug A Running App (Simulator)
@@ -89,7 +89,7 @@ xcodebuildmcp logging stop-sim-log-cap --log-session-id LOG_SESSION_ID
 
 Launch if not already running:
 ```bash
-xcodebuildmcp simulator launch-app-sim --bundle-id io.sentry.MyApp --simulator-id SIMULATOR_UDID
+xcodebuildmcp simulator launch-app --bundle-id io.sentry.MyApp --simulator-id SIMULATOR_UDID
 ```
 
 Attach the debugger:
@@ -97,7 +97,7 @@ Attach the debugger:
 It's generally a good idea to wait for 1-2s for the app to fully launch before attaching the debugger.
 
 ```bash
-xcodebuildmcp debugging debug-attach-sim --bundle-id io.sentry.MyApp --simulator-id SIMULATOR_UDID
+xcodebuildmcp debugging attach --bundle-id io.sentry.MyApp --simulator-id SIMULATOR_UDID
 ```
 
 To add/remove breakpoints, inspect stack/variables, and issue arbitrary LLDB commands, view debugging help:
@@ -125,8 +125,8 @@ xcodebuildmcp ui-automation --help
 ### macOS App Build/Run
 
 ```bash
-xcodebuildmcp macos build-macos --scheme MyMacApp --project-path ./MyMacApp.xcodeproj
-xcodebuildmcp macos build-run-macos --scheme MyMacApp --project-path ./MyMacApp.xcodeproj
+xcodebuildmcp macos build --scheme MyMacApp --project-path ./MyMacApp.xcodeproj
+xcodebuildmcp macos build-and-run --scheme MyMacApp --project-path ./MyMacApp.xcodeproj
 ```
 
 To see all macOS tools, view macOS help:
@@ -137,7 +137,7 @@ xcodebuildmcp macos --help
 ### SwiftPM Package Workflows
 
 ```bash
-xcodebuildmcp swift-package list --package-path ./MyPackage
+xcodebuildmcp swift-package list
 xcodebuildmcp swift-package build --package-path ./MyPackage
 xcodebuildmcp swift-package test --package-path ./MyPackage
 ```
@@ -150,7 +150,7 @@ xcodebuildmcp swift-package --help
 ### Project Discovery
 
 ```bash
-xcodebuildmcp project-discovery discover-projs --workspace-root .
+xcodebuildmcp project-discovery discover-projects --workspace-root .
 xcodebuildmcp project-discovery list-schemes --project-path ./MyApp.xcodeproj
 xcodebuildmcp project-discovery get-app-bundle-id --app-path ./Build/MyApp.app
 ```
@@ -166,8 +166,8 @@ It's worth viewing the --help for the scaffolding tools to see the available opt
 Here are some minimal examples:
 
 ```bash
-xcodebuildmcp project-scaffolding scaffold-ios-project --project-name MyApp --output-path ./Projects
-xcodebuildmcp project-scaffolding scaffold-macos-project --project-name MyMacApp --output-path ./Projects
+xcodebuildmcp project-scaffolding scaffold-ios --project-name MyApp --output-path ./Projects
+xcodebuildmcp project-scaffolding scaffold-macos --project-name MyMacApp --output-path ./Projects
 ```
 
 To see all project scaffolding tools, view project scaffolding help:


### PR DESCRIPTION
I noticed that many of the tool names in the CLI agent skill were wrong(/outdated), making the skill less than helpful. 
I had codex update it using this prompt (using the installed 2.0.7 CLI tool): 
"Use the installed xcodebuildmcp CLI tool to explore its available tools and options and fix any mistakes in SKILL.md that don't line up with what is available in the actual CLI tool."

-----

The xcodebuildmcp skill guide contained outdated command and tool names that no longer match the installed CLI interface. This patch updates the examples to the currently supported workflow/tool names and argument shapes so agents can execute documented commands without translation or failures.

Validated against live CLI output via:
- xcodebuildmcp --help
- xcodebuildmcp tools --json
- per-workflow and per-tool --help checks for all commands referenced in SKILL.md

Key updates:
- Replaced deprecated names such as discover-projs/list-sims/build-run-sim/build-sim/test-sim with discover-projects/list/build-and-run/build/test
- Updated device examples from list-devices/build-device/get-device-app-path/install-app-device/launch-app-device to list/build/get-app-path/install/launch
- Updated logging and debugging examples to start/stop-simulator-log-capture and debugging attach
- Updated macOS and scaffolding commands to build/build-and-run and scaffold-ios/scaffold-macos
- Removed invalid arguments from examples (e.g. --app-path on device launch, --package-path on swift-package list)

Result: SKILL.md now reflects the actual CLI tool surface and option usage for the installed xcodebuildmcp binary.
