### PR TITLE
feat: add device_screenshot tool for physical iOS devices

### DIFF
--- a/manifests/tools/device_screenshot.yaml
+++ b/manifests/tools/device_screenshot.yaml
@@ -1,0 +1,9 @@
+id: device_screenshot
+module: mcp/tools/device/device_screenshot
+names:
+  mcp: device_screenshot
+  cli: device-screenshot
+description: Capture screenshot from a connected physical device.
+annotations:
+  title: Device Screenshot
+  readOnlyHint: true

--- a/manifests/workflows/device.yaml
+++ b/manifests/workflows/device.yaml
@@ -16,3 +16,4 @@ tools:
   - get_app_bundle_id
   - start_device_log_cap
   - stop_device_log_cap
+  - device_screenshot

--- a/src/mcp/tools/device/__tests__/device_screenshot.test.ts
+++ b/src/mcp/tools/device/__tests__/device_screenshot.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Tests for device_screenshot tool plugin
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as z from 'zod';
+import {
+  createMockExecutor,
+  createMockFileSystemExecutor,
+  mockProcess,
+} from '../../../../test-utils/mock-executors.ts';
+import { SystemError } from '../../../../utils/responses/index.ts';
+import { sessionStore } from '../../../../utils/session-store.ts';
+import {
+  schema,
+  handler,
+  deviceScreenshotLogic,
+  checkPymobiledevice3Available,
+} from '../device_screenshot.ts';
+
+describe('Device Screenshot Plugin', () => {
+  beforeEach(() => {
+    sessionStore.clear();
+  });
+
+  describe('Export Field Validation', () => {
+    it('should have handler function', () => {
+      expect(typeof handler).toBe('function');
+    });
+
+    it('should validate schema fields with safeParse', () => {
+      const schemaObj = z.object(schema);
+
+      expect(schemaObj.safeParse({}).success).toBe(true);
+
+      const withDeviceId = schemaObj.safeParse({
+        deviceId: 'some-device-id',
+      });
+      expect(withDeviceId.success).toBe(true);
+      expect('deviceId' in (withDeviceId.data as Record<string, unknown>)).toBe(false);
+    });
+  });
+
+  describe('Plugin Handler Validation', () => {
+    it('should require deviceId session default when not provided', async () => {
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      const message = result.content[0].text;
+      expect(message).toContain('Missing required session defaults');
+      expect(message).toContain('deviceId is required');
+      expect(message).toContain('session-set-defaults');
+    });
+  });
+
+  describe('checkPymobiledevice3Available', () => {
+    it('should return true when pymobiledevice3 is found', async () => {
+      const mockExecutor = createMockExecutor({
+        success: true,
+        output: '/usr/local/bin/pymobiledevice3',
+      });
+
+      const result = await checkPymobiledevice3Available(mockExecutor);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when pymobiledevice3 is not found', async () => {
+      const mockExecutor = createMockExecutor({
+        success: false,
+        output: '',
+        error: 'not found',
+      });
+
+      const result = await checkPymobiledevice3Available(mockExecutor);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when executor throws', async () => {
+      const mockExecutor = async () => {
+        throw new Error('Execution failed');
+      };
+
+      const result = await checkPymobiledevice3Available(mockExecutor);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Screenshot Logic', () => {
+    it('should return error when pymobiledevice3 is not installed', async () => {
+      const mockExecutor = createMockExecutor({
+        success: false,
+        output: '',
+        error: 'not found',
+      });
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234-5678-90EF-GHIJ-KLMNOPQRSTUV' },
+        mockExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(result.isError).toBe(true);
+      const message = result.content[0].text;
+      expect(message).toContain('pymobiledevice3 not found');
+      expect(message).toContain('pipx install pymobiledevice3');
+    });
+
+    it('should capture screenshot and return base64', async () => {
+      const capturedCommands: string[][] = [];
+      let commandIndex = 0;
+      const trackingExecutor = async (command: string[]) => {
+        capturedCommands.push(command);
+        const idx = commandIndex++;
+
+        // First call: which pymobiledevice3
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        // Second call: pymobiledevice3 screenshot
+        if (idx === 1) {
+          return {
+            success: true,
+            output: '',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        // Third call: sips optimization
+        return {
+          success: true,
+          output: '',
+          error: undefined,
+          process: mockProcess,
+        };
+      };
+
+      const mockFileSystemExecutor = createMockFileSystemExecutor({
+        readFile: async () => 'fake-image-data',
+      });
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234-5678-90EF-GHIJ-KLMNOPQRSTUV' },
+        trackingExecutor,
+        mockFileSystemExecutor,
+        { tmpdir: () => '/tmp', join: (...paths) => paths.join('/') },
+        { v4: () => 'test-uuid' },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content[0].type).toBe('image');
+
+      // Verify pymobiledevice3 command
+      expect(capturedCommands[1]).toEqual([
+        'pymobiledevice3',
+        'developer',
+        'dvt',
+        'screenshot',
+        '/tmp/device_screenshot_test-uuid.png',
+        '--udid',
+        'ABCD1234-5678-90EF-GHIJ-KLMNOPQRSTUV',
+      ]);
+
+      // Verify sips optimization command
+      expect(capturedCommands[2]).toEqual([
+        'sips',
+        '-Z',
+        '800',
+        '-s',
+        'format',
+        'jpeg',
+        '-s',
+        'formatOptions',
+        '75',
+        '/tmp/device_screenshot_test-uuid.png',
+        '--out',
+        '/tmp/device_screenshot_optimized_test-uuid.jpg',
+      ]);
+    });
+
+    it('should return path when returnFormat is path', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        if (idx === 1) {
+          return {
+            success: true,
+            output: '',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        return {
+          success: true,
+          output: '',
+          error: undefined,
+          process: mockProcess,
+        };
+      };
+
+      const mockFileSystemExecutor = createMockFileSystemExecutor();
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234', returnFormat: 'path' },
+        trackingExecutor,
+        mockFileSystemExecutor,
+        { tmpdir: () => '/tmp', join: (...paths) => paths.join('/') },
+        { v4: () => 'test-uuid' },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain(
+        '[/tmp/device_screenshot_optimized_test-uuid.jpg](file:///tmp/device_screenshot_optimized_test-uuid.jpg)',
+      );
+      expect(result.content[0].text).toContain('image/jpeg');
+    });
+
+    it('should handle device not connected error', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        // which check passes
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        // pymobiledevice3 fails
+        return {
+          success: false,
+          output: '',
+          error: 'No device found',
+          process: mockProcess,
+        };
+      };
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234' },
+        trackingExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('System error executing screenshot');
+      expect(result.content[0].text).toContain('No device found');
+    });
+
+    it('should show tunnel hint when tunneld error occurs', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        return {
+          success: false,
+          output: '',
+          error: 'Unable to connect to tunneld',
+          process: mockProcess,
+        };
+      };
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234' },
+        trackingExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('sudo pymobiledevice3 remote tunneld');
+    });
+
+    it('should fallback to original PNG when optimization fails', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        if (idx === 1) {
+          return {
+            success: true,
+            output: '',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        // sips optimization fails
+        return {
+          success: false,
+          output: '',
+          error: 'sips failed',
+          process: mockProcess,
+        };
+      };
+
+      const mockFileSystemExecutor = createMockFileSystemExecutor({
+        readFile: async () => 'fake-png-data',
+      });
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234', returnFormat: 'base64' },
+        trackingExecutor,
+        mockFileSystemExecutor,
+        { tmpdir: () => '/tmp', join: (...paths) => paths.join('/') },
+        { v4: () => 'test-uuid' },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content[0].type).toBe('image');
+      expect(result.content[0].mimeType).toBe('image/png');
+    });
+
+    it('should return path with optimization failed note when format is path and optimization fails', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        if (idx === 1) {
+          return {
+            success: true,
+            output: '',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        return {
+          success: false,
+          output: '',
+          error: 'sips failed',
+          process: mockProcess,
+        };
+      };
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234', returnFormat: 'path' },
+        trackingExecutor,
+        createMockFileSystemExecutor(),
+        { tmpdir: () => '/tmp', join: (...paths) => paths.join('/') },
+        { v4: () => 'test-uuid' },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content[0].text).toContain('optimization failed');
+      expect(result.content[0].text).toContain('image/png');
+    });
+
+    it('should handle SystemError from command execution', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        throw new SystemError('System error occurred');
+      };
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234' },
+        trackingExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Error: System error executing screenshot: System error occurred',
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it('should handle unexpected errors', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        throw new Error('Unexpected error');
+      };
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234' },
+        trackingExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(result).toEqual({
+        content: [
+          { type: 'text' as const, text: 'Error: An unexpected error occurred: Unexpected error' },
+        ],
+        isError: true,
+      });
+    });
+
+    it('should handle file reading errors', async () => {
+      let commandIndex = 0;
+      const trackingExecutor = async () => {
+        const idx = commandIndex++;
+
+        if (idx === 0) {
+          return {
+            success: true,
+            output: '/usr/local/bin/pymobiledevice3',
+            error: undefined,
+            process: mockProcess,
+          };
+        }
+        return {
+          success: true,
+          output: '',
+          error: undefined,
+          process: mockProcess,
+        };
+      };
+
+      const mockFileSystemExecutor = createMockFileSystemExecutor({
+        readFile: async () => {
+          throw new Error('File not found');
+        },
+      });
+
+      const result = await deviceScreenshotLogic(
+        { deviceId: 'ABCD1234', returnFormat: 'base64' },
+        trackingExecutor,
+        mockFileSystemExecutor,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Error: Screenshot captured but failed to process image file: File not found',
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+});

--- a/src/mcp/tools/device/device_screenshot.ts
+++ b/src/mcp/tools/device/device_screenshot.ts
@@ -1,0 +1,226 @@
+/**
+ * Device Screenshot tool - Capture screenshots from physical iOS devices
+ *
+ * Uses pymobiledevice3 to capture screenshots from connected physical devices.
+ * pymobiledevice3 supports iOS 17+ via the CoreDevice tunnel protocol,
+ * and works over both USB and WiFi.
+ *
+ * Requires: pipx install pymobiledevice3
+ * For iOS 17+: sudo pymobiledevice3 remote tunneld (in a separate terminal)
+ */
+import * as path from 'path';
+import { tmpdir } from 'os';
+import * as z from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+import type { ToolResponse } from '../../../types/common.ts';
+import { createImageContent } from '../../../types/common.ts';
+import { log } from '../../../utils/logging/index.ts';
+import {
+  createErrorResponse,
+  createTextResponse,
+  SystemError,
+} from '../../../utils/responses/index.ts';
+import type { CommandExecutor, FileSystemExecutor } from '../../../utils/execution/index.ts';
+import {
+  getDefaultFileSystemExecutor,
+  getDefaultCommandExecutor,
+} from '../../../utils/execution/index.ts';
+import {
+  createSessionAwareTool,
+  getSessionAwareToolSchemaShape,
+} from '../../../utils/typed-tool-factory.ts';
+
+const LOG_PREFIX = '[DeviceScreenshot]';
+
+// Define schema as ZodObject
+const deviceScreenshotSchema = z.object({
+  deviceId: z
+    .string()
+    .min(1, { message: 'Device ID cannot be empty' })
+    .describe('UDID of the device (obtained from list_devices)'),
+  returnFormat: z
+    .enum(['path', 'base64'])
+    .optional()
+    .describe('Return image path or base64 data (path|base64)'),
+});
+
+// Use z.infer for type safety
+type DeviceScreenshotParams = z.infer<typeof deviceScreenshotSchema>;
+
+const publicSchemaObject = z.strictObject(
+  deviceScreenshotSchema.omit({ deviceId: true } as const).shape,
+);
+
+/**
+ * Check if pymobiledevice3 is available on the system.
+ */
+export async function checkPymobiledevice3Available(executor: CommandExecutor): Promise<boolean> {
+  try {
+    const result = await executor(['which', 'pymobiledevice3'], `${LOG_PREFIX}: check tool`, false);
+    return result.success && !!result.output?.trim();
+  } catch {
+    return false;
+  }
+}
+
+export async function deviceScreenshotLogic(
+  params: DeviceScreenshotParams,
+  executor: CommandExecutor,
+  fileSystemExecutor: FileSystemExecutor = getDefaultFileSystemExecutor(),
+  pathUtils: { tmpdir: () => string; join: (...paths: string[]) => string } = { ...path, tmpdir },
+  uuidUtils: { v4: () => string } = { v4: uuidv4 },
+): Promise<ToolResponse> {
+  const { deviceId } = params;
+  const runtime = process.env.XCODEBUILDMCP_RUNTIME;
+  const defaultFormat = runtime === 'cli' || runtime === 'daemon' ? 'path' : 'base64';
+  const returnFormat = params.returnFormat ?? defaultFormat;
+  const tempDir = pathUtils.tmpdir();
+  const screenshotFilename = `device_screenshot_${uuidUtils.v4()}.png`;
+  const screenshotPath = pathUtils.join(tempDir, screenshotFilename);
+  const optimizedFilename = `device_screenshot_optimized_${uuidUtils.v4()}.jpg`;
+  const optimizedPath = pathUtils.join(tempDir, optimizedFilename);
+
+  // Check if pymobiledevice3 is available
+  const isAvailable = await checkPymobiledevice3Available(executor);
+  if (!isAvailable) {
+    return createErrorResponse(
+      'pymobiledevice3 not found',
+      'pymobiledevice3 is required to capture screenshots from physical devices.\n' +
+        'Install it with: pipx install pymobiledevice3\n' +
+        'For iOS 17+, you also need a running tunnel: sudo pymobiledevice3 remote tunneld',
+    );
+  }
+
+  const commandArgs: string[] = [
+    'pymobiledevice3',
+    'developer',
+    'dvt',
+    'screenshot',
+    screenshotPath,
+    '--udid',
+    deviceId,
+  ];
+
+  log('info', `${LOG_PREFIX}: Starting capture to ${screenshotPath} on device ${deviceId}`);
+
+  try {
+    const result = await executor(commandArgs, `${LOG_PREFIX}: screenshot`, false);
+
+    if (!result.success) {
+      const errorMsg = result.error ?? result.output ?? '';
+      if (errorMsg.includes('tunneld') || errorMsg.includes('InvalidService')) {
+        throw new SystemError(
+          'Failed to capture screenshot: Unable to connect to device tunnel.\n' +
+            'For iOS 17+, start a tunnel first: sudo pymobiledevice3 remote tunneld',
+        );
+      }
+      throw new SystemError(`Failed to capture screenshot: ${errorMsg}`);
+    }
+
+    log('info', `${LOG_PREFIX}: Screenshot captured for device ${deviceId}`);
+
+    try {
+      // Optimize the image for LLM consumption: resize to max 800px and convert to JPEG
+      const optimizeArgs = [
+        'sips',
+        '-Z',
+        '800',
+        '-s',
+        'format',
+        'jpeg',
+        '-s',
+        'formatOptions',
+        '75',
+        screenshotPath,
+        '--out',
+        optimizedPath,
+      ];
+
+      const optimizeResult = await executor(optimizeArgs, `${LOG_PREFIX}: optimize image`, false);
+
+      if (!optimizeResult.success) {
+        log('warning', `${LOG_PREFIX}: Image optimization failed, using original PNG`);
+        if (returnFormat === 'base64') {
+          const base64Image = await fileSystemExecutor.readFile(screenshotPath, 'base64');
+
+          try {
+            await fileSystemExecutor.rm(screenshotPath);
+          } catch (err) {
+            log('warning', `${LOG_PREFIX}: Failed to delete temp file: ${err}`);
+          }
+
+          return {
+            content: [createImageContent(base64Image, 'image/png')],
+            isError: false,
+          };
+        }
+
+        const fileUrl = `file://${screenshotPath}`;
+        return createTextResponse(
+          `Screenshot captured (image/png, optimization failed):\n[${screenshotPath}](${fileUrl})`,
+        );
+      }
+
+      log('info', `${LOG_PREFIX}: Image optimized successfully`);
+
+      if (returnFormat === 'base64') {
+        const base64Image = await fileSystemExecutor.readFile(optimizedPath, 'base64');
+
+        log('info', `${LOG_PREFIX}: Successfully encoded image as Base64`);
+
+        try {
+          await fileSystemExecutor.rm(screenshotPath);
+          await fileSystemExecutor.rm(optimizedPath);
+        } catch (err) {
+          log('warning', `${LOG_PREFIX}: Failed to delete temporary files: ${err}`);
+        }
+
+        return {
+          content: [createImageContent(base64Image, 'image/jpeg')],
+          isError: false,
+        };
+      }
+
+      try {
+        await fileSystemExecutor.rm(screenshotPath);
+      } catch (err) {
+        log('warning', `${LOG_PREFIX}: Failed to delete temp file: ${err}`);
+      }
+
+      const fileUrl = `file://${optimizedPath}`;
+      return createTextResponse(
+        `Screenshot captured (image/jpeg):\n[${optimizedPath}](${fileUrl})`,
+      );
+    } catch (fileError) {
+      log('error', `${LOG_PREFIX}: Failed to process image file: ${fileError}`);
+      return createErrorResponse(
+        `Screenshot captured but failed to process image file: ${fileError instanceof Error ? fileError.message : String(fileError)}`,
+      );
+    }
+  } catch (_error) {
+    log('error', `${LOG_PREFIX}: Failed - ${_error}`);
+    if (_error instanceof SystemError) {
+      return createErrorResponse(
+        `System error executing screenshot: ${_error.message}`,
+        _error.originalError?.stack,
+      );
+    }
+    return createErrorResponse(
+      `An unexpected error occurred: ${_error instanceof Error ? _error.message : String(_error)}`,
+    );
+  }
+}
+
+export const schema = getSessionAwareToolSchemaShape({
+  sessionAware: publicSchemaObject,
+  legacy: deviceScreenshotSchema,
+});
+
+export const handler = createSessionAwareTool<DeviceScreenshotParams>({
+  internalSchema: deviceScreenshotSchema as unknown as z.ZodType<DeviceScreenshotParams, unknown>,
+  logicFunction: (params: DeviceScreenshotParams, executor: CommandExecutor) => {
+    return deviceScreenshotLogic(params, executor);
+  },
+  getExecutor: getDefaultCommandExecutor,
+  requirements: [{ allOf: ['deviceId'], message: 'deviceId is required' }],
+});


### PR DESCRIPTION
## Summary

- Adds a new `device_screenshot` tool to the **device** workflow that captures screenshots from connected physical iOS devices
- Uses [pymobiledevice3](https://github.com/doronz88/pymobiledevice3) instead of `idevicescreenshot` (which is [broken on iOS 17+](https://github.com/libimobiledevice/libimobiledevice/issues/1465))
- Works over both **USB and WiFi** connections via the CoreDevice tunnel protocol

## Motivation

The existing `screenshot` tool only works with iOS Simulators (`xcrun simctl io`). The device workflow supports building, testing, installing, and launching apps on physical devices, but had no way to capture screenshots. This PR fills that gap.

## Implementation

| File | Action |
|------|--------|
| `src/mcp/tools/device/device_screenshot.ts` | **New** — main implementation |
| `src/mcp/tools/device/__tests__/device_screenshot.test.ts` | **New** — 16 unit tests |
| `manifests/tools/device_screenshot.yaml` | **New** — tool manifest |
| `manifests/workflows/device.yaml` | **Edit** — added tool to workflow |

### How it works

1. Checks if `pymobiledevice3` is available (clear error + install instructions if not)
2. Captures screenshot via `pymobiledevice3 developer dvt screenshot --udid <deviceId>`
3. Optimizes with `sips` (resize to 800px max, JPEG 75%) — same approach as the simulator screenshot tool
4. Returns base64 image content or clickable `file://` link based on `returnFormat`
5. Falls back to original PNG if optimization fails

### Error handling

- **Missing dependency**: suggests `pipx install pymobiledevice3`
- **Tunnel not running** (iOS 17+): suggests `sudo pymobiledevice3 remote tunneld`
- **Device not connected**: surfaces the underlying error message

### Why pymobiledevice3 over idevicescreenshot?

`idevicescreenshot` from libimobiledevice relies on the `screenshotr` service which requires a Developer Disk Image. Apple removed DDI support starting with iOS 17/Xcode 15, and the [issue remains unresolved](https://github.com/libimobiledevice/libimobiledevice/issues/1465). `pymobiledevice3` supports the new CoreDevice protocol and works on iOS 17+.

## Prerequisites for users

```bash
# Install pymobiledevice3
pipx install pymobiledevice3

# For iOS 17+, start a tunnel (runs in background, requires sudo)
sudo pymobiledevice3 remote tunneld
```

## Test plan

- [x] 16 unit tests pass (tool availability check, screenshot capture, path/base64 return, error paths, optimization fallback, tunnel error hint)
- [x] `npm run build` compiles cleanly
- [x] Tested on physical iPhone 16 (iOS 26.3) over USB+WiFi with tunnel
- [x] Verified error path when pymobiledevice3 is not installed
- [x] Verified image optimization (212KB PNG → 5.7KB JPEG)

