### PR TITLE
Add AgentAudit security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Model Context Protocol (MCP) server and CLI that provides tools for agent use 
 
 [![CI](https://github.com/getsentry/XcodeBuildMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/getsentry/XcodeBuildMCP/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/xcodebuildmcp.svg)](https://badge.fury.io/js/xcodebuildmcp) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Node.js](https://img.shields.io/badge/node->=18.x-brightgreen.svg)](https://nodejs.org/) [![Xcode 16](https://img.shields.io/badge/Xcode-16-blue.svg)](https://developer.apple.com/xcode/) [![macOS](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos/) [![MCP](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io/) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/getsentry/XcodeBuildMCP)
+[![AgentAudit Security](https://agentaudit.dev/api/badge/xcodebuildmcp)](https://agentaudit.dev/packages/xcodebuildmcp)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds an [AgentAudit](https://agentaudit.dev) security badge to the README, showing the current trust score for the `xcodebuildmcp` package.

**Current Trust Score: 96/100** — No significant security findings detected across multiple independent AI-powered audits.

[![AgentAudit Security](https://agentaudit.dev/api/badge/xcodebuildmcp)](https://agentaudit.dev/packages/xcodebuildmcp)

## What is AgentAudit?

[AgentAudit](https://agentaudit.dev) is an open security registry for AI agent packages (MCP servers, skills, npm/pip packages). It provides:

- Multi-model security audits (Claude, GPT-4o, Gemini, etc.)
- Consensus-based trust scoring
- Standardized vulnerability IDs (ASF-IDs)

The badge auto-updates as new audits are submitted. Full audit details: https://agentaudit.dev/packages/xcodebuildmcp