### PR TITLE
fix: include stdout diagnostics when stderr is empty on swift package failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `swift_package_build`, `swift_package_test`, and `swift_package_clean` swallowing compiler diagnostics on failure by treating empty stderr as falsy, so stdout diagnostics are included in the error response ([#243](https://github.com/getsentry/XcodeBuildMCP/issues/243)).
+
 ## [2.1.0]
 
 ### Added

--- a/src/mcp/tools/swift-package/__tests__/swift_package_build.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_build.test.ts
@@ -228,6 +228,32 @@ describe('swift_package_build plugin', () => {
       });
     });
 
+    it('should include stdout diagnostics when stderr is empty on build failure', async () => {
+      const executor = createMockExecutor({
+        success: false,
+        error: '',
+        output:
+          "main.swift:10:25: error: cannot find type 'DOESNOTEXIST' in scope\nlet broken: DOESNOTEXIST = 42",
+      });
+
+      const result = await swift_package_buildLogic(
+        {
+          packagePath: '/test/package',
+        },
+        executor,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: "Error: Swift package build failed\nDetails: main.swift:10:25: error: cannot find type 'DOESNOTEXIST' in scope\nlet broken: DOESNOTEXIST = 42",
+          },
+        ],
+        isError: true,
+      });
+    });
+
     it('should handle spawn error', async () => {
       const executor = async () => {
         throw new Error('spawn ENOENT');

--- a/src/mcp/tools/swift-package/__tests__/swift_package_test.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/swift_package_test.test.ts
@@ -218,6 +218,32 @@ describe('swift_package_test plugin', () => {
       });
     });
 
+    it('should include stdout diagnostics when stderr is empty on test failure', async () => {
+      const mockExecutor = createMockExecutor({
+        success: false,
+        error: '',
+        output:
+          "main.swift:10:25: error: cannot find type 'DOESNOTEXIST' in scope\nlet broken: DOESNOTEXIST = 42",
+      });
+
+      const result = await swift_package_testLogic(
+        {
+          packagePath: '/test/package',
+        },
+        mockExecutor,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: "Error: Swift package tests failed\nDetails: main.swift:10:25: error: cannot find type 'DOESNOTEXIST' in scope\nlet broken: DOESNOTEXIST = 42",
+          },
+        ],
+        isError: true,
+      });
+    });
+
     it('should handle spawn error', async () => {
       const mockExecutor = async () => {
         throw new Error('spawn ENOENT');

--- a/src/mcp/tools/swift-package/swift_package_build.ts
+++ b/src/mcp/tools/swift-package/swift_package_build.ts
@@ -57,7 +57,7 @@ export async function swift_package_buildLogic(
   try {
     const result = await executor(['swift', ...swiftArgs], 'Swift Package Build', false, undefined);
     if (!result.success) {
-      const errorMessage = result.error ?? result.output ?? 'Unknown error';
+      const errorMessage = result.error || result.output || 'Unknown error';
       return createErrorResponse('Swift package build failed', errorMessage);
     }
 

--- a/src/mcp/tools/swift-package/swift_package_clean.ts
+++ b/src/mcp/tools/swift-package/swift_package_clean.ts
@@ -26,7 +26,7 @@ export async function swift_package_cleanLogic(
   try {
     const result = await executor(['swift', ...swiftArgs], 'Swift Package Clean', false, undefined);
     if (!result.success) {
-      const errorMessage = result.error ?? result.output ?? 'Unknown error';
+      const errorMessage = result.error || result.output || 'Unknown error';
       return createErrorResponse('Swift package clean failed', errorMessage);
     }
 

--- a/src/mcp/tools/swift-package/swift_package_test.ts
+++ b/src/mcp/tools/swift-package/swift_package_test.ts
@@ -67,7 +67,7 @@ export async function swift_package_testLogic(
   try {
     const result = await executor(['swift', ...swiftArgs], 'Swift Package Test', false, undefined);
     if (!result.success) {
-      const errorMessage = result.error ?? result.output ?? 'Unknown error';
+      const errorMessage = result.error || result.output || 'Unknown error';
       return createErrorResponse('Swift package tests failed', errorMessage);
     }
 


### PR DESCRIPTION
## Summary

- Fixes `swift_package_build`, `swift_package_test`, and `swift_package_clean` swallowing compiler diagnostics on failure
- SPM writes compiler diagnostics to stdout, not stderr — the `??` operator does not treat `""` as falsy, so when stderr is empty the stdout diagnostics were silently dropped
- Switching to `||` fixes the fallback so diagnostics are always included in the error response

## Changes

- `swift_package_build.ts`, `swift_package_test.ts`, `swift_package_clean.ts`: `result.error ?? result.output` → `result.error || result.output`
- Added regression tests for the empty-stderr case in `swift_package_build` and `swift_package_test`

## Test plan

- [ ] Unit tests pass: `npx vitest run src/mcp/tools/swift-package/__tests__/swift_package_build.test.ts src/mcp/tools/swift-package/__tests__/swift_package_test.test.ts`
- [ ] CLI test: create a Swift package with `let broken: DOESNOTEXIST = 42`, run `node build/cli.js swift-package build --package-path <path>` — full diagnostics with file/line/col now appear in the error response

Fixes #243