### PR TITLE
fix(init): Surface MCP policy skip reasons

### DIFF
--- a/src/cli/commands/__tests__/init.test.ts
+++ b/src/cli/commands/__tests__/init.test.ts
@@ -159,6 +159,30 @@ describe('init command', () => {
       stdoutSpy.mockRestore();
     });
 
+    it('errors with skip reason when only Claude is detected for MCP auto-install', async () => {
+      const fakeHome = join(tempDir, 'home-only-claude');
+      mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+      mockedHomedir.mockReturnValue(fakeHome);
+
+      const yargs = (await import('yargs')).default;
+      const mod = await loadInitModule();
+
+      const app = yargs(['init', '--skill', 'mcp']).scriptName('').fail(false);
+      mod.registerInitCommand(app);
+
+      const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      await expect(app.parseAsync()).rejects.toThrow(
+        'No eligible install targets after applying skill policy. Skipped: Claude Code: MCP skill is unnecessary because Claude Code already uses server instructions.',
+      );
+
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain(
+        'Skipped Claude Code: MCP skill is unnecessary because Claude Code already uses server instructions.',
+      );
+
+      stdoutSpy.mockRestore();
+    });
+
     it('allows explicit Claude MCP install with --client claude', async () => {
       const fakeHome = join(tempDir, 'home-explicit-claude');
       mkdirSync(join(fakeHome, '.claude'), { recursive: true });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -100,6 +100,14 @@ interface InstallPolicyResult {
   skippedClients: Array<{ client: string; reason: string }>;
 }
 
+function formatSkippedClients(skippedClients: Array<{ client: string; reason: string }>): string {
+  if (skippedClients.length === 0) {
+    return '';
+  }
+
+  return skippedClients.map((skipped) => `${skipped.client}: ${skipped.reason}`).join('; ');
+}
+
 async function installSkill(
   skillsDir: string,
   clientName: string,
@@ -348,8 +356,14 @@ export function registerInitCommand(app: Argv, ctx?: { workspaceRoot: string }):
       const targets = resolveTargets(clientFlag, destFlag, 'install');
 
       const policy = enforceInstallPolicy(targets, skillType, clientFlag, destFlag);
+      for (const skipped of policy.skippedClients) {
+        writeLine(`Skipped ${skipped.client}: ${skipped.reason}`);
+      }
+
       if (policy.allowedTargets.length === 0) {
-        throw new Error('No eligible install targets after applying skill policy.');
+        const skippedSummary = formatSkippedClients(policy.skippedClients);
+        const reasonSuffix = skippedSummary.length > 0 ? ` Skipped: ${skippedSummary}` : '';
+        throw new Error(`No eligible install targets after applying skill policy.${reasonSuffix}`);
       }
 
       const results: InstallResult[] = [];
@@ -359,10 +373,6 @@ export function registerInitCommand(app: Argv, ctx?: { workspaceRoot: string }):
           removeConflict: argv['remove-conflict'] as boolean,
         });
         results.push(result);
-      }
-
-      for (const skipped of policy.skippedClients) {
-        writeLine(`Skipped ${skipped.client}: ${skipped.reason}`);
       }
 
       writeLine(`Installed ${skillDisplayName(skillType)} skill`);
@@ -393,6 +403,10 @@ function enforceInstallPolicy(
     return { allowedTargets: targets, skippedClients: [] };
   }
 
+  if (clientFlag === 'claude') {
+    return { allowedTargets: targets, skippedClients: [] };
+  }
+
   const allowedTargets: ClientInfo[] = [];
   const skippedClients: Array<{ client: string; reason: string }> = [];
 
@@ -405,10 +419,6 @@ function enforceInstallPolicy(
       continue;
     }
     allowedTargets.push(target);
-  }
-
-  if (clientFlag === 'claude') {
-    return { allowedTargets: targets, skippedClients: [] };
   }
 
   return { allowedTargets, skippedClients };


### PR DESCRIPTION
Improve `init --skill mcp` feedback when install policy filters out all targets.

This follow-up addresses post-merge review feedback on #250. The previous behavior raised a
technically correct but low-context error when only Claude was auto-detected and filtered.
Now we print skipped-client reasons before failing and include those reasons in the error
message, so users immediately understand why no eligible targets remain.

I considered only changing the throw message, but that would still hide useful per-client
skip output in the failing path. Printing skip reasons before the empty-target check keeps
the behavior consistent with successful installs while preserving a clear terminal failure.

Also move the explicit `--client claude` override before the filtering loop to make policy
intent explicit and avoid unnecessary filter work, and add a regression test for the
only-Claude auto-detect MCP scenario.

Refs GH-250