### PR TITLE
fix(runtime): Prevent startup simulator metadata config churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fixed startup simulator metadata refresh mutating `.xcodebuildmcp/config.yaml` by keeping derived simulator values in memory instead of persisting them during MCP startup hydration ([#230](https://github.com/getsentry/XcodeBuildMCP/issues/230)).
 - Fixed orphaned MCP server processes by attaching shutdown handlers before async startup, explicitly stopping the Xcode watcher during teardown, and adding lifecycle diagnostics for memory and peer-process anomalies ([#273](https://github.com/getsentry/XcodeBuildMCP/issues/273)).
 
 ## [2.2.1]

--- a/src/runtime/__tests__/bootstrap-runtime.test.ts
+++ b/src/runtime/__tests__/bootstrap-runtime.test.ts
@@ -1,5 +1,14 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
+
+const { scheduleSimulatorDefaultsRefreshMock } = vi.hoisted(() => ({
+  scheduleSimulatorDefaultsRefreshMock: vi.fn(),
+}));
+
+vi.mock('../../utils/simulator-defaults-refresh.ts', () => ({
+  scheduleSimulatorDefaultsRefresh: scheduleSimulatorDefaultsRefreshMock,
+}));
+
 import { bootstrapRuntime, type RuntimeKind } from '../bootstrap-runtime.ts';
 import { __resetConfigStoreForTests } from '../../utils/config-store.ts';
 import { sessionStore } from '../../utils/session-store.ts';
@@ -71,6 +80,8 @@ describe('bootstrapRuntime', () => {
   beforeEach(() => {
     __resetConfigStoreForTests();
     sessionStore.clear();
+    scheduleSimulatorDefaultsRefreshMock.mockReset();
+    scheduleSimulatorDefaultsRefreshMock.mockReturnValue(false);
   });
 
   it('hydrates session defaults for mcp runtime', async () => {
@@ -86,6 +97,14 @@ describe('bootstrapRuntime', () => {
       simulatorId: 'SIM-UUID',
       simulatorName: 'iPhone 17',
     });
+    expect(scheduleSimulatorDefaultsRefreshMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'startup-hydration',
+        persist: false,
+        simulatorId: 'SIM-UUID',
+        simulatorName: 'iPhone 17',
+      }),
+    );
   });
 
   it('hydrates non-simulator session defaults for mcp runtime', async () => {

--- a/src/runtime/bootstrap-runtime.ts
+++ b/src/runtime/bootstrap-runtime.ts
@@ -73,7 +73,7 @@ function hydrateSessionDefaultsForMcp(
     expectedRevision: revision,
     reason: 'startup-hydration',
     profile: sessionStore.getActiveProfile(),
-    persist: true,
+    persist: false,
     simulatorId: activeDefaults.simulatorId,
     simulatorName: activeDefaults.simulatorName,
     recomputePlatform: true,


### PR DESCRIPTION
Stop MCP startup hydration from persisting derived simulator metadata to `.xcodebuildmcp/config.yaml`.

This keeps behavior unchanged for end users (startup still hydrates defaults and refreshes simulator metadata in memory) while eliminating machine-specific config churn when a shared config sets `simulatorName`.

Alternative considered: adding a new config flag to control startup persistence. I chose not to add one because this persistence is derived/internal behavior rather than user intent, and defaulting to in-memory avoids extra surface area.

Also added a regression test to assert startup refresh is scheduled with `persist: false`.

Fixes #230