### PR TITLE
feat(setup): platform-aware wizard with smart workflow pre-seeding and macOS-only skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added platform selection step to the `xcodebuildmcp setup` wizard. You now choose which platforms you are developing for (macOS, iOS, tvOS, watchOS, visionOS) before selecting workflows. Based on the selection, the wizard automatically recommends the appropriate workflow set.
+
+### Changed
+
+- The `setup` wizard no longer prompts for a simulator or device when macOS is the only selected platform — macOS apps run natively and do not require a simulator or physical device.
+- When a single platform is selected, `xcodebuildmcp setup` now writes `platform` to `sessionDefaults` in `config.yaml` and includes `XCODEBUILDMCP_PLATFORM` in `--format mcp-json` output. For multi-platform projects the platform key is omitted so the agent can choose per-command.
+- The `setup` wizard remembers previous choices on re-run: existing `config.yaml` values (including the new `platform`) are pre-loaded as defaults for every prompt.
+
 ## [2.3.0]
 
 ### Added

--- a/src/cli/commands/__tests__/setup.test.ts
+++ b/src/cli/commands/__tests__/setup.test.ts
@@ -108,6 +108,26 @@ function createTestPrompter(): Prompter {
   };
 }
 
+function createPlatformPrompter(platforms: string[]): Prompter {
+  let selectManyCalls = 0;
+  return {
+    selectOne: async <T>(opts: { options: Array<{ value: T }> }) => {
+      const preferredOption = opts.options.find((option) => option.value != null);
+      return (preferredOption ?? opts.options[0]).value;
+    },
+    selectMany: async <T>(opts: { options: Array<{ value: T }> }) => {
+      selectManyCalls++;
+      if (selectManyCalls === 1) {
+        return opts.options
+          .filter((option) => platforms.includes(String(option.value)))
+          .map((option) => option.value);
+      }
+      return opts.options.map((option) => option.value);
+    },
+    confirm: async (opts: { defaultValue: boolean }) => opts.defaultValue,
+  };
+}
+
 describe('setup command', () => {
   const originalStdinIsTTY = process.stdin.isTTY;
   const originalStdoutIsTTY = process.stdout.isTTY;
@@ -1053,5 +1073,231 @@ sessionDefaults:
     Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
 
     await expect(runSetupWizard()).rejects.toThrow('requires an interactive TTY');
+  });
+
+  it('skips simulator and sets platform for macOS-only selection', async () => {
+    let storedConfig = '';
+
+    const fs = createMockFileSystemExecutor({
+      existsSync: (targetPath) => targetPath === configPath && storedConfig.length > 0,
+      stat: async () => ({ isDirectory: () => true, mtimeMs: 0 }),
+      readdir: async (targetPath) => {
+        if (targetPath === cwd) {
+          return [
+            {
+              name: 'App.xcworkspace',
+              isDirectory: () => true,
+              isSymbolicLink: () => false,
+            },
+          ];
+        }
+        return [];
+      },
+      readFile: async (targetPath) => {
+        if (targetPath !== configPath) throw new Error(`Unexpected read path: ${targetPath}`);
+        return storedConfig;
+      },
+      writeFile: async (targetPath, content) => {
+        if (targetPath !== configPath) throw new Error(`Unexpected write path: ${targetPath}`);
+        storedConfig = content;
+      },
+    });
+
+    const executor: CommandExecutor = async () =>
+      createMockCommandResponse({
+        success: true,
+        output: `Information about workspace "App":\n    Schemes:\n        App`,
+      });
+
+    await runSetupWizard({
+      cwd,
+      fs,
+      executor,
+      prompter: createPlatformPrompter(['macOS']),
+      quietOutput: true,
+    });
+
+    const parsed = parseYaml(storedConfig) as {
+      sessionDefaults?: Record<string, unknown>;
+    };
+
+    expect(parsed.sessionDefaults?.platform).toBe('macOS');
+    expect(parsed.sessionDefaults?.simulatorId).toBeUndefined();
+    expect(parsed.sessionDefaults?.simulatorName).toBeUndefined();
+  });
+
+  it('outputs XCODEBUILDMCP_PLATFORM=macOS and no simulator fields for macOS-only mcp-json', async () => {
+    const fs = createMockFileSystemExecutor({
+      existsSync: () => false,
+      stat: async () => ({ isDirectory: () => true, mtimeMs: 0 }),
+      readdir: async (targetPath) => {
+        if (targetPath === cwd) {
+          return [
+            {
+              name: 'App.xcworkspace',
+              isDirectory: () => true,
+              isSymbolicLink: () => false,
+            },
+          ];
+        }
+        return [];
+      },
+      readFile: async () => '',
+      writeFile: async () => {},
+    });
+
+    const executor: CommandExecutor = async () =>
+      createMockCommandResponse({
+        success: true,
+        output: `Information about workspace "App":\n    Schemes:\n        App`,
+      });
+
+    const result = await runSetupWizard({
+      cwd,
+      fs,
+      executor,
+      prompter: createPlatformPrompter(['macOS']),
+      quietOutput: true,
+      outputFormat: 'mcp-json',
+    });
+
+    expect(result.mcpConfigJson).toBeDefined();
+    const parsed = JSON.parse(result.mcpConfigJson!) as {
+      mcpServers: { XcodeBuildMCP: { env: Record<string, string> } };
+    };
+    const env = parsed.mcpServers.XcodeBuildMCP.env;
+
+    expect(env.XCODEBUILDMCP_PLATFORM).toBe('macOS');
+    expect(env.XCODEBUILDMCP_SIMULATOR_ID).toBeUndefined();
+    expect(env.XCODEBUILDMCP_SIMULATOR_NAME).toBeUndefined();
+  });
+
+  it('outputs XCODEBUILDMCP_PLATFORM=iOS Simulator and simulator fields for iOS-only mcp-json', async () => {
+    const fs = createMockFileSystemExecutor({
+      existsSync: () => false,
+      stat: async () => ({ isDirectory: () => true, mtimeMs: 0 }),
+      readdir: async (targetPath) => {
+        if (targetPath === cwd) {
+          return [
+            {
+              name: 'App.xcworkspace',
+              isDirectory: () => true,
+              isSymbolicLink: () => false,
+            },
+          ];
+        }
+        return [];
+      },
+      readFile: async () => '',
+      writeFile: async () => {},
+    });
+
+    const executor: CommandExecutor = async (command) => {
+      if (command.includes('--json')) {
+        return createMockCommandResponse({
+          success: true,
+          output: JSON.stringify({
+            devices: {
+              'iOS 17.0': [
+                { name: 'iPhone 15', udid: 'SIM-1', state: 'Shutdown', isAvailable: true },
+              ],
+            },
+          }),
+        });
+      }
+      if (command[0] === 'xcrun') {
+        return createMockCommandResponse({
+          success: true,
+          output: `== Devices ==\n-- iOS 17.0 --\n    iPhone 15 (SIM-1) (Shutdown)`,
+        });
+      }
+      return createMockCommandResponse({
+        success: true,
+        output: `Information about workspace "App":\n    Schemes:\n        App`,
+      });
+    };
+
+    const result = await runSetupWizard({
+      cwd,
+      fs,
+      executor,
+      prompter: createPlatformPrompter(['iOS']),
+      quietOutput: true,
+      outputFormat: 'mcp-json',
+    });
+
+    expect(result.mcpConfigJson).toBeDefined();
+    const parsed = JSON.parse(result.mcpConfigJson!) as {
+      mcpServers: { XcodeBuildMCP: { env: Record<string, string> } };
+    };
+    const env = parsed.mcpServers.XcodeBuildMCP.env;
+
+    expect(env.XCODEBUILDMCP_PLATFORM).toBe('iOS Simulator');
+    expect(env.XCODEBUILDMCP_SIMULATOR_ID).toBe('SIM-1');
+    expect(env.XCODEBUILDMCP_SIMULATOR_NAME).toBe('iPhone 15');
+  });
+
+  it('omits XCODEBUILDMCP_PLATFORM for multi-platform mcp-json', async () => {
+    const fs = createMockFileSystemExecutor({
+      existsSync: () => false,
+      stat: async () => ({ isDirectory: () => true, mtimeMs: 0 }),
+      readdir: async (targetPath) => {
+        if (targetPath === cwd) {
+          return [
+            {
+              name: 'App.xcworkspace',
+              isDirectory: () => true,
+              isSymbolicLink: () => false,
+            },
+          ];
+        }
+        return [];
+      },
+      readFile: async () => '',
+      writeFile: async () => {},
+    });
+
+    const executor: CommandExecutor = async (command) => {
+      if (command.includes('--json')) {
+        return createMockCommandResponse({
+          success: true,
+          output: JSON.stringify({
+            devices: {
+              'iOS 17.0': [
+                { name: 'iPhone 15', udid: 'SIM-1', state: 'Shutdown', isAvailable: true },
+              ],
+            },
+          }),
+        });
+      }
+      if (command[0] === 'xcrun') {
+        return createMockCommandResponse({
+          success: true,
+          output: `== Devices ==\n-- iOS 17.0 --\n    iPhone 15 (SIM-1) (Shutdown)`,
+        });
+      }
+      return createMockCommandResponse({
+        success: true,
+        output: `Information about workspace "App":\n    Schemes:\n        App`,
+      });
+    };
+
+    const result = await runSetupWizard({
+      cwd,
+      fs,
+      executor,
+      prompter: createPlatformPrompter(['macOS', 'iOS']),
+      quietOutput: true,
+      outputFormat: 'mcp-json',
+    });
+
+    expect(result.mcpConfigJson).toBeDefined();
+    const parsed = JSON.parse(result.mcpConfigJson!) as {
+      mcpServers: { XcodeBuildMCP: { env: Record<string, string> } };
+    };
+    const env = parsed.mcpServers.XcodeBuildMCP.env;
+
+    expect(env.XCODEBUILDMCP_PLATFORM).toBeUndefined();
+    expect(env.XCODEBUILDMCP_SIMULATOR_ID).toBe('SIM-1');
   });
 });

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -24,10 +24,13 @@ import type { FileSystemExecutor } from '../../utils/FileSystemExecutor.ts';
 import type { CommandExecutor } from '../../utils/CommandExecutor.ts';
 import { createDoctorDependencies } from '../../mcp/tools/doctor/lib/doctor.deps.ts';
 
+type SetupPlatform = 'macOS' | 'iOS' | 'tvOS' | 'watchOS' | 'visionOS';
+
 interface SetupSelection {
   debug: boolean;
   sentryDisabled: boolean;
   enabledWorkflows: string[];
+  platforms: SetupPlatform[];
   projectPath?: string;
   workspacePath?: string;
   scheme: string;
@@ -64,6 +67,84 @@ interface SetupDevice {
   udid: string;
   platform: string;
 }
+
+const PLATFORM_WORKFLOWS: Record<SetupPlatform, string[]> = {
+  macOS: [
+    'coverage',
+    'debugging',
+    'doctor',
+    'logging',
+    'macos',
+    'project-discovery',
+    'project-scaffolding',
+    'swift-package',
+    'ui-automation',
+    'utilities',
+    'xcode-ide',
+  ],
+  iOS: [
+    'coverage',
+    'debugging',
+    'doctor',
+    'logging',
+    'project-discovery',
+    'project-scaffolding',
+    'simulator',
+    'swift-package',
+    'ui-automation',
+    'utilities',
+    'xcode-ide',
+  ],
+  tvOS: [
+    'debugging',
+    'doctor',
+    'logging',
+    'project-discovery',
+    'simulator',
+    'swift-package',
+    'utilities',
+    'xcode-ide',
+  ],
+  watchOS: [
+    'debugging',
+    'doctor',
+    'logging',
+    'project-discovery',
+    'simulator',
+    'swift-package',
+    'utilities',
+    'xcode-ide',
+  ],
+  visionOS: [
+    'coverage',
+    'debugging',
+    'doctor',
+    'logging',
+    'project-discovery',
+    'project-scaffolding',
+    'simulator',
+    'swift-package',
+    'ui-automation',
+    'utilities',
+    'xcode-ide',
+  ],
+};
+
+const PLATFORM_OPTIONS: Array<{ value: SetupPlatform; label: string; description: string }> = [
+  { value: 'macOS', label: 'macOS', description: 'Native macOS apps — no simulator needed' },
+  { value: 'iOS', label: 'iOS', description: 'iPhone and iPad apps, runs on iOS Simulator' },
+  { value: 'tvOS', label: 'tvOS', description: 'Apple TV apps, runs on tvOS Simulator' },
+  {
+    value: 'watchOS',
+    label: 'watchOS',
+    description: 'Apple Watch apps, runs on watchOS Simulator',
+  },
+  {
+    value: 'visionOS',
+    label: 'visionOS',
+    description: 'Apple Vision Pro apps, runs on visionOS Simulator',
+  },
+];
 
 function showPromptHelp(helpText: string, quietOutput: boolean): void {
   if (quietOutput) {
@@ -134,6 +215,64 @@ function normalizeExistingDefaults(config?: ProjectConfig): {
     simulatorId: sessionDefaults.simulatorId,
     simulatorName: sessionDefaults.simulatorName,
   };
+}
+
+function inferPlatformsFromExisting(config?: ProjectConfig): SetupPlatform[] {
+  if (!config) return [];
+
+  const platform = config.sessionDefaults?.platform;
+  if (platform === 'macOS') return ['macOS'];
+  if (platform === 'iOS Simulator') return ['iOS'];
+  if (platform === 'tvOS Simulator') return ['tvOS'];
+  if (platform === 'watchOS Simulator') return ['watchOS'];
+  if (platform === 'visionOS Simulator') return ['visionOS'];
+
+  // Multi-platform or legacy config: combine workflow heuristic (macOS) with
+  // simulatorPlatform to recover the non-macOS component.
+  const results: SetupPlatform[] = [];
+  const workflows = new Set(config.enabledWorkflows ?? []);
+  if (workflows.has('macos')) results.push('macOS');
+
+  const simPlatform = config.sessionDefaults?.simulatorPlatform;
+  if (simPlatform === 'iOS Simulator') results.push('iOS');
+  else if (simPlatform === 'tvOS Simulator') results.push('tvOS');
+  else if (simPlatform === 'watchOS Simulator') results.push('watchOS');
+  else if (simPlatform === 'visionOS Simulator') results.push('visionOS');
+  else if (workflows.has('simulator')) results.push('iOS'); // legacy fallback
+
+  return results;
+}
+
+function derivePlatformSessionDefault(platforms: SetupPlatform[]): string | undefined {
+  if (platforms.length !== 1) return undefined;
+  const platformMap: Record<SetupPlatform, string> = {
+    macOS: 'macOS',
+    iOS: 'iOS Simulator',
+    tvOS: 'tvOS Simulator',
+    watchOS: 'watchOS Simulator',
+    visionOS: 'visionOS Simulator',
+  };
+  return platformMap[platforms[0]];
+}
+
+function filterSimulatorsByPlatforms(
+  simulators: ListedSimulator[],
+  platforms: SetupPlatform[],
+): ListedSimulator[] {
+  const nonMacPlatforms = platforms.filter((p) => p !== 'macOS') as Exclude<
+    SetupPlatform,
+    'macOS'
+  >[];
+  if (nonMacPlatforms.length !== 1) return simulators;
+
+  const platform = nonMacPlatforms[0];
+  const filtered = simulators.filter((sim) => {
+    if (platform === 'visionOS') {
+      return sim.runtime.includes('xrOS') || sim.runtime.includes('visionOS');
+    }
+    return sim.runtime.includes(platform);
+  });
+  return filtered.length > 0 ? filtered : simulators;
 }
 
 function getWorkflowOptions(
@@ -208,6 +347,11 @@ function getChangedFields(
       beforeValue: beforeDefaults.simulatorName,
       afterValue: afterDefaults.simulatorName,
     },
+    {
+      label: 'sessionDefaults.platform',
+      beforeValue: beforeDefaults.platform,
+      afterValue: afterDefaults.platform,
+    },
   ];
 
   const changed: string[] = [];
@@ -226,6 +370,7 @@ async function selectWorkflowIds(opts: {
   debug: boolean;
   existingConfig?: ProjectConfig;
   existingEnabledWorkflows: string[];
+  platforms: SetupPlatform[];
   prompter: Prompter;
   quietOutput: boolean;
 }): Promise<string[]> {
@@ -240,11 +385,25 @@ async function selectWorkflowIds(opts: {
     description: workflow.description,
   }));
 
-  const defaults =
-    opts.existingEnabledWorkflows.length > 0 ? opts.existingEnabledWorkflows : ['simulator'];
+  let defaults: string[];
+  if (opts.existingEnabledWorkflows.length > 0) {
+    defaults = opts.existingEnabledWorkflows;
+  } else if (opts.platforms.length > 0) {
+    const availableIds = new Set(workflows.map((w) => w.id));
+    const recommended = new Set<string>();
+    for (const platform of opts.platforms) {
+      for (const workflowId of PLATFORM_WORKFLOWS[platform]) {
+        if (availableIds.has(workflowId)) recommended.add(workflowId);
+      }
+    }
+    defaults = Array.from(recommended);
+  } else {
+    defaults = ['simulator'];
+  }
 
   showPromptHelp(
-    'Select workflows to choose which groups of tools are enabled by default in this project.',
+    'Select workflows to choose which groups of tools are enabled by default in this project.\n' +
+      'The selection above is recommended for your chosen platforms — you can adjust it freely.',
     opts.quietOutput,
   );
   const selected = await opts.prompter.selectMany({
@@ -256,6 +415,26 @@ async function selectWorkflowIds(opts: {
   });
 
   return selected;
+}
+
+async function selectPlatforms(opts: {
+  existingPlatforms: SetupPlatform[];
+  prompter: Prompter;
+  quietOutput: boolean;
+}): Promise<SetupPlatform[]> {
+  const defaults = opts.existingPlatforms.length > 0 ? opts.existingPlatforms : ['iOS'];
+  showPromptHelp(
+    'Select which platforms you are developing for. This determines which workflows are\n' +
+      'recommended and whether a simulator needs to be configured.',
+    opts.quietOutput,
+  );
+  return opts.prompter.selectMany({
+    message: 'Select target platforms',
+    options: PLATFORM_OPTIONS,
+    initialSelectedKeys: new Set(defaults),
+    getKey: (value) => value,
+    minSelected: 1,
+  });
 }
 
 type ProjectChoice = { kind: 'workspace' | 'project'; absolutePath: string };
@@ -369,12 +548,13 @@ function getDefaultSimulatorIndex(
 async function selectSimulator(opts: {
   existingSimulatorId?: string;
   existingSimulatorName?: string;
+  platformFilter: SetupPlatform[];
   executor: CommandExecutor;
   prompter: Prompter;
   isTTY: boolean;
   quietOutput: boolean;
 }): Promise<ListedSimulator | null> {
-  const simulators = await withSpinner({
+  const allSimulators = await withSpinner({
     isTTY: opts.isTTY,
     quietOutput: opts.quietOutput,
     startMessage: 'Loading simulators...',
@@ -387,6 +567,7 @@ async function selectSimulator(opts: {
       }
     },
   });
+  const simulators = filterSimulatorsByPlatforms(allSimulators, opts.platformFilter);
 
   const defaultIndex =
     simulators.length > 0
@@ -692,10 +873,17 @@ async function collectSetupSelection(
     defaultValue: existingConfig?.sentryDisabled ?? false,
   });
 
+  const platforms = await selectPlatforms({
+    existingPlatforms: inferPlatformsFromExisting(existingConfig),
+    prompter: deps.prompter,
+    quietOutput: deps.quietOutput,
+  });
+
   const enabledWorkflows = await selectWorkflowIds({
     debug,
     existingConfig,
     existingEnabledWorkflows: existingConfig?.enabledWorkflows ?? [],
+    platforms,
     prompter: deps.prompter,
     quietOutput: deps.quietOutput,
   });
@@ -721,40 +909,47 @@ async function collectSetupSelection(
     quietOutput: deps.quietOutput,
   });
 
-  const simulator = requiresSimulatorDefault(enabledWorkflows)
-    ? await selectSimulator({
-        existingSimulatorId: existing.simulatorId,
-        existingSimulatorName: existing.simulatorName,
-        executor: deps.executor,
-        prompter: deps.prompter,
-        isTTY,
-        quietOutput: deps.quietOutput,
-      })
-    : undefined;
+  const isMacOsOnly = platforms.length > 0 && platforms.every((p) => p === 'macOS');
 
-  const device = requiresDeviceDefault(enabledWorkflows)
-    ? await selectDevice({
-        existingDeviceId: existing.deviceId,
-        fs: deps.fs,
-        executor: deps.executor,
-        prompter: deps.prompter,
-        isTTY,
-        quietOutput: deps.quietOutput,
-      })
-    : undefined;
+  const simulator =
+    !isMacOsOnly && requiresSimulatorDefault(enabledWorkflows)
+      ? await selectSimulator({
+          existingSimulatorId: existing.simulatorId,
+          existingSimulatorName: existing.simulatorName,
+          platformFilter: platforms,
+          executor: deps.executor,
+          prompter: deps.prompter,
+          isTTY,
+          quietOutput: deps.quietOutput,
+        })
+      : undefined;
+
+  const device =
+    !isMacOsOnly && requiresDeviceDefault(enabledWorkflows)
+      ? await selectDevice({
+          existingDeviceId: existing.deviceId,
+          fs: deps.fs,
+          executor: deps.executor,
+          prompter: deps.prompter,
+          isTTY,
+          quietOutput: deps.quietOutput,
+        })
+      : undefined;
 
   return {
     debug,
     sentryDisabled,
     enabledWorkflows,
+    platforms,
     projectPath: projectChoice.kind === 'project' ? projectChoice.absolutePath : undefined,
     workspacePath: projectChoice.kind === 'workspace' ? projectChoice.absolutePath : undefined,
     scheme,
     deviceId: device?.udid,
     simulatorId: simulator?.udid,
     simulatorName: simulator?.name,
-    clearDeviceDefault: requiresDeviceDefault(enabledWorkflows) && device == null,
-    clearSimulatorDefault: requiresSimulatorDefault(enabledWorkflows) && simulator == null,
+    clearDeviceDefault: isMacOsOnly || (requiresDeviceDefault(enabledWorkflows) && device == null),
+    clearSimulatorDefault:
+      isMacOsOnly || (requiresSimulatorDefault(enabledWorkflows) && simulator == null),
   };
 }
 
@@ -783,6 +978,12 @@ function selectionToMcpConfigJson(selection: SetupSelection): string {
   if (selection.deviceId) {
     env.XCODEBUILDMCP_DEVICE_ID = selection.deviceId;
   }
+
+  const derivedPlatform = derivePlatformSessionDefault(selection.platforms);
+  if (derivedPlatform) {
+    env.XCODEBUILDMCP_PLATFORM = derivedPlatform;
+  }
+
   if (selection.simulatorId) {
     env.XCODEBUILDMCP_SIMULATOR_ID = selection.simulatorId;
   }
@@ -825,18 +1026,20 @@ export async function runSetupWizard(deps?: Partial<SetupDependencies>): Promise
     if (isMcpJson) {
       clack.log.info(
         'This wizard will configure your project defaults for XcodeBuildMCP.\n' +
-          'You will select a project or workspace, scheme, and any\n' +
-          'simulator/device defaults required by the workflows you enable.\n' +
-          'A bootstrap MCP config JSON block for\n' +
-          'clients with limited workspace support will be printed at the end.',
+          'You will select target platforms, workflows, a project or workspace,\n' +
+          'scheme, and any simulator/device defaults required by the workflows\n' +
+          'you enable. A ready-to-paste MCP config JSON block will be printed\n' +
+          'at the end. You can rerun this wizard at any time — previous choices\n' +
+          'are pre-loaded automatically.',
       );
     } else {
       clack.log.info(
         'This wizard will configure your project defaults for XcodeBuildMCP.\n' +
-          'You will select a project or workspace, scheme, and any\n' +
-          'simulator/device defaults required by the workflows you enable.\n' +
-          'Settings are saved to\n' +
-          '.xcodebuildmcp/config.yaml in your project directory.',
+          'You will select target platforms, workflows, a project or workspace,\n' +
+          'scheme, and any simulator/device defaults required by the workflows\n' +
+          'you enable. Settings are saved to .xcodebuildmcp/config.yaml in your\n' +
+          'project directory. You can rerun this wizard at any time — previous\n' +
+          'choices are pre-loaded automatically.',
       );
     }
   }
@@ -882,6 +1085,11 @@ export async function runSetupWizard(deps?: Partial<SetupDependencies>): Promise
     deleteSessionDefaultKeys.push('simulatorId', 'simulatorName');
   }
 
+  const derivedPlatform = derivePlatformSessionDefault(selection.platforms);
+  if (!derivedPlatform) {
+    deleteSessionDefaultKeys.push('platform');
+  }
+
   const persistedProjectPath =
     selection.projectPath != null
       ? relativePathOrAbsolute(selection.projectPath, resolvedDeps.cwd)
@@ -905,6 +1113,7 @@ export async function runSetupWizard(deps?: Partial<SetupDependencies>): Promise
         deviceId: selection.deviceId,
         simulatorId: selection.simulatorId,
         simulatorName: selection.simulatorName,
+        platform: derivedPlatform,
       },
     },
     deleteSessionDefaultKeys,


### PR DESCRIPTION
Closes #280

Builds on the env var session defaults and `--format mcp-json` foundation landed in #272 to add the platform-aware wizard described in #269.

### What this adds

**New `selectPlatforms` step** — the first substantive wizard prompt asks which platforms the project targets (macOS, iOS, tvOS, watchOS, visionOS) via multi-select. Previous choices are recovered on re-run from `sessionDefaults.platform`, `sessionDefaults.simulatorPlatform`, or the existing workflow set via `inferPlatformsFromExisting`.

**`PLATFORM_WORKFLOWS` mapping** — each platform maps to its recommended workflow set. The workflow selection prompt is pre-seeded with the union of recommended workflows for all selected platforms. Users can still freely adjust.

**macOS-only guard** — when macOS is the only selected platform, both the simulator selection prompt and the device selection prompt are skipped entirely (`isMacOsOnly` guard in `collectSetupSelection`). Stale `simulatorId`, `simulatorName`, and `deviceId` session defaults are cleaned up from config on save.

**`platform` session default** — for single-platform selections, `derivePlatformSessionDefault` writes `platform` to `sessionDefaults` in `config.yaml`. For multi-platform the key is omitted and any existing `platform` value is deleted.

**`--format mcp-json` includes `XCODEBUILDMCP_PLATFORM`** — when a single platform is selected, `XCODEBUILDMCP_PLATFORM` is included in the output env block.

### Changes

- `src/cli/commands/setup.ts` — platform selection, `PLATFORM_WORKFLOWS`, `inferPlatformsFromExisting`, `filterSimulatorsByPlatforms`, `derivePlatformSessionDefault`, macOS-only guards, mcp-json platform output
- `src/cli/commands/__tests__/setup.test.ts` — tests for macOS-only skip, platform env var in mcp-json output, multi-platform handling, platform inference from existing config
- `CHANGELOG.md` — new entries under `[Unreleased]`
