### PR TITLE
Fix build_device next step suggesting unsupported --device-id flag

### DIFF
--- a/src/mcp/tools/device/__tests__/list_devices.test.ts
+++ b/src/mcp/tools/device/__tests__/list_devices.test.ts
@@ -217,7 +217,7 @@ describe('list_devices plugin (device-shared)', () => {
       expect(text).toContain('Test iPhone');
       expect(text).toContain('test-device-123');
       expect(result.nextStepParams).toEqual({
-        build_device: { scheme: 'YOUR_SCHEME', deviceId: 'UUID_FROM_ABOVE' },
+        build_device: { scheme: 'YOUR_SCHEME' },
         install_app_device: { deviceId: 'UUID_FROM_ABOVE', appPath: 'PATH_TO_APP' },
       });
     });

--- a/src/mcp/tools/device/list_devices.ts
+++ b/src/mcp/tools/device/list_devices.ts
@@ -18,7 +18,7 @@ type ListDevicesParams = z.infer<typeof listDevicesSchema>;
 type ListDevicesResult = DeviceListDomainResult;
 
 const NEXT_STEP_PARAMS = {
-  build_device: { scheme: 'YOUR_SCHEME', deviceId: 'UUID_FROM_ABOVE' },
+  build_device: { scheme: 'YOUR_SCHEME' },
   install_app_device: { deviceId: 'UUID_FROM_ABOVE', appPath: 'PATH_TO_APP' },
 } as const;
 


### PR DESCRIPTION
## Summary

Fixes #287

The `list_devices` tool included `deviceId` in `nextStepParams` for `build_device`, but `build_device` does not accept a `deviceId` parameter -- it builds generically for the iOS device platform without targeting a specific device.

This caused the CLI to render an invalid suggestion:
```
xcodebuildmcp device build --scheme "SCHEME" --device-id "DEVICE_UDID"
```

Running this command would fail because `build` does not recognize `--device-id`.

### Changes

- Removed `deviceId` from `build_device` entry in `nextStepParams` within `list_devices.ts`
- Updated corresponding test assertion in `list_devices.test.ts`
- `build_run_device` and `test_device` entries correctly retain `deviceId` since those tools require it

## Test plan

- [x] All 104 device tool tests pass
- [x] Next-steps-renderer tests pass
- [x] Pre-commit hooks (format, lint, build, tests) pass