### PR TITLE
fix(sentry): Exclude peer anomalies from shutdown summary level escalation

### DIFF
--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -402,7 +402,10 @@ export function captureMcpShutdownSummary(summary: McpShutdownSummaryEvent): voi
 
   try {
     const snapshotAnomalies = (summary.snapshot as { anomalies?: unknown }).anomalies;
-    const anomalyCount = Array.isArray(snapshotAnomalies) ? snapshotAnomalies.length : 0;
+    const PEER_ANOMALIES: ReadonlySet<string> = new Set(['peer-count-high', 'peer-age-high']);
+    const localAnomalyCount = Array.isArray(snapshotAnomalies)
+      ? snapshotAnomalies.filter((a) => typeof a === 'string' && !PEER_ANOMALIES.has(a)).length
+      : 0;
 
     const isCrashReason =
       summary.reason === 'startup-failure' ||
@@ -412,7 +415,7 @@ export function captureMcpShutdownSummary(summary: McpShutdownSummaryEvent): voi
     let level: 'error' | 'warning' | 'info';
     if (isCrashReason) {
       level = 'error';
-    } else if (summary.cleanupFailureCount > 0 || anomalyCount > 0) {
+    } else if (summary.cleanupFailureCount > 0 || localAnomalyCount > 0) {
       level = 'warning';
     } else {
       level = 'info';


### PR DESCRIPTION
Exclude peer anomalies (`peer-count-high`, `peer-age-high`) from the level
escalation logic in `captureMcpShutdownSummary`. These are environmental
observations common in multi-client setups (multiple MCP hosts connecting
simultaneously), not indicators of a problem with the shutting-down process
itself.

Previously, any anomaly elevated the shutdown summary event to `warning`
level. With `PEER_COUNT_HIGH_THRESHOLD = 2` and multiple MCP clients being
standard, nearly every `stdin-end` shutdown was emitted as a warning --
generating ~484k Sentry events on XCODEBUILDMCP-Z since March 16.

Now only process-local anomalies (`high-rss`, `long-lived-high-rss`) and
cleanup failures escalate to `warning`. Normal shutdowns with only peer
anomalies emit at `info` level. Peer anomaly data is still:
- Present in the event snapshot extra data
- Tracked independently via `recordMcpLifecycleAnomalyMetric`

Fixes XCODEBUILDMCP-Z