### PR TITLE
docs: add build, architecture, and convention sections to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,9 @@ ESM TypeScript project (`type: module`). Key layers:
    ```
 4. Update `CHANGELOG.md` under `## [Unreleased]`
 5. Update documentation if adding or modifying features
-6. Push and create a pull request with a clear description
-7. Link any related issues
+6. Clone and test against example projects (e.g., `XcodeBuildMCP-iOS-Template`) when changes affect runtime behavior
+7. Push and create a pull request with a clear description
+8. Link any related issues
 
 ## Code Quality
 - No `any` types unless absolutely necessary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,47 @@
 # Development Rules
 
+## Build & Test
+- `npm run build` - Build (wireit + tsup, ESM)
+- `npm run test` - Unit/integration tests (Vitest)
+- `npm run test:smoke` - Smoke tests (builds first, serial execution)
+- `npm run lint` / `npm run lint:fix` - ESLint
+- `npm run format` / `npm run format:check` - Prettier
+- `npm run typecheck` - TypeScript type checking (`tsc --noEmit`, plus test config)
+- `npm run docs:check` - Validate docs match CLI surface
+
+## Architecture
+ESM TypeScript project (`type: module`). Key layers:
+
+- `src/cli/` - CLI entrypoint, yargs wiring, daemon routing
+- `src/server/` - MCP stdio server, lifecycle, workflow/resource registration
+- `src/runtime/` - Config bootstrap, session state, tool catalog assembly
+- `src/core/manifest/` - YAML manifest loading, validation, tool module imports
+- `src/mcp/tools/` - Tool implementations grouped by workflow (mirrors `manifests/workflows/`)
+- `src/mcp/resources/` - MCP resource implementations
+- `src/integrations/` - External integrations (Xcode mcpbridge proxy)
+- `src/utils/` - Shared helpers (execution, logging, validation, responses)
+- `src/visibility/` - Tool/workflow exposure predicates
+- `src/daemon/` - Background daemon for persistent sessions
+- `src/rendering/` - Output rendering and formatting
+- `src/types/` - Shared type definitions
+
+## Contributing Workflow
+1. Create a branch from `main`
+2. Make changes following the conventions in this file
+3. Run the pre-commit checklist before committing:
+   ```bash
+   npm run lint:fix
+   npm run typecheck
+   npm run format
+   npm run build
+   npm run docs:check
+   npm test
+   ```
+4. Update `CHANGELOG.md` under `## [Unreleased]`
+5. Update documentation if adding or modifying features
+6. Push and create a pull request with a clear description
+7. Link any related issues
+
 ## Code Quality
 - No `any` types unless absolutely necessary
 - Check node_modules for external API type definitions instead of guessing
@@ -7,6 +49,24 @@
 - NEVER remove or downgrade code to fix type errors from outdated dependencies; upgrade the dependency instead
 - Always ask before removing functionality or code that appears to be intentional
 - Follow TypeScript best practices
+
+## Import Conventions
+- ESM with explicit `.ts` extensions in `src/` (tsup rewrites to `.js` at build)
+- No `.js` imports in `src/` (enforced by ESLint)
+- No barrel imports from `utils/index` - import from specific submodules (e.g., `src/utils/execution/index.ts`, `src/utils/logging/index.ts`)
+
+## Test Conventions
+- Vitest with colocated `__tests__/` directories using `*.test.ts`
+- Smoke tests in `src/smoke-tests/__tests__/` (separate Vitest config, serial execution)
+- Use `vi.mock`/`vi.hoisted` for isolation; inject executors and mock file systems
+- MCP integration tests use `McpServer`, `InMemoryTransport`, and `Client`
+- External dependencies (command execution, file system) must use dependency injection via `createMockExecutor()` / `createMockFileSystemExecutor()` from `src/test-utils/`
+
+## Tool Development
+- Tool manifests in `manifests/tools/*.yaml` define `id`, `module`, `names.mcp` (snake_case), optional `names.cli` (kebab-case), predicates, and annotations
+- Workflow manifests in `manifests/workflows/*.yaml` group tools and define exposure rules
+- Tool modules export a Zod schema, a pure `*Logic` function, and a `handler` via `createTypedTool` or `createSessionAwareTool`
+- Resources export `{ uri, name, description, mimeType, handler }`
 
 ## Commands
 - NEVER commit unless user asks
@@ -48,8 +108,8 @@ Use these sections under `## [Unreleased]`:
 - NEVER update snapshot fixtures unless asked to do so, these are integration tests, on failure assume code is wrong before questioning the fixture
 -
 #### Attribution
-- **Internal changes (from issues)**: `Fixed foo bar ([#123](https://github.com/cameroncook/XcodeBuildMCP/issues/123))`
-- **External contributions**: `Added feature X ([#456](https://github.com/cameroncook/XcodeBuildMCP/pull/456) by [@username](https://github.com/username))`
+- **Internal changes (from issues)**: `Fixed foo bar ([#123](https://github.com/getsentry/XcodeBuildMCP/issues/123))`
+- **External contributions**: `Added feature X ([#456](https://github.com/getsentry/XcodeBuildMCP/pull/456) by [@username](https://github.com/username))`
 
 ## Test Execution Rules
 - When running long test suites (snapshot tests, smoke tests), ALWAYS write full output to a log file and read it afterwards. NEVER pipe through `tail` or `grep` directly — that loses output you may need to debug failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - `npm run test:smoke` - Smoke tests (builds first, serial execution)
 - `npm run lint` / `npm run lint:fix` - ESLint
 - `npm run format` / `npm run format:check` - Prettier
-- `npm run typecheck` - TypeScript type checking (`tsc --noEmit`, plus test config)
+- `npm run typecheck` - TypeScript type checking (src + test config)
 - `npm run docs:check` - Validate docs match CLI surface
 
 ## Architecture
@@ -18,7 +18,7 @@ ESM TypeScript project (`type: module`). Key layers:
 - `src/core/manifest/` - YAML manifest loading, validation, tool module imports
 - `src/mcp/tools/` - Tool implementations grouped by workflow (mirrors `manifests/workflows/`)
 - `src/mcp/resources/` - MCP resource implementations
-- `src/integrations/` - External integrations (Xcode mcpbridge proxy)
+- `src/integrations/` - External integrations (Xcode tools bridge)
 - `src/utils/` - Shared helpers (execution, logging, validation, responses)
 - `src/visibility/` - Tool/workflow exposure predicates
 - `src/daemon/` - Background daemon for persistent sessions
@@ -66,8 +66,8 @@ ESM TypeScript project (`type: module`). Key layers:
 ## Tool Development
 - Tool manifests in `manifests/tools/*.yaml` define `id`, `module`, `names.mcp` (snake_case), optional `names.cli` (kebab-case), predicates, and annotations
 - Workflow manifests in `manifests/workflows/*.yaml` group tools and define exposure rules
-- Tool modules export a Zod schema, a pure `*Logic` function, and a `handler` via `createTypedTool` or `createSessionAwareTool`
-- Resources export `{ uri, name, description, mimeType, handler }`
+- Tool modules export a Zod `schema`, a pure `*Logic` function, and a `handler` built with `createTypedTool` or `createSessionAwareTool`
+- Resource modules export a `handler` (and a pure `*Logic` function); `uri`, `name`, `description`, and `mimeType` are declared in `manifests/resources/*.yaml`
 
 ## Commands
 - NEVER commit unless user asks


### PR DESCRIPTION
Syncs AGENTS.md with CLAUDE.md by adding sections that were already present in CLAUDE.md but missing from AGENTS.md.

## Added sections

- **Build & Test** - all npm scripts agents need to run (`build`, `test`, `lint`, `typecheck`, `docs:update`, etc.)
- **Architecture** - component map of `src/` layers with one-line descriptions
- **Developer Documentation** - links to all `docs/dev/` guides (contributing, architecture, testing, manifests, release, code quality)
- **Contributing Workflow** - step-by-step instructions including the pre-commit checklist
- **Import Conventions** - ESM, `.ts` extensions in `src/`, no barrel imports
- **Test Conventions** - Vitest patterns, colocated tests, smoke tests, dependency injection requirements
- **Tool Development** - manifest-driven tool registration, handler shape, resource exports

## Why

AI agents reading AGENTS.md (Copilot, Windsurf, Cursor, etc.) were missing build commands, architecture context, contributing workflows, and convention details that were already documented in CLAUDE.md. This caused agents to guess at import styles, test patterns, and project structure rather than following established conventions. The contributing workflow and dev doc links are critical for agents to know the full PR preparation process.

## Other changes

- Clean up stray trailing hyphens on empty lines between sections