### PR TITLE
feat(events): emit per-test timing in test results

### DIFF
--- a/src/mcp/tools/session-management/session_set_defaults.ts
+++ b/src/mcp/tools/session-management/session_set_defaults.ts
@@ -58,6 +58,7 @@ const PARAM_LABEL_MAP: Record<string, string> = {
   useLatestOS: 'Use Latest OS',
   arch: 'Architecture',
   suppressWarnings: 'Suppress Warnings',
+  showTestResults: 'Show Test Results',
   derivedDataPath: 'Derived Data Path',
   preferXcodebuild: 'Prefer xcodebuild',
   platform: 'Platform',

--- a/src/rendering/__tests__/text-render-parity.test.ts
+++ b/src/rendering/__tests__/text-render-parity.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PipelineEvent } from '../../types/pipeline-events.ts';
 import { renderEvents } from '../render.ts';
 import { createCliTextRenderer } from '../../utils/renderers/cli-text-renderer.ts';
+import { renderCliTextTranscript } from '../../utils/renderers/cli-text-renderer.ts';
 
 function captureCliText(events: readonly PipelineEvent[]): string {
   const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -167,5 +168,38 @@ describe('text render parity', () => {
     expect(output).toBe(captureCliText(events));
     expect(output).toContain('xcodebuildmcp macos get-app-path --scheme "MCPTest"');
     expect(output).not.toContain('get_mac_app_path({');
+  });
+
+  it('omits per-test results by default and includes them when showTestResults is true', () => {
+    const events: PipelineEvent[] = [
+      {
+        type: 'test-case-result',
+        timestamp: '2026-04-14T00:00:00.000Z',
+        operation: 'TEST',
+        suite: 'Suite',
+        test: 'testA',
+        status: 'passed',
+        durationMs: 100,
+      },
+      {
+        type: 'summary',
+        timestamp: '2026-04-14T00:00:01.000Z',
+        operation: 'TEST',
+        status: 'SUCCEEDED',
+        totalTests: 1,
+        passedTests: 1,
+        skippedTests: 0,
+        durationMs: 100,
+      },
+    ];
+
+    const withoutFlag = renderCliTextTranscript(events);
+    expect(withoutFlag).not.toContain('Test Results:');
+    expect(withoutFlag).toContain('1 test passed');
+
+    const withFlag = renderCliTextTranscript(events, { showTestResults: true });
+    expect(withFlag).toContain('Test Results:');
+    expect(withFlag).toContain('Suite/testA (0.100s)');
+    expect(withFlag).toContain('1 test passed');
   });
 });

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -66,7 +66,8 @@ function createTextRenderSession(): RenderSession {
 }
 
 function createCliTextRenderSession(options: { interactive: boolean }): RenderSession {
-  const renderer = createCliTextRenderer(options);
+  const showTestResults = sessionStore.get('showTestResults');
+  const renderer = createCliTextRenderer({ ...options, showTestResults: showTestResults ?? false });
 
   return createBaseRenderSession({
     onEmit: (event) => renderer.onEvent(event),

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -54,11 +54,13 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
 
 function createTextRenderSession(): RenderSession {
   const suppressWarnings = sessionStore.get('suppressWarnings');
+  const showTestResults = sessionStore.get('showTestResults');
 
   return createBaseRenderSession({
     finalize: (events) =>
       renderCliTextTranscript(events, {
         suppressWarnings: suppressWarnings ?? false,
+        showTestResults: showTestResults ?? false,
       }),
   });
 }

--- a/src/types/pipeline-events.ts
+++ b/src/types/pipeline-events.ts
@@ -127,6 +127,15 @@ export interface TestProgressEvent extends BaseEvent {
   skipped: number;
 }
 
+export interface TestCaseResultEvent extends BaseEvent {
+  type: 'test-case-result';
+  operation: 'TEST';
+  suite?: string;
+  test: string;
+  status: 'passed' | 'failed' | 'skipped';
+  durationMs?: number;
+}
+
 export interface TestFailureEvent extends BaseEvent {
   type: 'test-failure';
   operation: 'TEST';
@@ -158,6 +167,7 @@ export type BuildTestPipelineEvent =
   | CompilerErrorEvent
   | TestDiscoveryEvent
   | TestProgressEvent
+  | TestCaseResultEvent
   | TestFailureEvent;
 
 export type PipelineEvent = CommonPipelineEvent | BuildTestPipelineEvent;

--- a/src/utils/__tests__/xcodebuild-event-parser.test.ts
+++ b/src/utils/__tests__/xcodebuild-event-parser.test.ts
@@ -304,4 +304,34 @@ describe('xcodebuild-event-parser', () => {
     const statusEvents = events.filter((e) => e.type === 'build-stage');
     expect(statusEvents.length).toBeLessThanOrEqual(1);
   });
+
+  it('emits test-case-result events with per-test timing for all statuses', () => {
+    const events = collectEvents('TEST', [
+      { source: 'stdout', text: "Test Case '-[Suite testA]' passed (0.001 seconds)\n" },
+      { source: 'stdout', text: "Test Case '-[Suite testB]' failed (0.002 seconds)\n" },
+      { source: 'stdout', text: "Test Case '-[Suite testC]' skipped (0.000 seconds)\n" },
+    ]);
+
+    const results = events.filter((e) => e.type === 'test-case-result');
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({
+      type: 'test-case-result',
+      operation: 'TEST',
+      suite: 'Suite',
+      test: 'testA',
+      status: 'passed',
+      durationMs: 1,
+    });
+    expect(results[1]).toMatchObject({ test: 'testB', status: 'failed', durationMs: 2 });
+    expect(results[2]).toMatchObject({ test: 'testC', status: 'skipped', durationMs: 0 });
+  });
+
+  it('does not emit test-case-result for BUILD operations', () => {
+    const events = collectEvents('BUILD', [
+      { source: 'stdout', text: "Test Case '-[Suite testA]' passed (0.001 seconds)\n" },
+    ]);
+
+    const results = events.filter((e) => e.type === 'test-case-result');
+    expect(results).toHaveLength(0);
+  });
 });

--- a/src/utils/__tests__/xcodebuild-run-state.test.ts
+++ b/src/utils/__tests__/xcodebuild-run-state.test.ts
@@ -404,4 +404,32 @@ describe('xcodebuild-run-state', () => {
     expect(forwarded[0].type).toBe('header');
     expect(forwarded[1].type).toBe('next-steps');
   });
+
+  it('collects test-case-result events', () => {
+    const state = createXcodebuildRunState({ operation: 'TEST' });
+
+    state.push({
+      type: 'test-case-result',
+      timestamp: ts(),
+      operation: 'TEST',
+      suite: 'Suite',
+      test: 'testA',
+      status: 'passed',
+      durationMs: 100,
+    });
+    state.push({
+      type: 'test-case-result',
+      timestamp: ts(),
+      operation: 'TEST',
+      suite: 'Suite',
+      test: 'testB',
+      status: 'failed',
+      durationMs: 200,
+    });
+
+    const snap = state.snapshot();
+    expect(snap.testCaseResults).toHaveLength(2);
+    expect(snap.testCaseResults[0]).toMatchObject({ test: 'testA', status: 'passed' });
+    expect(snap.testCaseResults[1]).toMatchObject({ test: 'testB', status: 'failed' });
+  });
 });

--- a/src/utils/config-store.ts
+++ b/src/utils/config-store.ts
@@ -265,6 +265,7 @@ function readEnvSessionDefaults(env: NodeJS.ProcessEnv): Partial<SessionDefaults
   setString('bundleId', env.XCODEBUILDMCP_BUNDLE_ID);
   setBool('useLatestOS', env.XCODEBUILDMCP_USE_LATEST_OS);
   setBool('suppressWarnings', env.XCODEBUILDMCP_SUPPRESS_WARNINGS);
+  setBool('showTestResults', env.XCODEBUILDMCP_SHOW_TEST_RESULTS);
   setBool('preferXcodebuild', env.XCODEBUILDMCP_PREFER_XCODEBUILD);
 
   const simulatorPlatform = env.XCODEBUILDMCP_SIMULATOR_PLATFORM;

--- a/src/utils/renderers/__tests__/event-formatting.test.ts
+++ b/src/utils/renderers/__tests__/event-formatting.test.ts
@@ -12,6 +12,7 @@ import {
   formatStatusLineEvent,
   formatDetailTreeEvent,
   formatTransientStatusLineEvent,
+  formatTestCaseResults,
 } from '../event-formatting.ts';
 
 describe('event formatting', () => {
@@ -276,5 +277,35 @@ describe('event formatting', () => {
     expect(rendered).toContain('  ✗ testAdd:');
     expect(rendered).toContain('      - XCTAssertEqual failed');
     expect(rendered).toContain('      - Expected 4, got 5');
+  });
+
+  it('formats per-test case results with status icons and durations', () => {
+    const rendered = formatTestCaseResults([
+      {
+        type: 'test-case-result',
+        timestamp: '',
+        operation: 'TEST',
+        suite: 'MathTests',
+        test: 'testAdd',
+        status: 'passed',
+        durationMs: 1234,
+      },
+      {
+        type: 'test-case-result',
+        timestamp: '',
+        operation: 'TEST',
+        test: 'testOrphan',
+        status: 'skipped',
+      },
+    ]);
+
+    expect(rendered).toContain('Test Results:');
+    expect(rendered).toContain('\u{2705} MathTests/testAdd (1.234s)');
+    expect(rendered).toContain('\u{23ED}\u{FE0F} testOrphan');
+    expect(rendered).not.toContain('testOrphan (');
+  });
+
+  it('returns empty string for no test case results', () => {
+    expect(formatTestCaseResults([])).toBe('');
   });
 });

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -194,7 +194,9 @@ function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRende
         }
 
         case 'test-case-result': {
-          collectedTestCaseResults.push(event);
+          if (showTestResults) {
+            collectedTestCaseResults.push(event);
+          }
           break;
         }
 

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -47,15 +47,17 @@ interface CliTextProcessorOptions {
   interactive: boolean;
   sink: CliTextSink;
   suppressWarnings: boolean;
+  showTestResults: boolean;
 }
 
 interface CliTextRendererOptions {
   interactive: boolean;
   suppressWarnings?: boolean;
+  showTestResults?: boolean;
 }
 
 function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRenderer {
-  const { interactive, sink, suppressWarnings } = options;
+  const { interactive, sink, suppressWarnings, showTestResults } = options;
   const groupedCompilerErrors: CompilerErrorEvent[] = [];
   const groupedWarnings: CompilerWarningEvent[] = [];
   const groupedTestFailures: TestFailureEvent[] = [];
@@ -229,7 +231,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRende
             flushPendingTransientRuntimeLine();
           }
 
-          if (collectedTestCaseResults.length > 0) {
+          if (showTestResults && collectedTestCaseResults.length > 0) {
             const testResultsBlock = formatTestCaseResults(collectedTestCaseResults);
             if (testResultsBlock) {
               writeSection(testResultsBlock);
@@ -271,6 +273,7 @@ export function createCliTextRenderer(options: CliTextRendererOptions): Pipeline
   return createCliTextProcessor({
     interactive: options.interactive,
     suppressWarnings: options.suppressWarnings ?? false,
+    showTestResults: options.showTestResults ?? false,
     sink: {
       clearTransient(): void {
         reporter.clear();
@@ -290,12 +293,13 @@ export function createCliTextRenderer(options: CliTextRendererOptions): Pipeline
 
 export function renderCliTextTranscript(
   events: readonly PipelineEvent[],
-  options: { suppressWarnings?: boolean } = {},
+  options: { suppressWarnings?: boolean; showTestResults?: boolean } = {},
 ): string {
   let output = '';
   const renderer = createCliTextProcessor({
     interactive: false,
     suppressWarnings: options.suppressWarnings ?? false,
+    showTestResults: options.showTestResults ?? false,
     sink: {
       clearTransient(): void {},
       updateTransient(): void {},

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -3,6 +3,7 @@ import type {
   CompilerWarningEvent,
   PipelineEvent,
   StatusLineEvent,
+  TestCaseResultEvent,
   TestFailureEvent,
 } from '../../types/pipeline-events.ts';
 import { createCliProgressReporter } from '../cli-progress-reporter.ts';
@@ -25,6 +26,7 @@ import {
   formatSummaryEvent,
   formatNextStepsEvent,
   formatTestDiscoveryEvent,
+  formatTestCaseResults,
 } from './event-formatting.ts';
 
 function formatCliTextBlock(text: string): string {
@@ -57,6 +59,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRende
   const groupedCompilerErrors: CompilerErrorEvent[] = [];
   const groupedWarnings: CompilerWarningEvent[] = [];
   const groupedTestFailures: TestFailureEvent[] = [];
+  const collectedTestCaseResults: TestCaseResultEvent[] = [];
   let pendingTransientRuntimeLine: string | null = null;
   let diagnosticBaseDir: string | null = null;
   let hasDurableRuntimeContent = false;
@@ -188,6 +191,11 @@ function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRende
           break;
         }
 
+        case 'test-case-result': {
+          collectedTestCaseResults.push(event);
+          break;
+        }
+
         case 'summary': {
           const diagOpts = { baseDir: diagnosticBaseDir ?? undefined };
           const diagnosticSections: string[] = [];
@@ -219,6 +227,14 @@ function createCliTextProcessor(options: CliTextProcessorOptions): PipelineRende
             }
           } else if (event.status === 'FAILED') {
             flushPendingTransientRuntimeLine();
+          }
+
+          if (collectedTestCaseResults.length > 0) {
+            const testResultsBlock = formatTestCaseResults(collectedTestCaseResults);
+            if (testResultsBlock) {
+              writeSection(testResultsBlock);
+            }
+            collectedTestCaseResults.length = 0;
           }
 
           writeSection(formatSummaryEvent(event));

--- a/src/utils/renderers/event-formatting.ts
+++ b/src/utils/renderers/event-formatting.ts
@@ -12,6 +12,7 @@ import type {
   FileRefEvent,
   DetailTreeEvent,
   SummaryEvent,
+  TestCaseResultEvent,
   TestDiscoveryEvent,
   TestFailureEvent,
   NextStepsEvent,
@@ -591,5 +592,26 @@ export function formatGroupedTestFailures(
     }
   }
 
+  return lines.join('\n');
+}
+
+export function formatTestCaseResults(results: TestCaseResultEvent[]): string {
+  if (results.length === 0) {
+    return '';
+  }
+
+  const statusIcon: Record<string, string> = {
+    passed: '\u{2705}',
+    failed: '\u{274C}',
+    skipped: '\u{23ED}\u{FE0F}',
+  };
+
+  const lines: string[] = ['Test Results:'];
+  for (const r of results) {
+    const icon = statusIcon[r.status] ?? '?';
+    const duration = r.durationMs !== undefined ? ` (${(r.durationMs / 1000).toFixed(3)}s)` : '';
+    const name = r.suite ? `${r.suite}/${r.test}` : r.test;
+    lines.push(`  ${icon} ${name}${duration}`);
+  }
   return lines.join('\n');
 }

--- a/src/utils/session-defaults-schema.ts
+++ b/src/utils/session-defaults-schema.ts
@@ -14,6 +14,7 @@ export const sessionDefaultKeys = [
   'useLatestOS',
   'arch',
   'suppressWarnings',
+  'showTestResults',
   'derivedDataPath',
   'preferXcodebuild',
   'platform',
@@ -40,6 +41,10 @@ export const sessionDefaultsSchema = z.object({
   useLatestOS: z.boolean().optional(),
   arch: z.enum(['arm64', 'x86_64']).optional(),
   suppressWarnings: z.boolean().optional(),
+  showTestResults: z
+    .boolean()
+    .optional()
+    .describe('Show per-test timing breakdown in test output.'),
   derivedDataPath: nonEmptyString
     .optional()
     .describe('Default DerivedData path for Xcode build/test/clean tools.'),

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -16,6 +16,7 @@ export type SessionDefaults = {
   useLatestOS?: boolean;
   arch?: 'arm64' | 'x86_64';
   suppressWarnings?: boolean;
+  showTestResults?: boolean;
   derivedDataPath?: string;
   preferXcodebuild?: boolean;
   platform?: string;

--- a/src/utils/swift-testing-event-parser.ts
+++ b/src/utils/swift-testing-event-parser.ts
@@ -71,6 +71,26 @@ export function createSwiftTestingEventParser(
     });
   }
 
+  function emitTestCaseResult(testCase: {
+    suiteName?: string;
+    testName?: string;
+    status: string;
+    durationText?: string;
+  }): void {
+    if (!testCase.testName) {
+      return;
+    }
+    onEvent({
+      type: 'test-case-result',
+      timestamp: now(),
+      operation: 'TEST',
+      suite: testCase.suiteName,
+      test: testCase.testName,
+      status: testCase.status as 'passed' | 'failed' | 'skipped',
+      durationMs: parseDurationMs(testCase.durationText),
+    });
+  }
+
   function processLine(rawLine: string): void {
     const line = rawLine.trim();
     if (!line) {
@@ -103,6 +123,7 @@ export function createSwiftTestingEventParser(
       const increment = stResult.caseCount ?? 1;
       completedCount += increment;
       failedCount += increment;
+      emitTestCaseResult(stResult);
       emitTestProgress();
       return;
     }
@@ -131,6 +152,7 @@ export function createSwiftTestingEventParser(
       if (stResult.status === 'skipped') {
         skippedCount += increment;
       }
+      emitTestCaseResult(stResult);
       emitTestProgress();
       return;
     }
@@ -155,6 +177,7 @@ export function createSwiftTestingEventParser(
       if (xcTestCase.status === 'skipped') {
         skippedCount += xcIncrement;
       }
+      emitTestCaseResult(xcTestCase);
       emitTestProgress();
       return;
     }

--- a/src/utils/xcodebuild-event-parser.ts
+++ b/src/utils/xcodebuild-event-parser.ts
@@ -247,6 +247,17 @@ export function createXcodebuildEventParser(options: EventParserOptions): Xcodeb
     if (testCase.status === 'skipped') {
       skippedCount += increment;
     }
+    if (operation === 'TEST' && testCase.testName) {
+      onEvent({
+        type: 'test-case-result',
+        timestamp: now(),
+        operation: 'TEST',
+        suite: testCase.suiteName,
+        test: testCase.testName,
+        status: testCase.status as 'passed' | 'failed' | 'skipped',
+        durationMs: parseDurationMs(testCase.durationText),
+      });
+    }
     emitTestProgress();
   }
 

--- a/src/utils/xcodebuild-run-state.ts
+++ b/src/utils/xcodebuild-run-state.ts
@@ -5,6 +5,7 @@ import type {
   BuildStageEvent,
   CompilerWarningEvent,
   CompilerErrorEvent,
+  TestCaseResultEvent,
   TestFailureEvent,
 } from '../types/pipeline-events.ts';
 import { STAGE_RANK } from '../types/pipeline-events.ts';
@@ -15,6 +16,7 @@ export interface XcodebuildRunState {
   milestones: BuildStageEvent[];
   warnings: CompilerWarningEvent[];
   errors: CompilerErrorEvent[];
+  testCaseResults: TestCaseResultEvent[];
   testFailures: TestFailureEvent[];
   completedTests: number;
   failedTests: number;
@@ -83,6 +85,7 @@ export function createXcodebuildRunState(options: RunStateOptions): XcodebuildRu
     milestones: [],
     warnings: [],
     errors: [],
+    testCaseResults: [],
     testFailures: [],
     completedTests: 0,
     failedTests: 0,
@@ -145,6 +148,12 @@ export function createXcodebuildRunState(options: RunStateOptions): XcodebuildRu
           }
           seenDiagnostics.add(key);
           state.testFailures.push(event);
+          accept(event);
+          break;
+        }
+
+        case 'test-case-result': {
+          state.testCaseResults.push(event);
           accept(event);
           break;
         }
@@ -235,6 +244,7 @@ export function createXcodebuildRunState(options: RunStateOptions): XcodebuildRu
         milestones: [...state.milestones],
         warnings: [...state.warnings],
         errors: [...state.errors],
+        testCaseResults: [...state.testCaseResults],
         testFailures: [...state.testFailures],
       };
     },
@@ -246,6 +256,7 @@ export function createXcodebuildRunState(options: RunStateOptions): XcodebuildRu
         milestones: [...state.milestones],
         warnings: [...state.warnings],
         errors: [...state.errors],
+        testCaseResults: [...state.testCaseResults],
         testFailures: [...state.testFailures],
       };
     },


### PR DESCRIPTION
Emit a `test-case-result` pipeline event for every individual test case (passed, failed, skipped) with its duration. Previously only `TestFailureEvent` carried per-test timing; passing and skipped tests were reduced to aggregate counters in `TestProgressEvent`, discarding the duration that xcodebuild already provides.

The new `TestCaseResultEvent` is emitted from both `xcodebuild-event-parser` and `swift-testing-event-parser`, collected in `XcodebuildRunState`, and rendered as a per-test timing breakdown before the summary line. The event carries `suite`, `test`, `status`, and `durationMs`.

Per-test output is opt-in via the `showTestResults` session default or `XCODEBUILDMCP_SHOW_TEST_RESULTS` env var. When disabled (the default), only the aggregate summary line is shown.

Example output when enabled:

```
Test Results:
  ✅ Suite/testA (0.001s)
  ❌ Suite/testB (0.002s)
  ⏭️ Suite/testC

✅ 2 tests passed, 1 skipped (⏱️ 3.2s)
```

All 1446 tests pass (6 new). Verified against a real iOS project (201 tests).