### PR TITLE
feat(session): auto-scope DerivedData per workspace/project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Changed
 
-- Auto-scope DerivedData per workspace/project path when no explicit `derivedDataPath` is configured. The session store now derives a hashed sub-directory under the global DerivedData root from the active workspace or project path, so concurrent agents and git worktrees no longer share a single explicit DerivedData and corrupt incremental builds. Explicit `derivedDataPath` still takes precedence ([#340](https://github.com/getsentry/XcodeBuildMCP/issues/340)).
+- Auto-scope DerivedData per workspace/project path at xcodebuild invocation time when no explicit `derivedDataPath` is configured. Session defaults remain raw, while build/test/app-path commands derive a stable hashed subdirectory under the global DerivedData root from the resolved workspace or project path. Explicit `derivedDataPath` still takes precedence ([#340](https://github.com/getsentry/XcodeBuildMCP/issues/340)).
 
 ## [2.3.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Expanded leading `~` and `~/` prefixes in configured `derivedDataPath`, `projectPath`, `workspacePath`, `axePath`, and the iOS/macOS template paths so values like `~/.foo/derivedData` resolve under the user's home directory instead of creating a literal `~` directory under the project root. As part of this change, configured absolute paths are now lexically normalized (e.g. `/a/b/../c` collapses to `/a/c`) before being passed to `xcodebuild` ([#283](https://github.com/getsentry/XcodeBuildMCP/issues/283), supersedes [#301](https://github.com/getsentry/XcodeBuildMCP/pull/301) by [@trmquang93](https://github.com/trmquang93)).
 
+### Changed
+
+- Auto-scope DerivedData per workspace/project path when no explicit `derivedDataPath` is configured. The session store now derives a hashed sub-directory under the global DerivedData root from the active workspace or project path, so concurrent agents and git worktrees no longer share a single explicit DerivedData and corrupt incremental builds. Explicit `derivedDataPath` still takes precedence ([#340](https://github.com/getsentry/XcodeBuildMCP/issues/340)).
+
 ## [2.3.2]
 
 ### Fixed

--- a/src/mcp/tools/device/__tests__/build_device.test.ts
+++ b/src/mcp/tools/device/__tests__/build_device.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import { createMockExecutor } from '../../../../test-utils/mock-executors.ts';
 import { expectPendingBuildResponse, runToolLogic } from '../../../../test-utils/test-helpers.ts';
@@ -172,7 +172,7 @@ describe('build_device plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         'build',
       ]);
       expect(spy.commandCalls[0].logPrefix).toBe('iOS Device Build');
@@ -206,7 +206,7 @@ describe('build_device plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcodeproj'),
         'build',
       ]);
       expect(spy.commandCalls[0].logPrefix).toBe('iOS Device Build');
@@ -263,6 +263,30 @@ describe('build_device plugin', () => {
 
       expect(result.isError()).toBeFalsy();
       expectPendingBuildResponse(result, 'get_device_app_path');
+    });
+
+    it('should include explicit derivedDataPath in get_device_app_path next step', async () => {
+      const mockExecutor = createMockExecutor({
+        success: true,
+        output: 'Build succeeded',
+      });
+
+      const { result } = await runToolLogic(() =>
+        buildDeviceLogic(
+          {
+            projectPath: '/path/to/MyProject.xcodeproj',
+            scheme: 'MyScheme',
+            derivedDataPath: '/tmp/derived-data',
+          },
+          mockExecutor,
+        ),
+      );
+
+      expect(result.isError()).toBeFalsy();
+      expect(result.nextStepParams?.get_device_app_path).toEqual({
+        scheme: 'MyScheme',
+        derivedDataPath: '/tmp/derived-data',
+      });
     });
 
     it('should return exact build failure response', async () => {

--- a/src/mcp/tools/device/__tests__/get_device_app_path.test.ts
+++ b/src/mcp/tools/device/__tests__/get_device_app_path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import {
   createMockCommandResponse,
@@ -134,7 +134,7 @@ describe('get_device_app_path plugin', () => {
           '-destination',
           'generic/platform=iOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         ],
         logPrefix: 'Get App Path',
         useShell: false,
@@ -193,7 +193,7 @@ describe('get_device_app_path plugin', () => {
           '-destination',
           'generic/platform=watchOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         ],
         logPrefix: 'Get App Path',
         useShell: false,
@@ -251,7 +251,7 @@ describe('get_device_app_path plugin', () => {
           '-destination',
           'generic/platform=iOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/workspace.xcworkspace'),
         ],
         logPrefix: 'Get App Path',
         useShell: false,
@@ -343,6 +343,60 @@ describe('get_device_app_path plugin', () => {
       expect(result.nextStepParams).toBeUndefined();
     });
 
+    it('should use explicit derivedDataPath when resolving build settings', async () => {
+      const calls: Array<{
+        args: string[];
+        logPrefix?: string;
+        useShell?: boolean;
+        opts?: { cwd?: string };
+      }> = [];
+
+      const mockExecutor = (
+        args: string[],
+        logPrefix?: string,
+        useShell?: boolean,
+        opts?: { cwd?: string },
+        _detached?: boolean,
+      ) => {
+        calls.push({ args, logPrefix, useShell, opts });
+        return Promise.resolve(
+          createMockCommandResponse({
+            success: true,
+            output:
+              'Build settings for scheme "MyScheme"\n\nBUILT_PRODUCTS_DIR = /path/to/build/Debug-iphoneos\nFULL_PRODUCT_NAME = MyApp.app\n',
+            error: undefined,
+          }),
+        );
+      };
+
+      await runLogic(() =>
+        get_device_app_pathLogic(
+          {
+            projectPath: '/path/to/project.xcodeproj',
+            scheme: 'MyScheme',
+            derivedDataPath: '/custom/DerivedData',
+          },
+          mockExecutor,
+        ),
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args).toEqual([
+        'xcodebuild',
+        '-showBuildSettings',
+        '-project',
+        '/path/to/project.xcodeproj',
+        '-scheme',
+        'MyScheme',
+        '-configuration',
+        'Debug',
+        '-destination',
+        'generic/platform=iOS',
+        '-derivedDataPath',
+        '/custom/DerivedData',
+      ]);
+    });
+
     it('should include optional configuration parameter in command', async () => {
       const calls: Array<{
         args: string[];
@@ -394,7 +448,7 @@ describe('get_device_app_path plugin', () => {
           '-destination',
           'generic/platform=iOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         ],
         logPrefix: 'Get App Path',
         useShell: false,

--- a/src/mcp/tools/device/__tests__/test_device.test.ts
+++ b/src/mcp/tools/device/__tests__/test_device.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as z from 'zod';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import {
   createMockExecutor,
   createMockFileSystemExecutor,
@@ -166,7 +166,7 @@ describe('test_device plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         'test',
       ]);
     });

--- a/src/mcp/tools/device/build_device.ts
+++ b/src/mcp/tools/device/build_device.ts
@@ -27,6 +27,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 function createBuildDeviceRequest(params: BuildDeviceParams): BuildInvocationRequest {
@@ -34,6 +35,7 @@ function createBuildDeviceRequest(params: BuildDeviceParams): BuildInvocationReq
     scheme: params.scheme,
     workspacePath: params.workspacePath,
     projectPath: params.projectPath,
+    derivedDataPath: resolveEffectiveDerivedDataPath(params),
     configuration: params.configuration ?? 'Debug',
     platform: String(mapDevicePlatform(params.platform)),
     target: 'device',
@@ -123,6 +125,9 @@ export async function buildDeviceLogic(
     ctx.nextStepParams = {
       get_device_app_path: {
         scheme: params.scheme,
+        ...(params.derivedDataPath !== undefined
+          ? { derivedDataPath: params.derivedDataPath }
+          : {}),
       },
     };
   }

--- a/src/mcp/tools/device/build_run_device.ts
+++ b/src/mcp/tools/device/build_run_device.ts
@@ -34,6 +34,7 @@ import {
   createDomainStreamingPipeline,
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 function createBuildRunDeviceRequest(params: BuildRunDeviceParams): BuildInvocationRequest {
@@ -41,6 +42,7 @@ function createBuildRunDeviceRequest(params: BuildRunDeviceParams): BuildInvocat
     scheme: params.scheme,
     workspacePath: params.workspacePath,
     projectPath: params.projectPath,
+    derivedDataPath: resolveEffectiveDerivedDataPath(params),
     configuration: params.configuration ?? 'Debug',
     platform: String(mapDevicePlatform(params.platform)),
     deviceId: params.deviceId,

--- a/src/mcp/tools/device/get_device_app_path.ts
+++ b/src/mcp/tools/device/get_device_app_path.ts
@@ -32,6 +32,7 @@ import {
 const baseOptions = {
   scheme: z.string().describe('The scheme to use'),
   configuration: z.string().optional().describe('Build configuration (Debug, Release, etc.)'),
+  derivedDataPath: z.string().optional(),
   platform: devicePlatformSchema,
 };
 
@@ -53,6 +54,7 @@ const publicSchemaObject = baseSchemaObject.omit({
   workspacePath: true,
   scheme: true,
   configuration: true,
+  derivedDataPath: true,
 } as const);
 
 function createRequest(params: GetDeviceAppPathParams) {
@@ -82,6 +84,7 @@ export function createGetDeviceAppPathExecutor(
           scheme: params.scheme,
           configuration,
           platform,
+          derivedDataPath: params.derivedDataPath,
         },
         executor,
       );

--- a/src/mcp/tools/device/test_device.ts
+++ b/src/mcp/tools/device/test_device.ts
@@ -29,6 +29,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 const baseSchemaObject = z.object({
@@ -102,6 +103,9 @@ async function prepareTestDeviceExecution(
     preflight: preflight ?? undefined,
     invocationRequest: {
       scheme: params.scheme,
+      workspacePath: params.workspacePath,
+      projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration,
       platform: String(platform),
       deviceId: params.deviceId,

--- a/src/mcp/tools/macos/__tests__/build_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/build_macos.test.ts
@@ -142,6 +142,12 @@ describe('build_macos plugin', () => {
 
       expect(result.isError()).toBeFalsy();
       expectPendingBuildResponse(result, 'get_mac_app_path');
+      expect(result.nextStepParams).toEqual({
+        get_mac_app_path: {
+          scheme: 'MyScheme',
+          derivedDataPath: '/path/to/derived-data',
+        },
+      });
     });
 
     it('should return exact exception handling response', async () => {

--- a/src/mcp/tools/macos/__tests__/build_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/build_macos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import { createMockExecutor } from '../../../../test-utils/mock-executors.ts';
 import { expectPendingBuildResponse, runToolLogic } from '../../../../test-utils/test-helpers.ts';
@@ -205,7 +205,7 @@ describe('build_macos plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         'build',
       ]);
     });
@@ -303,7 +303,7 @@ describe('build_macos plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         'build',
       ]);
     });
@@ -333,7 +333,7 @@ describe('build_macos plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/Users/dev/My Project/MyProject.xcodeproj'),
         'build',
       ]);
     });
@@ -363,7 +363,7 @@ describe('build_macos plugin', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/workspace.xcworkspace'),
         'build',
       ]);
     });

--- a/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import { createMockExecutor, mockProcess } from '../../../../test-utils/mock-executors.ts';
 import { runToolLogic, type MockToolHandlerResult } from '../../../../test-utils/test-helpers.ts';
@@ -127,7 +127,7 @@ describe('build_run_macos', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         'build',
       ]);
       expect(executorCalls[0].description).toBe('macOS Build');
@@ -195,7 +195,7 @@ describe('build_run_macos', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/workspace.xcworkspace'),
         'build',
       ]);
 
@@ -398,7 +398,7 @@ describe('build_run_macos', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
         'build',
       ]);
       expect(executorCalls[0].description).toBe('macOS Build');

--- a/src/mcp/tools/macos/__tests__/get_mac_app_path.test.ts
+++ b/src/mcp/tools/macos/__tests__/get_mac_app_path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import {
   createMockCommandResponse,
@@ -131,7 +131,7 @@ describe('get_mac_app_path plugin', () => {
           '-destination',
           'generic/platform=macOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         ],
         'Get App Path',
         false,
@@ -173,7 +173,7 @@ describe('get_mac_app_path plugin', () => {
           '-destination',
           'generic/platform=macOS',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcodeproj'),
         ],
         'Get App Path',
         false,
@@ -217,7 +217,7 @@ describe('get_mac_app_path plugin', () => {
           '-destination',
           'platform=macOS,arch=arm64',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         ],
         'Get App Path',
         false,
@@ -261,7 +261,7 @@ describe('get_mac_app_path plugin', () => {
           '-destination',
           'platform=macOS,arch=x86_64',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         ],
         'Get App Path',
         false,
@@ -350,7 +350,7 @@ describe('get_mac_app_path plugin', () => {
           '-destination',
           'platform=macOS,arch=arm64',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         ],
         'Get App Path',
         false,

--- a/src/mcp/tools/macos/build_macos.ts
+++ b/src/mcp/tools/macos/build_macos.ts
@@ -22,6 +22,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 function createBuildMacOSRequest(params: BuildMacOSParams): BuildInvocationRequest {
@@ -29,6 +30,7 @@ function createBuildMacOSRequest(params: BuildMacOSParams): BuildInvocationReque
     scheme: params.scheme,
     workspacePath: params.workspacePath,
     projectPath: params.projectPath,
+    derivedDataPath: resolveEffectiveDerivedDataPath(params),
     configuration: params.configuration ?? 'Debug',
     platform: 'macOS',
     arch: params.arch,

--- a/src/mcp/tools/macos/build_macos.ts
+++ b/src/mcp/tools/macos/build_macos.ts
@@ -153,6 +153,9 @@ export async function buildMacOSLogic(
     ctx.nextStepParams = {
       get_mac_app_path: {
         scheme: params.scheme,
+        ...(params.derivedDataPath !== undefined
+          ? { derivedDataPath: params.derivedDataPath }
+          : {}),
       },
     };
   }

--- a/src/mcp/tools/macos/build_run_macos.ts
+++ b/src/mcp/tools/macos/build_run_macos.ts
@@ -23,6 +23,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 function createBuildRunMacOSRequest(params: BuildRunMacOSParams): BuildInvocationRequest {
@@ -30,6 +31,7 @@ function createBuildRunMacOSRequest(params: BuildRunMacOSParams): BuildInvocatio
     scheme: params.scheme,
     workspacePath: params.workspacePath,
     projectPath: params.projectPath,
+    derivedDataPath: resolveEffectiveDerivedDataPath(params),
     configuration: params.configuration ?? 'Debug',
     platform: 'macOS',
     arch: params.arch,

--- a/src/mcp/tools/macos/test_macos.ts
+++ b/src/mcp/tools/macos/test_macos.ts
@@ -28,6 +28,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 const baseSchemaObject = z.object({
@@ -92,6 +93,9 @@ async function prepareTestMacosExecution(
     preflight: preflight ?? undefined,
     invocationRequest: {
       scheme: params.scheme,
+      workspacePath: params.workspacePath,
+      projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration,
       platform: 'macOS',
       onlyTesting: preflight?.selectors.onlyTesting.map((selector) => selector.raw),

--- a/src/mcp/tools/session-management/__tests__/session_clear_defaults.test.ts
+++ b/src/mcp/tools/session-management/__tests__/session_clear_defaults.test.ts
@@ -44,8 +44,7 @@ describe('session-clear-defaults tool', () => {
       const current = sessionStore.getAll();
       expect(current.scheme).toBeUndefined();
       expect(current.deviceId).toBeUndefined();
-      // derivedDataPath is computed from projectPath when not explicitly set
-      expect(current.derivedDataPath).toContain('proj-');
+      expect(current.derivedDataPath).toBeUndefined();
       expect(current.projectPath).toBe('/path/to/proj.xcodeproj');
       expect(current.simulatorName).toBe('iPhone 17');
       expect(current.useLatestOS).toBe(true);

--- a/src/mcp/tools/session-management/__tests__/session_clear_defaults.test.ts
+++ b/src/mcp/tools/session-management/__tests__/session_clear_defaults.test.ts
@@ -44,7 +44,8 @@ describe('session-clear-defaults tool', () => {
       const current = sessionStore.getAll();
       expect(current.scheme).toBeUndefined();
       expect(current.deviceId).toBeUndefined();
-      expect(current.derivedDataPath).toBeUndefined();
+      // derivedDataPath is computed from projectPath when not explicitly set
+      expect(current.derivedDataPath).toContain('proj-');
       expect(current.projectPath).toBe('/path/to/proj.xcodeproj');
       expect(current.simulatorName).toBe('iPhone 17');
       expect(current.useLatestOS).toBe(true);

--- a/src/mcp/tools/simulator/__tests__/build_run_sim.test.ts
+++ b/src/mcp/tools/simulator/__tests__/build_run_sim.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
 import * as z from 'zod';
 import {
@@ -370,7 +371,7 @@ describe('build_run_sim tool', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         'build',
       ]);
       expect(callHistory[1].logPrefix).toBe('iOS Simulator Build');
@@ -429,7 +430,7 @@ describe('build_run_sim tool', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         'build',
       ]);
       expect(callHistory[1].logPrefix).toBe('iOS Simulator Build');
@@ -496,7 +497,7 @@ describe('build_run_sim tool', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         'build',
       ]);
       expect(callHistory[1].logPrefix).toBe('iOS Simulator Build');
@@ -512,7 +513,7 @@ describe('build_run_sim tool', () => {
         '-destination',
         'platform=iOS Simulator,name=iPhone 17',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
       ]);
       expect(callHistory[2].logPrefix).toBe('Get App Path');
     });
@@ -545,7 +546,7 @@ describe('build_run_sim tool', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/Users/dev/My Project/MyProject.xcworkspace'),
         'build',
       ]);
       expect(callHistory[1].logPrefix).toBe('iOS Simulator Build');
@@ -579,7 +580,7 @@ describe('build_run_sim tool', () => {
         '-collect-test-diagnostics',
         'never',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
         'build',
       ]);
       expect(callHistory[1].logPrefix).toBe('tvOS Simulator Build');

--- a/src/mcp/tools/simulator/__tests__/build_sim.test.ts
+++ b/src/mcp/tools/simulator/__tests__/build_sim.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import * as z from 'zod';
 import {
   createMockExecutor,
@@ -212,7 +212,7 @@ describe('build_sim tool', () => {
           '-collect-test-diagnostics',
           'never',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
           'build',
         ],
         'iOS Simulator Build',
@@ -247,7 +247,7 @@ describe('build_sim tool', () => {
           '-collect-test-diagnostics',
           'never',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcodeproj'),
           'build',
         ],
         'iOS Simulator Build',
@@ -322,7 +322,7 @@ describe('build_sim tool', () => {
           '-collect-test-diagnostics',
           'never',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/Users/dev/My Project/MyProject.xcworkspace'),
           'build',
         ],
         'iOS Simulator Build',
@@ -358,7 +358,7 @@ describe('build_sim tool', () => {
           '-collect-test-diagnostics',
           'never',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
           'build',
         ],
         'iOS Simulator Build',
@@ -393,7 +393,7 @@ describe('build_sim tool', () => {
           '-collect-test-diagnostics',
           'never',
           '-derivedDataPath',
-          DERIVED_DATA_DIR,
+          computeScopedDerivedDataPath('/path/to/MyProject.xcworkspace'),
           'build',
         ],
         'watchOS Simulator Build',
@@ -437,6 +437,9 @@ describe('build_sim tool', () => {
 
       expect(result.isError()).toBeFalsy();
       expectPendingBuildResponse(result, 'get_sim_app_path');
+      expect(result.nextStepParams?.get_sim_app_path).toMatchObject({
+        derivedDataPath: '/path/to/derived',
+      });
     });
 
     it('should handle build failure', async () => {

--- a/src/mcp/tools/simulator/__tests__/get_sim_app_path.test.ts
+++ b/src/mcp/tools/simulator/__tests__/get_sim_app_path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DERIVED_DATA_DIR } from '../../../../utils/log-paths.ts';
+import { computeScopedDerivedDataPath } from '../../../../utils/derived-data-path.ts';
 import { ChildProcess } from 'child_process';
 import * as z from 'zod';
 import { createMockExecutor } from '../../../../test-utils/mock-executors.ts';
@@ -161,7 +161,7 @@ describe('get_sim_app_path tool', () => {
         '-destination',
         'platform=iOS Simulator,name=iPhone 17,OS=latest',
         '-derivedDataPath',
-        DERIVED_DATA_DIR,
+        computeScopedDerivedDataPath('/path/to/workspace.xcworkspace'),
       ]);
 
       expect(result.isError).toBeFalsy();
@@ -169,6 +169,63 @@ describe('get_sim_app_path tool', () => {
       expect(text).toContain('Get App Path');
       expect(text).toContain('/tmp/DerivedData/Build/MyApp.app');
       expect(result.nextStepParams).toBeDefined();
+    });
+
+    it('should use explicit derivedDataPath when resolving build settings', async () => {
+      const callHistory: Array<{
+        command: string[];
+        logPrefix?: string;
+        useShell?: boolean;
+        opts?: unknown;
+      }> = [];
+
+      const trackingExecutor: CommandExecutor = async (
+        command,
+        logPrefix,
+        useShell,
+        opts,
+      ): Promise<{
+        success: boolean;
+        output: string;
+        process: ChildProcess;
+      }> => {
+        callHistory.push({ command, logPrefix, useShell, opts });
+        return {
+          success: true,
+          output:
+            '    BUILT_PRODUCTS_DIR = /tmp/DerivedData/Build\n    FULL_PRODUCT_NAME = MyApp.app\n',
+          process: { pid: 12345 } as unknown as ChildProcess,
+        };
+      };
+
+      await runLogic(() =>
+        get_sim_app_pathLogic(
+          {
+            workspacePath: '/path/to/workspace.xcworkspace',
+            scheme: 'MyScheme',
+            platform: XcodePlatform.iOSSimulator,
+            simulatorName: 'iPhone 17',
+            derivedDataPath: '/custom/DerivedData',
+          },
+          trackingExecutor,
+        ),
+      );
+
+      expect(callHistory).toHaveLength(1);
+      expect(callHistory[0].command).toEqual([
+        'xcodebuild',
+        '-showBuildSettings',
+        '-workspace',
+        '/path/to/workspace.xcworkspace',
+        '-scheme',
+        'MyScheme',
+        '-configuration',
+        'Debug',
+        '-destination',
+        'platform=iOS Simulator,name=iPhone 17,OS=latest',
+        '-derivedDataPath',
+        '/custom/DerivedData',
+      ]);
     });
 
     it('should surface executor failures when build settings cannot be retrieved', async () => {

--- a/src/mcp/tools/simulator/build_run_sim.ts
+++ b/src/mcp/tools/simulator/build_run_sim.ts
@@ -47,6 +47,7 @@ import {
   createDomainStreamingPipeline,
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 const baseOptions = {
@@ -157,6 +158,7 @@ async function prepareBuildRunSimExecution(
       scheme: params.scheme,
       workspacePath: params.workspacePath,
       projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration,
       platform: displayPlatform,
       simulatorName: params.simulatorName,
@@ -505,6 +507,7 @@ export async function build_run_simLogic(
       scheme: params.scheme,
       workspacePath: params.workspacePath,
       projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration: params.configuration ?? 'Debug',
       platform: 'Simulator',
       simulatorName: params.simulatorName,

--- a/src/mcp/tools/simulator/build_sim.ts
+++ b/src/mcp/tools/simulator/build_sim.ts
@@ -33,6 +33,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 const baseOptions = {
@@ -130,6 +131,7 @@ async function prepareBuildSimExecution(
       scheme: params.scheme,
       workspacePath: params.workspacePath,
       projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration,
       platform: detectedPlatform,
       simulatorName: params.simulatorName,
@@ -216,6 +218,9 @@ export async function build_simLogic(
           : { simulatorName: params.simulatorName ?? '' }),
         scheme: params.scheme,
         platform: prepared.detectedPlatform,
+        ...(params.derivedDataPath !== undefined
+          ? { derivedDataPath: params.derivedDataPath }
+          : {}),
       },
     };
   }

--- a/src/mcp/tools/simulator/get_sim_app_path.ts
+++ b/src/mcp/tools/simulator/get_sim_app_path.ts
@@ -66,6 +66,7 @@ const baseGetSimulatorAppPathSchema = z.object({
       "Name of the simulator (e.g., 'iPhone 17'). Provide EITHER this OR simulatorId, not both",
     ),
   configuration: z.string().optional().describe('Build configuration (Debug, Release, etc.)'),
+  derivedDataPath: z.string().optional(),
   useLatestOS: z
     .boolean()
     .optional()
@@ -121,6 +122,7 @@ export function createGetSimAppPathExecutor(
           configuration,
           platform: params.platform,
           destination,
+          derivedDataPath: params.derivedDataPath,
         },
         executor,
       );
@@ -181,6 +183,7 @@ const publicSchemaObject = baseGetSimulatorAppPathSchema.omit({
   simulatorId: true,
   simulatorName: true,
   configuration: true,
+  derivedDataPath: true,
   useLatestOS: true,
 } as const);
 

--- a/src/mcp/tools/simulator/test_sim.ts
+++ b/src/mcp/tools/simulator/test_sim.ts
@@ -37,6 +37,7 @@ import {
   setXcodebuildStructuredOutput,
 } from '../../../utils/xcodebuild-domain-results.ts';
 import type { BuildInvocationRequest } from '../../../types/domain-fragments.ts';
+import { resolveEffectiveDerivedDataPath } from '../../../utils/derived-data-path.ts';
 import { createBuildInvocationFragment } from '../../../utils/xcodebuild-pipeline.ts';
 
 const baseSchemaObject = z.object({
@@ -134,6 +135,9 @@ async function prepareTestSimExecution(
       resolutionError: simulatorResolution.error,
       invocationRequest: {
         scheme: params.scheme,
+        workspacePath: params.workspacePath,
+        projectPath: params.projectPath,
+        derivedDataPath: resolveEffectiveDerivedDataPath(params),
         configuration,
         platform: inferred.platform,
         simulatorName: params.simulatorName,
@@ -166,6 +170,9 @@ async function prepareTestSimExecution(
     resolvedSimulatorId: simulatorResolution.simulatorId,
     invocationRequest: {
       scheme: params.scheme,
+      workspacePath: params.workspacePath,
+      projectPath: params.projectPath,
+      derivedDataPath: resolveEffectiveDerivedDataPath(params),
       configuration,
       platform: inferred.platform,
       simulatorName: params.simulatorName,

--- a/src/snapshot-tests/__fixtures__/cli/device/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/device/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--success.txt
@@ -5,7 +5,7 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -16,7 +16,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/get-app-path--success.txt
@@ -7,9 +7,9 @@
    Platform: iOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app"
-2. Install app on device: xcodebuildmcp device install --device-id "DEVICE_UDID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app"
+1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
+2. Install app on device: xcodebuildmcp device install --device-id "DEVICE_UDID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
 3. Launch app on device: xcodebuildmcp device launch --device-id "DEVICE_UDID" --bundle-id "BUNDLE_ID"

--- a/src/snapshot-tests/__fixtures__/cli/device/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/install--success.txt
@@ -2,6 +2,6 @@
 📦 Install App
 
    Device: <DEVICE> (<UUID>)
-   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 ✅ App installed successfully.

--- a/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Discovered 52 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear

--- a/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   ├ Bundle ID: io.sentry.MCPTest.macOS

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -14,7 +14,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
   ├ Bundle ID: io.sentry.MCPTest.macOS
   ├ Process ID: <PID>
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/get-app-path--success.txt
@@ -7,8 +7,8 @@
    Platform: macOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp macos get-macos-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app"
-2. Launch app: xcodebuildmcp macos launch --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app"
+1. Get bundle ID: xcodebuildmcp macos get-macos-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
+2. Launch app: xcodebuildmcp macos launch --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"

--- a/src/snapshot-tests/__fixtures__/cli/macos/launch--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/launch--success.txt
@@ -1,7 +1,7 @@
 
 🚀 Launch macOS App
 
-   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 ✅ App launched successfully
   ├ Bundle ID: io.sentry.MCPTest.macOS

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: NONEXISTENT
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Discovered 4 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
@@ -15,12 +16,12 @@ Discovered 4 test(s):
 MCPTestsXCTests
   ✗ testDeliberateFailure():
       - XCTAssertTrue failed - This test is designed to fail for snapshot testing
-        MCPTestsXCTests.swift:11
+        example_projects/macOS/MCPTestTests/MCPTestsXCTests.swift:11
 
 MCPTestTests
   ✗ deliberateFailure():
       - Expectation failed: 1 == 2: This test is designed to fail for snapshot testing
-        MCPTestTests.swift:11
+        example_projects/macOS/MCPTestTests/MCPTestTests.swift:11
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
    Selective Testing:
      MCPTestTests/MCPTestTests/appNameIsCorrect()
      MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -18,7 +18,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
   ├ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/get-app-path--success.txt
@@ -8,10 +8,10 @@
    Simulator: iPhone 17
 
 ✅ Get app path successful (⏱️ <DURATION>)
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
 2. Boot simulator: xcodebuildmcp simulator-management boot --simulator-id "SIMULATOR_UUID"
-3. Install app: xcodebuildmcp simulator install --simulator-id "SIMULATOR_UUID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+3. Install app: xcodebuildmcp simulator install --simulator-id "SIMULATOR_UUID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
 4. Launch app: xcodebuildmcp simulator launch-app --simulator-id "SIMULATOR_UUID" --bundle-id "BUNDLE_ID"

--- a/src/snapshot-tests/__fixtures__/cli/simulator/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/install--success.txt
@@ -2,7 +2,7 @@
 📦 Install App
 
    Simulator: <UUID>
-   App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+   App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 ✅ App installed successfully
 

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--error-wrong-scheme.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: NONEXISTENT
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Discovered 52 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 

--- a/src/snapshot-tests/__fixtures__/json/device/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--error-wrong-scheme.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "target": "device"

--- a/src/snapshot-tests/__fixtures__/json/device/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--success.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "target": "device"

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--success.json
@@ -18,7 +18,7 @@
       "target": "device"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app",
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app",
       "bundleId": "io.sentry.calculatorapp",
       "processId": 99999,
       "deviceId": "<UUID>",

--- a/src/snapshot-tests/__fixtures__/json/device/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/get-app-path--success.json
@@ -15,7 +15,7 @@
       "target": "device"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app"
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/device/install--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/install--success.json
@@ -9,7 +9,7 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app"
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--error-wrong-scheme.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"

--- a/src/snapshot-tests/__fixtures__/json/macos/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--success.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-wrong-scheme.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--success.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -17,7 +18,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app",
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
       "bundleId": "io.sentry.MCPTest.macOS",
       "processId": 99999,
       "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"

--- a/src/snapshot-tests/__fixtures__/json/macos/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/get-app-path--success.json
@@ -15,7 +15,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app"
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/macos/launch--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/launch--success.json
@@ -8,7 +8,7 @@
       "status": "SUCCEEDED"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app",
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
       "bundleId": "io.sentry.MCPTest.macOS",
       "processId": 99999
     },

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "NONEXISTENT",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "MCPTest",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--success.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "MCPTest",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--error-wrong-scheme.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--success.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-wrong-scheme.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--success.json
@@ -7,6 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -17,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app",
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app",
       "bundleId": "io.sentry.calculatorapp",
       "processId": 99999,
       "simulatorId": "<UUID>",

--- a/src/snapshot-tests/__fixtures__/json/simulator/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/get-app-path--success.json
@@ -17,7 +17,7 @@
       "durationMs": 1234
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/simulator/install--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/install--success.json
@@ -9,7 +9,7 @@
     },
     "artifacts": {
       "simulatorId": "<UUID>",
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--error-wrong-scheme.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "NONEXISTENT",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
@@ -6,6 +6,8 @@
   "data": {
     "request": {
       "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--success.txt
@@ -5,7 +5,7 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -16,7 +16,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--success.txt
@@ -7,9 +7,9 @@
    Platform: iOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app" })
-2. Install app on device: install_app_device({ deviceId: "DEVICE_UDID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app" })
+1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
+2. Install app on device: install_app_device({ deviceId: "DEVICE_UDID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
 3. Launch app on device: launch_app_device({ deviceId: "DEVICE_UDID", bundleId: "BUNDLE_ID" })

--- a/src/snapshot-tests/__fixtures__/mcp/device/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/install--success.txt
@@ -2,6 +2,6 @@
 📦 Install App
 
    Device: <DEVICE> (<UUID>)
-   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphoneos/CalculatorApp.app
+   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 ✅ App installed successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Discovered 52 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   ├ Bundle ID: io.sentry.MCPTest.macOS

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-wrong-scheme.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -14,7 +14,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
   ├ Bundle ID: io.sentry.MCPTest.macOS
   ├ Process ID: <PID>
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--success.txt
@@ -7,8 +7,8 @@
    Platform: macOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 Next steps:
-1. Get bundle ID: get_mac_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app" })
-2. Launch app: launch_mac_app({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app" })
+1. Get bundle ID: get_mac_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })
+2. Launch app: launch_mac_app({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })

--- a/src/snapshot-tests/__fixtures__/mcp/macos/launch--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/launch--success.txt
@@ -1,7 +1,7 @@
 
 🚀 Launch macOS App
 
-   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug/MCPTest.app
+   App: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 ✅ App launched successfully
   ├ Bundle ID: io.sentry.MCPTest.macOS

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: NONEXISTENT
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
 
 Discovered 4 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
@@ -2,9 +2,10 @@
 🧪 Test
 
    Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
    Selective Testing:
      MCPTestTests/MCPTestTests/appNameIsCorrect()
      MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-wrong-scheme.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -18,7 +18,7 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
   ├ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--success.txt
@@ -8,10 +8,10 @@
    Simulator: iPhone 17
 
 ✅ Get app path successful (⏱️ <DURATION>)
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
+1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
 2. Boot simulator: boot_sim({ simulatorId: "SIMULATOR_UUID" })
-3. Install app: install_app_sim({ simulatorId: "SIMULATOR_UUID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
+3. Install app: install_app_sim({ simulatorId: "SIMULATOR_UUID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
 4. Launch app: launch_app_sim({ simulatorId: "SIMULATOR_UUID", bundleId: "BUNDLE_ID" })

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/install--success.txt
@@ -2,7 +2,7 @@
 📦 Install App
 
    Simulator: <UUID>
-   App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+   App Path: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 ✅ App installed successfully
 

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-wrong-scheme.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: NONEXISTENT
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
 
 Discovered 52 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
@@ -2,10 +2,11 @@
 🧪 Test
 
    Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 

--- a/src/snapshot-tests/normalize.ts
+++ b/src/snapshot-tests/normalize.ts
@@ -23,7 +23,7 @@ const LLDB_SYS_FRAME_FUNC_REGEX =
   /(frame #\d+: )\S+( at (?:\/usr\/lib\/|\/Library\/Developer\/CoreSimulator\/)[^`\n]*`)[^:\n]+(:<OFFSET>)/gm;
 const LLDB_FRAME_NUMBER_REGEX = /  frame #\d+:/g;
 const LLDB_BREAKPOINT_LOCATIONS_REGEX = /locations = .+$/gm;
-const DERIVED_DATA_HASH_REGEX = /(DerivedData\/[A-Za-z0-9_]+)-[a-z]{28}\b/g;
+const DERIVED_DATA_HASH_REGEX = /(DerivedData\/[^/\s]+)-(?:[a-z]{28}|[0-9a-f]{12})(?=\/|\b)/g;
 const LOCAL_TIMESTAMP_REGEX = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}/g;
 const XCTEST_PARENS_DURATION_REGEX = /\(\d+\.\d+\) seconds/g;
 const SWIFT_TESTING_DURATION_REGEX = /after \d+\.\d+ seconds/g;

--- a/src/utils/__tests__/build-preflight.test.ts
+++ b/src/utils/__tests__/build-preflight.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { displayPath, formatToolPreflight } from '../build-preflight.ts';
+import { computeScopedDerivedDataPath } from '../derived-data-path.ts';
 import { DERIVED_DATA_DIR } from '../log-paths.ts';
 
 const DISPLAY_DERIVED_DATA = displayPath(DERIVED_DATA_DIR);
+const displayScopedDerivedData = (anchorPath: string): string =>
+  displayPath(computeScopedDerivedDataPath(anchorPath));
 
 describe('formatToolPreflight', () => {
   it('formats simulator build with workspace and simulator name', () => {
@@ -24,7 +27,7 @@ describe('formatToolPreflight', () => {
         '   Configuration: Debug',
         '   Platform: iOS Simulator',
         '   Simulator: iPhone 17',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcworkspace')}`,
         '',
       ].join('\n'),
     );
@@ -49,7 +52,7 @@ describe('formatToolPreflight', () => {
         '   Configuration: Release',
         '   Platform: iOS Simulator',
         '   Simulator: ABC-123-DEF',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcodeproj')}`,
         '',
       ].join('\n'),
     );
@@ -74,7 +77,7 @@ describe('formatToolPreflight', () => {
         '   Configuration: Debug',
         '   Platform: iOS',
         '   Device: DEVICE-UDID-123',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcodeproj')}`,
         '',
       ].join('\n'),
     );
@@ -100,7 +103,7 @@ describe('formatToolPreflight', () => {
         '   Configuration: Debug',
         '   Platform: iOS',
         "   Device: Cameron's iPhone (DEVICE-UDID-123)",
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcodeproj')}`,
         '',
       ].join('\n'),
     );
@@ -123,7 +126,7 @@ describe('formatToolPreflight', () => {
         '   Project: /path/to/MacApp.xcodeproj',
         '   Configuration: Debug',
         '   Platform: macOS',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MacApp.xcodeproj')}`,
         '',
       ].join('\n'),
     );
@@ -147,7 +150,7 @@ describe('formatToolPreflight', () => {
         '   Workspace: /path/to/workspace.xcworkspace',
         '   Configuration: Debug',
         '   Platform: macOS',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/workspace.xcworkspace')}`,
         '   Architecture: arm64',
         '',
       ].join('\n'),
@@ -171,7 +174,7 @@ describe('formatToolPreflight', () => {
         '   Project: /path/to/MyApp.xcodeproj',
         '   Configuration: Debug',
         '   Platform: iOS',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcodeproj')}`,
         '',
       ].join('\n'),
     );
@@ -217,7 +220,7 @@ describe('formatToolPreflight', () => {
         '   Configuration: Debug',
         '   Platform: iOS Simulator',
         '   Simulator: iPhone 17',
-        `   Derived Data: ${DISPLAY_DERIVED_DATA}`,
+        `   Derived Data: ${displayScopedDerivedData('/path/to/MyApp.xcworkspace')}`,
         '',
       ].join('\n'),
     );

--- a/src/utils/__tests__/derived-data-path.test.ts
+++ b/src/utils/__tests__/derived-data-path.test.ts
@@ -1,39 +1,94 @@
-import { describe, expect, it } from 'vitest';
 import path from 'node:path';
 import { homedir } from 'node:os';
-import { resolveEffectiveDerivedDataPath } from '../derived-data-path.ts';
+import { describe, expect, it } from 'vitest';
+import {
+  computeScopedDerivedDataPath,
+  resolveEffectiveDerivedDataPath,
+} from '../derived-data-path.ts';
 import { DERIVED_DATA_DIR } from '../log-paths.ts';
 
 describe('resolveEffectiveDerivedDataPath', () => {
-  it('returns the default derived data dir when input is undefined', () => {
-    expect(resolveEffectiveDerivedDataPath(undefined)).toBe(DERIVED_DATA_DIR);
+  it('returns the global DerivedData root when no explicit path or anchor is present', () => {
+    expect(resolveEffectiveDerivedDataPath()).toBe(DERIVED_DATA_DIR);
+    expect(
+      resolveEffectiveDerivedDataPath({
+        derivedDataPath: ' ',
+        workspacePath: '\t',
+        projectPath: '',
+      }),
+    ).toBe(DERIVED_DATA_DIR);
   });
 
-  it('returns the default derived data dir when input is empty', () => {
-    expect(resolveEffectiveDerivedDataPath('')).toBe(DERIVED_DATA_DIR);
-  });
-
-  it('returns the default derived data dir when input is whitespace', () => {
-    expect(resolveEffectiveDerivedDataPath('   ')).toBe(DERIVED_DATA_DIR);
-  });
-
-  it('returns absolute paths unchanged', () => {
-    expect(resolveEffectiveDerivedDataPath('/abs/path/dd')).toBe('/abs/path/dd');
-  });
-
-  it('resolves relative paths against the current working directory', () => {
-    expect(resolveEffectiveDerivedDataPath('.derivedData/e2e')).toBe(
-      path.resolve(process.cwd(), '.derivedData/e2e'),
+  it('uses an explicit absolute derivedDataPath', () => {
+    expect(resolveEffectiveDerivedDataPath({ derivedDataPath: '/tmp/DerivedData' })).toBe(
+      '/tmp/DerivedData',
     );
   });
 
-  it('expands a bare ~ input to the home directory', () => {
-    expect(resolveEffectiveDerivedDataPath('~')).toBe(homedir());
+  it('resolves an explicit relative derivedDataPath from cwd', () => {
+    expect(
+      resolveEffectiveDerivedDataPath({ derivedDataPath: '.derivedData/app', cwd: '/repo' }),
+    ).toBe('/repo/.derivedData/app');
   });
 
-  it('expands a ~/-prefixed input under the home directory', () => {
-    expect(resolveEffectiveDerivedDataPath('~/.foo/derivedData')).toBe(
+  it('expands a bare ~ explicit derivedDataPath to the home directory', () => {
+    expect(resolveEffectiveDerivedDataPath({ derivedDataPath: '~' })).toBe(homedir());
+  });
+
+  it('expands a ~/-prefixed explicit derivedDataPath under the home directory', () => {
+    expect(resolveEffectiveDerivedDataPath({ derivedDataPath: '~/.foo/derivedData' })).toBe(
       path.join(homedir(), '.foo/derivedData'),
     );
+  });
+
+  it('scopes DerivedData from workspacePath when derivedDataPath is absent', () => {
+    const workspacePath = '/Users/dev/clone-1/MyApp.xcworkspace';
+
+    expect(resolveEffectiveDerivedDataPath({ workspacePath })).toBe(
+      computeScopedDerivedDataPath(workspacePath),
+    );
+  });
+
+  it('prefers workspacePath over projectPath when both anchors are present', () => {
+    const workspacePath = '/Users/dev/clone-1/MyApp.xcworkspace';
+    const projectPath = '/Users/dev/clone-1/MyApp.xcodeproj';
+
+    expect(resolveEffectiveDerivedDataPath({ workspacePath, projectPath })).toBe(
+      computeScopedDerivedDataPath(workspacePath),
+    );
+  });
+
+  it('scopes DerivedData from projectPath when workspacePath is absent', () => {
+    const projectPath = '/Users/dev/clone-2/MyApp.xcodeproj';
+
+    expect(resolveEffectiveDerivedDataPath({ projectPath })).toBe(
+      computeScopedDerivedDataPath(projectPath),
+    );
+  });
+
+  it('resolves relative workspace anchors before hashing', () => {
+    const cwd = '/Users/dev/repo';
+    const workspacePath = 'App/MyApp.xcworkspace';
+
+    expect(resolveEffectiveDerivedDataPath({ workspacePath, cwd })).toBe(
+      computeScopedDerivedDataPath(workspacePath, cwd),
+    );
+  });
+
+  it('expands a ~/-prefixed workspace anchor before hashing', () => {
+    const workspacePath = '~/clone/MyApp.xcworkspace';
+
+    expect(resolveEffectiveDerivedDataPath({ workspacePath })).toBe(
+      computeScopedDerivedDataPath(path.join(homedir(), 'clone/MyApp.xcworkspace')),
+    );
+  });
+
+  it('produces different scoped paths for matching basenames in different directories', () => {
+    const firstPath = computeScopedDerivedDataPath('/clone-1/MyApp.xcworkspace');
+    const secondPath = computeScopedDerivedDataPath('/clone-2/MyApp.xcworkspace');
+
+    expect(firstPath).toMatch(/MyApp-[a-f0-9]{12}$/);
+    expect(secondPath).toMatch(/MyApp-[a-f0-9]{12}$/);
+    expect(firstPath).not.toBe(secondPath);
   });
 });

--- a/src/utils/__tests__/session-store.test.ts
+++ b/src/utils/__tests__/session-store.test.ts
@@ -121,4 +121,38 @@ describe('SessionStore', () => {
     const stored = sessionStore.getAll();
     expect(stored.env).toEqual({ API_KEY: 'secret' });
   });
+
+  it('computes a workspace-scoped derivedDataPath when workspacePath is set', () => {
+    sessionStore.setDefaults({ workspacePath: '/Users/dev/clone-1/MyApp.xcworkspace' });
+
+    const defaults = sessionStore.getAll();
+    expect(defaults.derivedDataPath).toMatch(/MyApp-[a-f0-9]{12}$/);
+  });
+
+  it('computes a project-scoped derivedDataPath when projectPath is set', () => {
+    sessionStore.setDefaults({ projectPath: '/Users/dev/clone-2/MyApp.xcodeproj' });
+
+    const defaults = sessionStore.getAll();
+    expect(defaults.derivedDataPath).toMatch(/MyApp-[a-f0-9]{12}$/);
+  });
+
+  it('does not override an explicitly set derivedDataPath', () => {
+    sessionStore.setDefaults({
+      workspacePath: '/Users/dev/clone-1/MyApp.xcworkspace',
+      derivedDataPath: '/custom/path',
+    });
+
+    expect(sessionStore.getAll().derivedDataPath).toBe('/custom/path');
+  });
+
+  it('produces different hashes for different workspace paths', () => {
+    sessionStore.setDefaults({ workspacePath: '/clone-1/MyApp.xcworkspace' });
+    const path1 = sessionStore.getAll().derivedDataPath;
+
+    sessionStore.clearAll();
+    sessionStore.setDefaults({ workspacePath: '/clone-2/MyApp.xcworkspace' });
+    const path2 = sessionStore.getAll().derivedDataPath;
+
+    expect(path1).not.toBe(path2);
+  });
 });

--- a/src/utils/__tests__/session-store.test.ts
+++ b/src/utils/__tests__/session-store.test.ts
@@ -155,4 +155,15 @@ describe('SessionStore', () => {
 
     expect(path1).not.toBe(path2);
   });
+
+  it('recomputes derivedDataPath when workspacePath changes', () => {
+    sessionStore.setDefaults({ workspacePath: '/clone-1/MyApp.xcworkspace' });
+    const path1 = sessionStore.getAll().derivedDataPath;
+
+    sessionStore.setDefaults({ workspacePath: '/clone-2/MyApp.xcworkspace' });
+    const path2 = sessionStore.getAll().derivedDataPath;
+
+    expect(path1).not.toBe(path2);
+    expect(path2).toMatch(/MyApp-[a-f0-9]{12}$/);
+  });
 });

--- a/src/utils/__tests__/session-store.test.ts
+++ b/src/utils/__tests__/session-store.test.ts
@@ -122,48 +122,20 @@ describe('SessionStore', () => {
     expect(stored.env).toEqual({ API_KEY: 'secret' });
   });
 
-  it('computes a workspace-scoped derivedDataPath when workspacePath is set', () => {
+  it('does not compute derivedDataPath from workspacePath', () => {
     sessionStore.setDefaults({ workspacePath: '/Users/dev/clone-1/MyApp.xcworkspace' });
 
     const defaults = sessionStore.getAll();
-    expect(defaults.derivedDataPath).toMatch(/MyApp-[a-f0-9]{12}$/);
+    expect(defaults.workspacePath).toBe('/Users/dev/clone-1/MyApp.xcworkspace');
+    expect(defaults.derivedDataPath).toBeUndefined();
   });
 
-  it('computes a project-scoped derivedDataPath when projectPath is set', () => {
-    sessionStore.setDefaults({ projectPath: '/Users/dev/clone-2/MyApp.xcodeproj' });
-
-    const defaults = sessionStore.getAll();
-    expect(defaults.derivedDataPath).toMatch(/MyApp-[a-f0-9]{12}$/);
-  });
-
-  it('does not override an explicitly set derivedDataPath', () => {
+  it('preserves an explicitly set derivedDataPath as raw session state', () => {
     sessionStore.setDefaults({
       workspacePath: '/Users/dev/clone-1/MyApp.xcworkspace',
       derivedDataPath: '/custom/path',
     });
 
     expect(sessionStore.getAll().derivedDataPath).toBe('/custom/path');
-  });
-
-  it('produces different hashes for different workspace paths', () => {
-    sessionStore.setDefaults({ workspacePath: '/clone-1/MyApp.xcworkspace' });
-    const path1 = sessionStore.getAll().derivedDataPath;
-
-    sessionStore.clearAll();
-    sessionStore.setDefaults({ workspacePath: '/clone-2/MyApp.xcworkspace' });
-    const path2 = sessionStore.getAll().derivedDataPath;
-
-    expect(path1).not.toBe(path2);
-  });
-
-  it('recomputes derivedDataPath when workspacePath changes', () => {
-    sessionStore.setDefaults({ workspacePath: '/clone-1/MyApp.xcworkspace' });
-    const path1 = sessionStore.getAll().derivedDataPath;
-
-    sessionStore.setDefaults({ workspacePath: '/clone-2/MyApp.xcworkspace' });
-    const path2 = sessionStore.getAll().derivedDataPath;
-
-    expect(path1).not.toBe(path2);
-    expect(path2).toMatch(/MyApp-[a-f0-9]{12}$/);
   });
 });

--- a/src/utils/__tests__/snapshot-normalize.test.ts
+++ b/src/utils/__tests__/snapshot-normalize.test.ts
@@ -39,4 +39,16 @@ describe('normalizeSnapshotOutput tilde handling', () => {
       'Discovered 2 test(s):\n   ExampleTests/testOne\n› Linking\n› Running tests\n\n✅ 2 tests passed, 0 skipped (⏱️ <DURATION>)\n',
     );
   });
+
+  it('normalizes scoped XcodeBuildMCP DerivedData hashes', () => {
+    const input =
+      'Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-22d700c6d603\n';
+
+    const result = normalizeSnapshotOutput(input);
+
+    expect(result).toContain(
+      '<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>',
+    );
+    expect(result).not.toContain('22d700c6d603');
+  });
 });

--- a/src/utils/__tests__/xcodebuild-pipeline.test.ts
+++ b/src/utils/__tests__/xcodebuild-pipeline.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { createXcodebuildPipeline } from '../xcodebuild-pipeline.ts';
+import {
+  createXcodebuildPipeline,
+  invocationRequestToHeaderParams,
+} from '../xcodebuild-pipeline.ts';
 import { STAGE_RANK } from '../../types/domain-fragments.ts';
 import type { AnyFragment, DomainFragment } from '../../types/domain-fragments.ts';
 import { renderCliTextTranscript } from '../renderers/cli-text-renderer.ts';
@@ -274,6 +277,28 @@ describe('xcodebuild-pipeline', () => {
     expect(output).toContain('   testF\n');
     expect(output).not.toContain('   testG\n');
     expect(output).toContain('   (...and 2 more)');
+  });
+
+  it('derives header DerivedData from request workspacePath', () => {
+    const params = invocationRequestToHeaderParams({
+      scheme: 'MyApp',
+      workspacePath: '/path/to/MyApp.xcworkspace',
+    });
+
+    expect(params).toContainEqual({ label: 'Workspace', value: '/path/to/MyApp.xcworkspace' });
+    expect(params).toContainEqual({
+      label: 'Derived Data',
+      value: expect.stringMatching(/MyApp-[a-f0-9]{12}$/),
+    });
+  });
+
+  it('does not add DerivedData header rows for package-only requests', () => {
+    const params = invocationRequestToHeaderParams({
+      target: 'swift-package',
+      packagePath: '/path/to/Package',
+    });
+
+    expect(params.some((param) => param.label === 'Derived Data')).toBe(false);
   });
 
   it('produces JSONL output in CLI json mode', () => {

--- a/src/utils/app-path-resolver.ts
+++ b/src/utils/app-path-resolver.ts
@@ -48,7 +48,11 @@ export async function resolveAppPathFromBuildSettings(
 
   const workspacePath = resolvePathFromCwd(params.workspacePath);
   const projectPath = resolvePathFromCwd(params.projectPath);
-  const derivedDataPath = resolveEffectiveDerivedDataPath(params.derivedDataPath);
+  const derivedDataPath = resolveEffectiveDerivedDataPath({
+    derivedDataPath: params.derivedDataPath,
+    workspacePath,
+    projectPath,
+  });
 
   let projectDir: string | undefined;
 

--- a/src/utils/build-preflight.ts
+++ b/src/utils/build-preflight.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import { resolveEffectiveDerivedDataPath } from './derived-data-path.ts';
+import { sessionStore } from './session-store.ts';
 
 export interface ToolPreflightParams {
   operation:
@@ -94,7 +95,7 @@ export function formatToolPreflight(params: ToolPreflightParams): string {
   }
 
   lines.push(
-    `   Derived Data: ${displayPath(resolveEffectiveDerivedDataPath(params.derivedDataPath))}`,
+    `   Derived Data: ${displayPath(resolveEffectiveDerivedDataPath(params.derivedDataPath ?? sessionStore.get('derivedDataPath')))}`,
   );
 
   if (params.arch) {

--- a/src/utils/build-preflight.ts
+++ b/src/utils/build-preflight.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import os from 'node:os';
 import { resolveEffectiveDerivedDataPath } from './derived-data-path.ts';
-import { sessionStore } from './session-store.ts';
 
 export interface ToolPreflightParams {
   operation:
@@ -95,7 +94,13 @@ export function formatToolPreflight(params: ToolPreflightParams): string {
   }
 
   lines.push(
-    `   Derived Data: ${displayPath(resolveEffectiveDerivedDataPath(params.derivedDataPath ?? sessionStore.get('derivedDataPath')))}`,
+    `   Derived Data: ${displayPath(
+      resolveEffectiveDerivedDataPath({
+        derivedDataPath: params.derivedDataPath,
+        workspacePath: params.workspacePath,
+        projectPath: params.projectPath,
+      }),
+    )}`,
   );
 
   if (params.arch) {

--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -78,7 +78,11 @@ export async function executeXcodeBuildCommand(
       ? resolvePathFromCwd(params.workspacePath)
       : undefined;
     const projectPath = params.projectPath ? resolvePathFromCwd(params.projectPath) : undefined;
-    const derivedDataPath = resolveEffectiveDerivedDataPath(params.derivedDataPath);
+    const derivedDataPath = resolveEffectiveDerivedDataPath({
+      derivedDataPath: params.derivedDataPath,
+      workspacePath,
+      projectPath,
+    });
 
     let projectDir = '';
     if (workspacePath) {

--- a/src/utils/derived-data-path.ts
+++ b/src/utils/derived-data-path.ts
@@ -1,9 +1,42 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import { DERIVED_DATA_DIR } from './log-paths.ts';
 import { resolvePathFromCwd } from './path.ts';
 
-export function resolveEffectiveDerivedDataPath(input?: string): string {
-  if (!input || input.trim().length === 0) {
-    return DERIVED_DATA_DIR;
+export type DerivedDataPathInput = {
+  derivedDataPath?: string | null;
+  workspacePath?: string | null;
+  projectPath?: string | null;
+  cwd?: string;
+};
+
+function getNonEmptyPath(pathValue?: string | null): string | undefined {
+  return pathValue && pathValue.trim().length > 0 ? pathValue : undefined;
+}
+
+export function computeScopedDerivedDataPath(anchorPath: string, cwd?: string): string {
+  const resolved = resolvePathFromCwd(anchorPath, cwd);
+  const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 12);
+  const name = path.basename(resolved, path.extname(resolved));
+  return path.join(DERIVED_DATA_DIR, `${name}-${hash}`);
+}
+
+export function resolveEffectiveDerivedDataPath(input: DerivedDataPathInput = {}): string {
+  const cwd = input.cwd ?? process.cwd();
+  const explicitDerivedDataPath = getNonEmptyPath(input.derivedDataPath);
+  if (explicitDerivedDataPath) {
+    return resolvePathFromCwd(explicitDerivedDataPath, cwd);
   }
-  return resolvePathFromCwd(input);
+
+  const workspacePath = getNonEmptyPath(input.workspacePath);
+  if (workspacePath) {
+    return computeScopedDerivedDataPath(workspacePath, cwd);
+  }
+
+  const projectPath = getNonEmptyPath(input.projectPath);
+  if (projectPath) {
+    return computeScopedDerivedDataPath(projectPath, cwd);
+  }
+
+  return DERIVED_DATA_DIR;
 }

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -1,6 +1,3 @@
-import * as crypto from 'node:crypto';
-import * as path from 'node:path';
-import { DERIVED_DATA_DIR } from './log-paths.ts';
 import { log } from './logger.ts';
 
 export type SessionDefaults = {
@@ -25,13 +22,6 @@ export type SessionDefaults = {
   bundleId?: string;
   env?: Record<string, string>;
 };
-
-function computeScopedDerivedDataPath(anchor: string): string {
-  const resolved = path.resolve(anchor);
-  const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 12);
-  const name = path.basename(resolved, path.extname(resolved));
-  return path.join(DERIVED_DATA_DIR, `${name}-${hash}`);
-}
 
 class SessionStore {
   private globalDefaults: SessionDefaults = {};
@@ -142,16 +132,7 @@ class SessionStore {
   }
 
   getAllForProfile(profile: string | null): SessionDefaults {
-    const result = this.getRawForProfile(profile);
-
-    if (!result.derivedDataPath) {
-      const anchor = result.workspacePath ?? result.projectPath;
-      if (anchor) {
-        result.derivedDataPath = computeScopedDerivedDataPath(anchor);
-      }
-    }
-
-    return result;
+    return this.getRawForProfile(profile);
   }
 
   private getRawForProfile(profile: string | null): SessionDefaults {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -79,7 +79,7 @@ class SessionStore {
   }
 
   setDefaultsForProfile(profile: string | null, partial: Partial<SessionDefaults>): void {
-    const previous = this.getAllForProfile(profile);
+    const previous = this.getRawForProfile(profile);
     const next = { ...previous, ...partial };
     this.setDefaultsForResolvedProfile(profile, next);
     this.revision += 1;
@@ -117,7 +117,7 @@ class SessionStore {
       return;
     }
 
-    const next = this.getAllForProfile(profile);
+    const next = this.getRawForProfile(profile);
     for (const k of keys) delete next[k];
 
     this.setDefaultsForResolvedProfile(profile, next);
@@ -135,8 +135,7 @@ class SessionStore {
   }
 
   getAllForProfile(profile: string | null): SessionDefaults {
-    const defaults = profile === null ? this.globalDefaults : (this.profiles[profile] ?? {});
-    const result = this.cloneDefaults(defaults);
+    const result = this.getRawForProfile(profile);
 
     if (!result.derivedDataPath) {
       const anchor = result.workspacePath ?? result.projectPath;
@@ -149,6 +148,11 @@ class SessionStore {
     }
 
     return result;
+  }
+
+  private getRawForProfile(profile: string | null): SessionDefaults {
+    const defaults = profile === null ? this.globalDefaults : (this.profiles[profile] ?? {});
+    return this.cloneDefaults(defaults);
   }
 
   listProfiles(): string[] {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -1,3 +1,6 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+import { DERIVED_DATA_DIR } from './log-paths.ts';
 import { log } from './logger.ts';
 
 export type SessionDefaults = {
@@ -133,7 +136,19 @@ class SessionStore {
 
   getAllForProfile(profile: string | null): SessionDefaults {
     const defaults = profile === null ? this.globalDefaults : (this.profiles[profile] ?? {});
-    return this.cloneDefaults(defaults);
+    const result = this.cloneDefaults(defaults);
+
+    if (!result.derivedDataPath) {
+      const anchor = result.workspacePath ?? result.projectPath;
+      if (anchor) {
+        const resolved = path.resolve(anchor);
+        const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 12);
+        const name = path.basename(resolved, path.extname(resolved));
+        result.derivedDataPath = path.join(DERIVED_DATA_DIR, `${name}-${hash}`);
+      }
+    }
+
+    return result;
   }
 
   listProfiles(): string[] {

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -26,6 +26,13 @@ export type SessionDefaults = {
   env?: Record<string, string>;
 };
 
+function computeScopedDerivedDataPath(anchor: string): string {
+  const resolved = path.resolve(anchor);
+  const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 12);
+  const name = path.basename(resolved, path.extname(resolved));
+  return path.join(DERIVED_DATA_DIR, `${name}-${hash}`);
+}
+
 class SessionStore {
   private globalDefaults: SessionDefaults = {};
   private profiles: Record<string, SessionDefaults> = {};
@@ -140,10 +147,7 @@ class SessionStore {
     if (!result.derivedDataPath) {
       const anchor = result.workspacePath ?? result.projectPath;
       if (anchor) {
-        const resolved = path.resolve(anchor);
-        const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 12);
-        const name = path.basename(resolved, path.extname(resolved));
-        result.derivedDataPath = path.join(DERIVED_DATA_DIR, `${name}-${hash}`);
+        result.derivedDataPath = computeScopedDerivedDataPath(anchor);
       }
     }
 

--- a/src/utils/xcodebuild-pipeline.ts
+++ b/src/utils/xcodebuild-pipeline.ts
@@ -11,6 +11,7 @@ import { createXcodebuildRunState } from './xcodebuild-run-state.ts';
 import type { XcodebuildRunState, XcodebuildRunStateHandle } from './xcodebuild-run-state.ts';
 import { displayPath } from './build-preflight.ts';
 import { resolveEffectiveDerivedDataPath } from './derived-data-path.ts';
+import { sessionStore } from './session-store.ts';
 import { formatDeviceId } from './device-name-resolver.ts';
 import { createLogCapture, createParserDebugCapture } from './xcodebuild-log-capture.ts';
 import { log as appLog } from './logging/index.ts';
@@ -132,7 +133,8 @@ function buildHeaderParams(
     (r) => r.label === 'Scheme' || r.label === 'Workspace' || r.label === 'Project',
   );
   if (hasXcodebuildContext && !result.some((r) => r.label === 'Derived Data')) {
-    result.push({ label: 'Derived Data', value: displayPath(resolveEffectiveDerivedDataPath()) });
+    const effectivePath = resolveEffectiveDerivedDataPath(sessionStore.get('derivedDataPath'));
+    result.push({ label: 'Derived Data', value: displayPath(effectivePath) });
   }
 
   return result;

--- a/src/utils/xcodebuild-pipeline.ts
+++ b/src/utils/xcodebuild-pipeline.ts
@@ -11,7 +11,6 @@ import { createXcodebuildRunState } from './xcodebuild-run-state.ts';
 import type { XcodebuildRunState, XcodebuildRunStateHandle } from './xcodebuild-run-state.ts';
 import { displayPath } from './build-preflight.ts';
 import { resolveEffectiveDerivedDataPath } from './derived-data-path.ts';
-import { sessionStore } from './session-store.ts';
 import { formatDeviceId } from './device-name-resolver.ts';
 import { createLogCapture, createParserDebugCapture } from './xcodebuild-log-capture.ts';
 import { log as appLog } from './logging/index.ts';
@@ -133,7 +132,12 @@ function buildHeaderParams(
     (r) => r.label === 'Scheme' || r.label === 'Workspace' || r.label === 'Project',
   );
   if (hasXcodebuildContext && !result.some((r) => r.label === 'Derived Data')) {
-    const effectivePath = resolveEffectiveDerivedDataPath(sessionStore.get('derivedDataPath'));
+    const effectivePath = resolveEffectiveDerivedDataPath({
+      derivedDataPath:
+        typeof params.derivedDataPath === 'string' ? params.derivedDataPath : undefined,
+      workspacePath: typeof params.workspacePath === 'string' ? params.workspacePath : undefined,
+      projectPath: typeof params.projectPath === 'string' ? params.projectPath : undefined,
+    });
     result.push({ label: 'Derived Data', value: displayPath(effectivePath) });
   }
 


### PR DESCRIPTION
When `derivedDataPath` is not explicitly set but `workspacePath` or `projectPath` is known in session defaults, the session store now computes a workspace-scoped subdirectory under the default DerivedData root using a `<name>-<hash>` scheme (e.g. `MyApp-4ee6552f04c9`).

This prevents concurrent MCP sessions (or CLI invocations) building different clones of the same project from colliding on a shared build directory. Previously all sessions shared a single flat `~/Library/Developer/XcodeBuildMCP/DerivedData`, which caused corrupted incremental builds when multiple agents worked on separate clones in parallel.

The isolation is handled entirely in the session store's `getAllForProfile()` as a computed default. `resolveEffectiveDerivedDataPath` and all tool implementations are unchanged. An explicitly set `derivedDataPath` (via session defaults or env var) always takes precedence.

Closes #340