### PR TITLE
fix(xcode-ide): suppress listChanged resync during manual bridge disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 - Auto-scope DerivedData per workspace/project path at xcodebuild invocation time when no explicit `derivedDataPath` is configured. Session defaults remain raw, while build/test/app-path commands derive a stable hashed subdirectory under the global DerivedData root from the resolved workspace or project path. Explicit `derivedDataPath` still takes precedence ([#340](https://github.com/getsentry/XcodeBuildMCP/issues/340)).
 
+### Fixed
+
+- Fixed `xcode_tools_bridge_disconnect` immediately re-syncing proxied tools after a manual disconnect ([#343](https://github.com/getsentry/XcodeBuildMCP/issues/343)).
+
 ## [2.3.2]
 
 ### Fixed
@@ -449,5 +453,3 @@ Please note that the UI automation features are an early preview and currently i
 ## [v1.0.1] - 2025-04-02
 - Initial release of XcodeBuildMCP
 - Basic support for building iOS and macOS applications
-
-

--- a/src/integrations/xcode-tools-bridge/__tests__/manager.test.ts
+++ b/src/integrations/xcode-tools-bridge/__tests__/manager.test.ts
@@ -1,27 +1,33 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { registryMocks, buildStatusMock, serviceMocks, onToolCatalogInvalidatedRef } = vi.hoisted(
-  () => ({
-    registryMocks: {
-      clear: vi.fn(),
-      getRegisteredCount: vi.fn(() => 0),
-      sync: vi.fn(() => ({ added: 0, updated: 0, removed: 0, total: 0 })),
-    },
-    buildStatusMock: vi.fn(),
-    serviceMocks: {
-      setWorkflowEnabled: vi.fn(),
-      disconnect: vi.fn(),
-      getClientStatus: vi.fn(),
-      getLastError: vi.fn(),
-      listTools: vi.fn(),
-      invokeTool: vi.fn(),
-    },
-    onToolCatalogInvalidatedRef: {
-      current: undefined as (() => void) | undefined,
-    },
-  }),
-);
+const {
+  registryMocks,
+  buildStatusMock,
+  serviceMocks,
+  onToolCatalogInvalidatedRef,
+  getMcpBridgeAvailabilityMock,
+} = vi.hoisted(() => ({
+  registryMocks: {
+    clear: vi.fn(),
+    getRegisteredCount: vi.fn(() => 0),
+    sync: vi.fn(() => ({ added: 0, updated: 0, removed: 0, total: 0 })),
+  },
+  buildStatusMock: vi.fn(),
+  serviceMocks: {
+    setWorkflowEnabled: vi.fn(),
+    disconnect: vi.fn(),
+    getClientStatus: vi.fn(),
+    getLastError: vi.fn(),
+    listTools: vi.fn(),
+    invokeTool: vi.fn(),
+  },
+  onToolCatalogInvalidatedRef: {
+    current: undefined as (() => void) | undefined,
+  },
+  getMcpBridgeAvailabilityMock: vi.fn(),
+}));
 
 vi.mock('../registry.ts', () => ({
   XcodeToolsProxyRegistry: vi.fn().mockImplementation(() => registryMocks),
@@ -30,7 +36,7 @@ vi.mock('../registry.ts', () => ({
 vi.mock('../core.ts', () => ({
   buildXcodeToolsBridgeStatus: buildStatusMock,
   classifyBridgeError: vi.fn(() => 'XCODE_MCP_UNAVAILABLE'),
-  getMcpBridgeAvailability: vi.fn(),
+  getMcpBridgeAvailability: getMcpBridgeAvailabilityMock,
   serializeBridgeTool: vi.fn((tool) => tool),
 }));
 
@@ -83,7 +89,11 @@ describe('XcodeToolsBridgeManager', () => {
     serviceMocks.getLastError.mockReset();
     serviceMocks.getLastError.mockReturnValue(null);
     serviceMocks.listTools.mockReset();
+    serviceMocks.listTools.mockResolvedValue([]);
     serviceMocks.invokeTool.mockReset();
+
+    getMcpBridgeAvailabilityMock.mockReset();
+    getMcpBridgeAvailabilityMock.mockResolvedValue({ available: true, path: '/usr/bin/mcpbridge' });
   });
 
   it('does not resync on listChanged while a manual disconnect is in progress', async () => {
@@ -104,5 +114,28 @@ describe('XcodeToolsBridgeManager', () => {
     expect(syncSpy).not.toHaveBeenCalled();
     expect(registryMocks.clear).toHaveBeenCalledOnce();
     expect(server.sendToolListChanged).toHaveBeenCalledOnce();
+  });
+
+  it('re-enables listChanged-driven syncs after a manual sync follows a disconnect', async () => {
+    const server = {
+      sendToolListChanged: vi.fn(),
+    } as unknown as McpServer;
+
+    const tools: Tool[] = [{ name: 'remote.tool', inputSchema: { type: 'object' } } as Tool];
+    serviceMocks.listTools.mockResolvedValue(tools);
+
+    const manager = new XcodeToolsBridgeManager(server);
+    manager.setWorkflowEnabled(true);
+
+    await manager.disconnectTool();
+    await manager.syncTools({ reason: 'manual' });
+
+    const syncSpy = vi.spyOn(manager, 'syncTools');
+
+    onToolCatalogInvalidatedRef.current?.();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(syncSpy).toHaveBeenCalledWith({ reason: 'listChanged' });
   });
 });

--- a/src/integrations/xcode-tools-bridge/__tests__/manager.test.ts
+++ b/src/integrations/xcode-tools-bridge/__tests__/manager.test.ts
@@ -1,0 +1,108 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { registryMocks, buildStatusMock, serviceMocks, onToolCatalogInvalidatedRef } = vi.hoisted(
+  () => ({
+    registryMocks: {
+      clear: vi.fn(),
+      getRegisteredCount: vi.fn(() => 0),
+      sync: vi.fn(() => ({ added: 0, updated: 0, removed: 0, total: 0 })),
+    },
+    buildStatusMock: vi.fn(),
+    serviceMocks: {
+      setWorkflowEnabled: vi.fn(),
+      disconnect: vi.fn(),
+      getClientStatus: vi.fn(),
+      getLastError: vi.fn(),
+      listTools: vi.fn(),
+      invokeTool: vi.fn(),
+    },
+    onToolCatalogInvalidatedRef: {
+      current: undefined as (() => void) | undefined,
+    },
+  }),
+);
+
+vi.mock('../registry.ts', () => ({
+  XcodeToolsProxyRegistry: vi.fn().mockImplementation(() => registryMocks),
+}));
+
+vi.mock('../core.ts', () => ({
+  buildXcodeToolsBridgeStatus: buildStatusMock,
+  classifyBridgeError: vi.fn(() => 'XCODE_MCP_UNAVAILABLE'),
+  getMcpBridgeAvailability: vi.fn(),
+  serializeBridgeTool: vi.fn((tool) => tool),
+}));
+
+vi.mock('../tool-service.ts', () => ({
+  XcodeIdeToolService: vi
+    .fn()
+    .mockImplementation((options: { onToolCatalogInvalidated?: () => void }) => {
+      onToolCatalogInvalidatedRef.current = options.onToolCatalogInvalidated;
+      return serviceMocks;
+    }),
+}));
+
+import { XcodeToolsBridgeManager } from '../manager.ts';
+
+describe('XcodeToolsBridgeManager', () => {
+  beforeEach(() => {
+    onToolCatalogInvalidatedRef.current = undefined;
+
+    registryMocks.clear.mockReset();
+    registryMocks.getRegisteredCount.mockReset();
+    registryMocks.getRegisteredCount.mockReturnValue(0);
+    registryMocks.sync.mockReset();
+    registryMocks.sync.mockReturnValue({ added: 0, updated: 0, removed: 0, total: 0 });
+
+    buildStatusMock.mockReset();
+    buildStatusMock.mockResolvedValue({
+      workflowEnabled: true,
+      bridgeAvailable: false,
+      bridgePath: null,
+      xcodeRunning: null,
+      connected: false,
+      bridgePid: null,
+      proxiedToolCount: 0,
+      lastError: null,
+      xcodePid: null,
+      xcodeSessionId: null,
+    });
+
+    serviceMocks.setWorkflowEnabled.mockReset();
+    serviceMocks.disconnect.mockReset();
+    serviceMocks.disconnect.mockImplementation(async () => {
+      onToolCatalogInvalidatedRef.current?.();
+    });
+    serviceMocks.getClientStatus.mockReset();
+    serviceMocks.getClientStatus.mockReturnValue({
+      connected: false,
+      bridgePid: null,
+      lastError: null,
+    });
+    serviceMocks.getLastError.mockReset();
+    serviceMocks.getLastError.mockReturnValue(null);
+    serviceMocks.listTools.mockReset();
+    serviceMocks.invokeTool.mockReset();
+  });
+
+  it('does not resync on listChanged while a manual disconnect is in progress', async () => {
+    const server = {
+      sendToolListChanged: vi.fn(),
+    } as unknown as McpServer;
+
+    const manager = new XcodeToolsBridgeManager(server);
+    manager.setWorkflowEnabled(true);
+
+    const syncSpy = vi.spyOn(manager, 'syncTools');
+
+    await manager.disconnectTool();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(serviceMocks.disconnect).toHaveBeenCalledOnce();
+    expect(syncSpy).not.toHaveBeenCalled();
+    expect(registryMocks.clear).toHaveBeenCalledOnce();
+    expect(server.sendToolListChanged).toHaveBeenCalledOnce();
+  });
+});

--- a/src/integrations/xcode-tools-bridge/manager.ts
+++ b/src/integrations/xcode-tools-bridge/manager.ts
@@ -24,12 +24,16 @@ export class XcodeToolsBridgeManager {
   private workflowEnabled = false;
   private lastError: string | null = null;
   private syncInFlight: Promise<ProxySyncResult> | null = null;
+  private suppressListChangedSync = false;
 
   constructor(server: McpServer) {
     this.server = server;
     this.registry = new XcodeToolsProxyRegistry(server);
     this.service = new XcodeIdeToolService({
       onToolCatalogInvalidated: (): void => {
+        if (this.suppressListChangedSync) {
+          return;
+        }
         void this.syncTools({ reason: 'listChanged' });
       },
     });
@@ -59,6 +63,10 @@ export class XcodeToolsBridgeManager {
   }): Promise<ProxySyncResult> {
     if (!this.workflowEnabled) {
       throw new Error('xcode-ide workflow is not enabled');
+    }
+
+    if (opts.reason !== 'listChanged') {
+      this.suppressListChangedSync = false;
     }
 
     if (this.syncInFlight) return this.syncInFlight;
@@ -107,6 +115,7 @@ export class XcodeToolsBridgeManager {
   }
 
   async disconnect(): Promise<void> {
+    this.suppressListChangedSync = true;
     this.registry.clear();
     this.server.sendToolListChanged();
     await this.service.disconnect();


### PR DESCRIPTION
## Summary

Fixes #343.

`xcode_tools_bridge_disconnect` is documented as the bridge tool that disconnects the Xcode IDE bridge and unregisters proxied `xcode_tools_*` tools. In the current implementation, the explicit disconnect path still allows the bridge invalidation callback to feed back into `syncTools({ reason: "listChanged" })`.

That makes a manual disconnect behave like a remote catalog refresh instead of a stable disconnected state.

## Why this change belongs here

The current bridge tool contract separates:

- `xcode_tools_bridge_disconnect` for explicit disconnect + unregister
- `xcode_tools_bridge_sync` for explicit/manual re-sync

Allowing `listChanged`-driven resync during a manual disconnect collapses those semantics and weakens the deterministic lifecycle behavior the repo has been tightening in the recent MCP lifecycle work.

## Changes

- suppress `listChanged`-driven resync while a manual bridge disconnect is in progress
- clear that suppression on the next explicit startup/manual sync
- add a focused regression test covering the manager callback flow
- record the fix in `CHANGELOG.md` under `Unreleased`

## Testing

- `npm run format`
- `npm run lint`
- `npm run generate:version`
- `npm run typecheck`
- `npm run build`
- `npm run docs:check`
- `npm test`

## Validation note

Before applying the fix, I locally reproduced the problem by triggering `disconnectTool()` and observing the manager callback still schedule `syncTools({ reason: "listChanged" })`. The new regression test locks that behavior out so an explicit disconnect remains disconnected until the next intentional sync path.
