### PR TITLE
feat(cli): Add upgrade command for CLI self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `xcodebuildmcp upgrade` command to check for updates and upgrade in place. Supports `--check` (report-only) and `--yes`/`-y` (skip confirmation). Detects install method (Homebrew, npm-global, npx) and runs the appropriate upgrade command. Non-interactive environments exit 1 when an auto-upgrade is possible but `--yes` was not supplied.
+- Added `xcodebuildmcp upgrade` command to check for updates and upgrade in place. Supports `--check` (report-only) and `--yes`/`-y` (skip confirmation). Detects install method (Homebrew, npm-global, npx) and queries the appropriate channel source (`brew info`, `npm view`, or GitHub Releases) for the latest version. Non-interactive environments exit 1 when an auto-upgrade is possible but `--yes` was not supplied.
 
 ## [2.3.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added `xcodebuildmcp upgrade` command to check for updates and upgrade in place. Supports `--check` (report-only) and `--yes`/`-y` (skip confirmation). Detects install method (Homebrew, npm-global, npx) and runs the appropriate upgrade command. Non-interactive environments exit 1 when an auto-upgrade is possible but `--yes` was not supplied.
+
 ## [2.3.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -352,6 +352,13 @@ xcodebuildmcp tools
 xcodebuildmcp simulator build --scheme MyApp --project-path ./MyApp.xcodeproj
 ```
 
+Check for updates and upgrade in place:
+
+```bash
+xcodebuildmcp upgrade --check
+xcodebuildmcp upgrade --yes
+```
+
 The CLI uses a per-workspace daemon for stateful operations (log capture, debugging, etc.) that auto-starts when needed. See [docs/CLI.md](docs/CLI.md) for full documentation.
 
 ## Documentation

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -54,6 +54,10 @@ xcodebuildmcp upgrade --yes
 
 When both `--check` and `--yes` are supplied, `--check` wins.
 
+### Channel-aware version lookup
+
+The version check queries the source of truth for your install channel — `brew info` for Homebrew, `npm view` for npm/npx, or GitHub Releases for unknown installs. This avoids misleading results when release channels drift (e.g. GitHub may publish a version before the Homebrew tap bumps). If the channel-specific lookup fails, the command does not fall back to another source; it reports the error and exits 1.
+
 ### Install method behavior
 
 The command detects how XcodeBuildMCP was installed and adapts accordingly:
@@ -73,9 +77,9 @@ When stdin is not a TTY (CI, pipes, scripts):
 - `--yes` runs the upgrade for Homebrew and npm-global installs.
 - Without `--check` or `--yes`, the command prints the manual upgrade command and exits 1 (it cannot prompt for confirmation).
 
-### GitHub API failures
+### Lookup failures
 
-If the release check fails (network error, rate limit, timeout), the command prints the detected install method and manual upgrade instructions, then exits 1.
+If the channel-specific version check fails (network error, rate limit, timeout, missing formula), the command prints the detected install method and manual upgrade instructions, then exits 1.
 
 ## Tool Options
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,7 +28,54 @@ xcodebuildmcp <workflow> <tool> --help
 
 # Run interactive setup for .xcodebuildmcp/config.yaml
 xcodebuildmcp setup
+
+# Check for updates
+xcodebuildmcp upgrade --check
 ```
+
+## Upgrade
+
+`xcodebuildmcp upgrade` checks for a newer release and optionally runs the upgrade.
+
+```bash
+# Check for updates without upgrading
+xcodebuildmcp upgrade --check
+
+# Upgrade automatically (skip confirmation prompt)
+xcodebuildmcp upgrade --yes
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--check` | Report the latest version and exit. Never prompts or runs an upgrade. |
+| `--yes` / `-y` | Skip the confirmation prompt and run the upgrade command automatically. |
+
+When both `--check` and `--yes` are supplied, `--check` wins.
+
+### Install method behavior
+
+The command detects how XcodeBuildMCP was installed and adapts accordingly:
+
+| Method | Auto-upgrade | Command |
+|--------|--------------|----------|
+| Homebrew | Yes | `brew update && brew upgrade xcodebuildmcp` |
+| npm global | Yes | `npm install -g xcodebuildmcp@latest` |
+| npx | No | npx resolves `@latest` on each run; update the pinned version in your client config if needed. |
+| Unknown | No | Manual instructions for all supported channels are shown. |
+
+### Non-interactive mode
+
+When stdin is not a TTY (CI, pipes, scripts):
+
+- `--check` works normally and exits 0.
+- `--yes` runs the upgrade for Homebrew and npm-global installs.
+- Without `--check` or `--yes`, the command prints the manual upgrade command and exits 1 (it cannot prompt for confirmation).
+
+### GitHub API failures
+
+If the release check fails (network error, rate limit, timeout), the command prints the detected install method and manual upgrade instructions, then exits 1.
 
 ## Tool Options
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -62,6 +62,16 @@ Using `@latest` ensures clients resolve the newest version on each run.
 
 See [CLI.md](CLI.md) for full CLI documentation.
 
+### Checking for updates
+
+After installing, check for newer releases at any time:
+
+```bash
+xcodebuildmcp upgrade --check
+```
+
+Homebrew and npm-global installs can auto-upgrade with `xcodebuildmcp upgrade --yes`. npx users don't need to upgrade explicitly — `@latest` resolves the newest version on each run. If you pinned a specific version in your MCP client config, update the version there instead.
+
 ## Project config (optional)
 For deterministic session defaults and runtime configuration, add a config file at:
 

--- a/scripts/check-docs-cli-commands.js
+++ b/scripts/check-docs-cli-commands.js
@@ -125,7 +125,7 @@ function extractCommandCandidates(content) {
 }
 
 function findInvalidCommands(files, validPairs, validWorkflows) {
-  const validTopLevel = new Set(['mcp', 'tools', 'daemon', 'init', 'setup']);
+  const validTopLevel = new Set(['mcp', 'tools', 'daemon', 'init', 'setup', 'upgrade']);
   const validDaemonActions = new Set(['status', 'start', 'stop', 'restart', 'list']);
   const findings = [];
 

--- a/scripts/generate-version.ts
+++ b/scripts/generate-version.ts
@@ -2,9 +2,21 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 interface PackageJson {
+  name: string;
   version: string;
   iOSTemplateVersion: string;
   macOSTemplateVersion: string;
+  repository?: {
+    url?: string;
+  };
+}
+
+function parseGitHubOwnerAndName(url: string): { owner: string; name: string } {
+  const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+  if (!match) {
+    throw new Error(`Cannot parse GitHub owner/name from repository URL: ${url}`);
+  }
+  return { owner: match[1], name: match[2] };
 }
 
 async function main(): Promise<void> {
@@ -15,10 +27,20 @@ async function main(): Promise<void> {
   const raw = await readFile(packagePath, 'utf8');
   const pkg = JSON.parse(raw) as PackageJson;
 
+  const repoUrl = pkg.repository?.url;
+  if (!repoUrl) {
+    throw new Error('package.json must have a repository.url field');
+  }
+
+  const repo = parseGitHubOwnerAndName(repoUrl);
+
   const content =
     `export const version = '${pkg.version}';\n` +
     `export const iOSTemplateVersion = '${pkg.iOSTemplateVersion}';\n` +
-    `export const macOSTemplateVersion = '${pkg.macOSTemplateVersion}';\n`;
+    `export const macOSTemplateVersion = '${pkg.macOSTemplateVersion}';\n` +
+    `export const packageName = '${pkg.name}';\n` +
+    `export const repositoryOwner = '${repo.owner}';\n` +
+    `export const repositoryName = '${repo.name}';\n`;
 
   await writeFile(versionPath, content, 'utf8');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,6 +80,13 @@ async function runSetupCommand(): Promise<void> {
   await app.parseAsync();
 }
 
+async function runUpgradeCommand(): Promise<void> {
+  const { registerUpgradeCommand } = await import('./cli/commands/upgrade.ts');
+  const app = await buildLightweightYargsApp();
+  registerUpgradeCommand(app);
+  await app.parseAsync();
+}
+
 async function main(): Promise<void> {
   const cliBootstrapStartedAt = Date.now();
   const earlyCommand = findTopLevelCommand(process.argv.slice(2));
@@ -93,6 +100,10 @@ async function main(): Promise<void> {
   }
   if (earlyCommand === 'setup') {
     await runSetupCommand();
+    return;
+  }
+  if (earlyCommand === 'upgrade') {
+    await runUpgradeCommand();
     return;
   }
 

--- a/src/cli/commands/__tests__/upgrade.test.ts
+++ b/src/cli/commands/__tests__/upgrade.test.ts
@@ -202,6 +202,24 @@ describe('upgrade command', () => {
       });
     });
 
+    it('parses prerelease with hyphenated identifier', () => {
+      expect(parseVersion('1.0.0-alpha-1')).toEqual({
+        major: 1,
+        minor: 0,
+        patch: 0,
+        prerelease: 'alpha-1',
+      });
+    });
+
+    it('parses hyphenated prerelease with hyphenated build metadata', () => {
+      expect(parseVersion('1.0.0-rc-1+build-hash')).toEqual({
+        major: 1,
+        minor: 0,
+        patch: 0,
+        prerelease: 'rc-1',
+      });
+    });
+
     it.each([['not-a-version'], ['1.2'], [''], ['1.2.3.4'], ['abc.def.ghi']])(
       'returns undefined for malformed input %j',
       (input) => {
@@ -939,6 +957,19 @@ describe('upgrade command', () => {
         expect(code).toBe(1);
         expect(collectStderr(stderrSpy)).toContain('Homebrew');
         expect(collectStderr(stderrSpy)).toContain('invalid JSON');
+      });
+
+      it('homebrew: exits 1 when brew info exits non-zero', async () => {
+        const deps = channelDeps(homebrewMethod(), {
+          stdout: '',
+          stderr: 'Error: Permission denied',
+          exitCode: 1,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Homebrew');
+        expect(collectStderr(stderrSpy)).toContain('exited with code 1');
       });
 
       it('npm-global: exits 1 when npm view exits non-zero', async () => {

--- a/src/cli/commands/__tests__/upgrade.test.ts
+++ b/src/cli/commands/__tests__/upgrade.test.ts
@@ -1,0 +1,820 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+    warn: vi.fn(),
+  },
+  note: vi.fn(),
+  confirm: vi.fn().mockResolvedValue(true),
+  isCancel: vi.fn(() => false),
+}));
+
+import * as clack from '@clack/prompts';
+import {
+  runUpgradeCommand,
+  parseVersion,
+  compareVersions,
+  detectInstallMethodFromPaths,
+  truncateReleaseNotes,
+  type LatestReleaseInfo,
+  type UpgradeDependencies,
+  type InstallMethod,
+} from '../upgrade.ts';
+
+const mockedConfirm = vi.mocked(clack.confirm);
+const mockedIsCancel = vi.mocked(clack.isCancel);
+
+// --- Fixtures ---
+
+function createMockRelease(overrides?: Partial<LatestReleaseInfo>): LatestReleaseInfo {
+  return {
+    tagName: 'v3.0.0',
+    version: '3.0.0',
+    name: 'Release 3.0.0',
+    body: 'Bug fixes and improvements.',
+    htmlUrl: 'https://github.com/getsentry/XcodeBuildMCP/releases/tag/v3.0.0',
+    publishedAt: '2025-01-15T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function homebrewMethod(): InstallMethod {
+  return {
+    kind: 'homebrew',
+    manualCommand: 'brew update && brew upgrade xcodebuildmcp',
+    autoCommands: [
+      ['brew', 'update'],
+      ['brew', 'upgrade', 'xcodebuildmcp'],
+    ],
+  };
+}
+
+function npmGlobalMethod(): InstallMethod {
+  return {
+    kind: 'npm-global',
+    manualCommand: 'npm install -g xcodebuildmcp@latest',
+    autoCommands: [['npm', 'install', '-g', 'xcodebuildmcp@latest']],
+  };
+}
+
+function npxMethod(): InstallMethod {
+  return {
+    kind: 'npx',
+    manualInstructions: [
+      'npx always fetches the latest version by default when using @latest.',
+      'If you pinned a specific version, update the version in your MCP client config.',
+    ],
+  };
+}
+
+function unknownMethod(): InstallMethod {
+  return {
+    kind: 'unknown',
+    manualInstructions: [
+      'Homebrew:   brew update && brew upgrade xcodebuildmcp',
+      'npm:        npm install -g xcodebuildmcp@latest',
+      'npx:        npx always fetches the latest when using @latest',
+    ],
+  };
+}
+
+function baseDeps(overrides?: Partial<UpgradeDependencies>): Partial<UpgradeDependencies> {
+  return {
+    currentVersion: '2.0.0',
+    packageName: 'xcodebuildmcp',
+    repositoryOwner: 'getsentry',
+    repositoryName: 'XcodeBuildMCP',
+    fetchLatestRelease: vi.fn(async () => createMockRelease()),
+    detectInstallMethod: vi.fn(() => homebrewMethod()),
+    spawnUpgradeProcess: vi.fn(async () => 0),
+    isInteractive: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+function collectStdout(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((c) => String(c[0])).join('');
+}
+
+function collectStderr(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((c) => String(c[0])).join('');
+}
+
+// --- Tests ---
+
+describe('upgrade command', () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockedConfirm.mockResolvedValue(true);
+    mockedIsCancel.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  // ── Pure helpers ──────────────────────────────────────────────────────
+
+  describe('parseVersion', () => {
+    it('parses standard version', () => {
+      expect(parseVersion('1.2.3')).toEqual({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: undefined,
+      });
+    });
+
+    it('strips leading v', () => {
+      expect(parseVersion('v1.2.3')).toEqual({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: undefined,
+      });
+    });
+
+    it('parses prerelease suffix', () => {
+      expect(parseVersion('1.2.3-beta.1')).toEqual({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: 'beta.1',
+      });
+    });
+
+    it('ignores build metadata', () => {
+      expect(parseVersion('1.2.3+build.42')).toEqual({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: undefined,
+      });
+    });
+
+    it('parses prerelease with build metadata', () => {
+      expect(parseVersion('1.2.3-rc.1+build')).toEqual({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: 'rc.1',
+      });
+    });
+
+    it.each([['not-a-version'], ['1.2'], [''], ['1.2.3.4'], ['abc.def.ghi']])(
+      'returns undefined for malformed input %j',
+      (input) => {
+        expect(parseVersion(input)).toBeUndefined();
+      },
+    );
+  });
+
+  describe('compareVersions', () => {
+    it('detects equal versions', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 2, patch: 3, prerelease: undefined },
+          { major: 1, minor: 2, patch: 3, prerelease: undefined },
+        ),
+      ).toBe('equal');
+    });
+
+    it('detects older by major', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: undefined },
+          { major: 2, minor: 0, patch: 0, prerelease: undefined },
+        ),
+      ).toBe('older');
+    });
+
+    it('detects newer by minor', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 5, patch: 0, prerelease: undefined },
+          { major: 1, minor: 3, patch: 0, prerelease: undefined },
+        ),
+      ).toBe('newer');
+    });
+
+    it('detects older by patch', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 2, patch: 3, prerelease: undefined },
+          { major: 1, minor: 2, patch: 5, prerelease: undefined },
+        ),
+      ).toBe('older');
+    });
+
+    it('prerelease is older than release at same version', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta.1' },
+          { major: 1, minor: 0, patch: 0, prerelease: undefined },
+        ),
+      ).toBe('older');
+    });
+
+    it('release is newer than prerelease at same version', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: undefined },
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta.1' },
+        ),
+      ).toBe('newer');
+    });
+
+    it('compares numeric prerelease identifiers numerically', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta.2' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta.10' },
+        ),
+      ).toBe('older');
+    });
+
+    it('compares string prerelease identifiers lexicographically', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'alpha' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta' },
+        ),
+      ).toBe('older');
+    });
+
+    it('numeric prerelease identifier is less than string identifier', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: '1' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'alpha' },
+        ),
+      ).toBe('older');
+    });
+
+    it('fewer prerelease parts is less than more parts', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'beta.1' },
+        ),
+      ).toBe('older');
+    });
+
+    it('equal prerelease identifiers are equal', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'rc.1' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'rc.1' },
+        ),
+      ).toBe('equal');
+    });
+  });
+
+  describe('detectInstallMethodFromPaths', () => {
+    it('detects homebrew on Intel Mac (/usr/local/Cellar)', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/usr/local/Cellar/xcodebuildmcp/2.0.0/bin/xcodebuildmcp',
+      ]);
+      expect(method.kind).toBe('homebrew');
+    });
+
+    it('detects homebrew on Apple Silicon (/opt/homebrew/Cellar)', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/opt/homebrew/Cellar/xcodebuildmcp/2.0.0/bin/xcodebuildmcp',
+      ]);
+      expect(method.kind).toBe('homebrew');
+    });
+
+    it('produces correct homebrew auto commands', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/opt/homebrew/Cellar/xcodebuildmcp/2.0.0/bin/xcodebuildmcp',
+      ]);
+      expect(method.kind).toBe('homebrew');
+      if (method.kind === 'homebrew') {
+        expect(method.autoCommands).toEqual([
+          ['brew', 'update'],
+          ['brew', 'upgrade', 'xcodebuildmcp'],
+        ]);
+      }
+    });
+
+    it('detects npm-global install', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/usr/local/lib/node_modules/xcodebuildmcp/build/cli.js',
+      ]);
+      expect(method.kind).toBe('npm-global');
+      if (method.kind === 'npm-global') {
+        expect(method.autoCommands).toEqual([['npm', 'install', '-g', 'xcodebuildmcp@latest']]);
+      }
+    });
+
+    it('detects npx from _npx cache path', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/Users/cam/.npm/_npx/abc123/node_modules/xcodebuildmcp/build/cli.js',
+      ]);
+      expect(method.kind).toBe('npx');
+    });
+
+    it('classifies npx before npm-global when path contains _npx and node_modules', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/Users/cam/.npm/_npx/12345/node_modules/xcodebuildmcp/build/cli.js',
+      ]);
+      expect(method.kind).toBe('npx');
+    });
+
+    it('returns unknown for unrecognized paths', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/some/custom/path/xcodebuildmcp',
+      ]);
+      expect(method.kind).toBe('unknown');
+    });
+
+    it('returns unknown for empty candidate list', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', []);
+      expect(method.kind).toBe('unknown');
+    });
+
+    it('matches case-insensitively', () => {
+      const method = detectInstallMethodFromPaths('xcodebuildmcp', [
+        '/opt/Homebrew/Cellar/XcodeBuildMCP/2.0.0/bin/xcodebuildmcp',
+      ]);
+      expect(method.kind).toBe('homebrew');
+    });
+  });
+
+  describe('truncateReleaseNotes', () => {
+    const url = 'https://example.com/release';
+
+    it('returns full text when under both limits', () => {
+      const body = 'Line 1\nLine 2\nLine 3';
+      const result = truncateReleaseNotes(body, url);
+      expect(result).not.toContain('(truncated)');
+      expect(result).toContain('Line 1\nLine 2\nLine 3');
+      expect(result).toContain(`Full release notes: ${url}`);
+    });
+
+    it('truncates at 20 lines', () => {
+      const lines = Array.from({ length: 30 }, (_, i) => `Line ${i + 1}`);
+      const body = lines.join('\n');
+      const result = truncateReleaseNotes(body, url);
+      expect(result).toContain('... (truncated)');
+      expect(result).toContain('Line 20');
+      expect(result).not.toContain('Line 21');
+    });
+
+    it('truncates at 2000 characters', () => {
+      const longLine = 'x'.repeat(300);
+      const lines = Array.from({ length: 10 }, () => longLine);
+      const body = lines.join('\n');
+      const result = truncateReleaseNotes(body, url);
+      expect(result).toContain('... (truncated)');
+      const beforeMarker = result.split('\n\n... (truncated)')[0];
+      expect(beforeMarker.length).toBeLessThanOrEqual(2000);
+    });
+
+    it('returns only the URL for empty body', () => {
+      const result = truncateReleaseNotes('', url);
+      expect(result).toBe(`Full release notes: ${url}`);
+    });
+
+    it('normalizes CRLF line endings', () => {
+      const body = 'Line 1\r\nLine 2\r\nLine 3';
+      const result = truncateReleaseNotes(body, url);
+      expect(result).toContain('Line 1\nLine 2\nLine 3');
+      expect(result).not.toContain('\r');
+    });
+  });
+
+  // ── Command flow ──────────────────────────────────────────────────────
+
+  describe('runUpgradeCommand', () => {
+    describe('up to date', () => {
+      it('exits 0 when versions match (non-TTY)', async () => {
+        const deps = baseDeps({
+          currentVersion: '3.0.0',
+          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Already up to date');
+      });
+
+      it('exits 0 when versions match (TTY)', async () => {
+        const deps = baseDeps({
+          currentVersion: '3.0.0',
+          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+          isInteractive: vi.fn(() => true),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(clack.log.success).toHaveBeenCalledWith(
+          expect.stringContaining('Already up to date'),
+        );
+      });
+    });
+
+    describe('local version newer', () => {
+      it('exits 0 without offering a downgrade', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          currentVersion: '4.0.0',
+          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('ahead of latest');
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('--check mode', () => {
+      it('exits 0 and shows update info without upgrading (non-TTY)', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({ spawnUpgradeProcess: spawnMock });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Update available');
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+
+      it('exits 0 in TTY mode without prompting', async () => {
+        const deps = baseDeps({ isInteractive: vi.fn(() => true) });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(clack.confirm).not.toHaveBeenCalled();
+      });
+
+      it('--check overrides --yes', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({ spawnUpgradeProcess: spawnMock });
+
+        const code = await runUpgradeCommand({ check: true, yes: true }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('homebrew install method', () => {
+      it('runs upgrade with --yes and verifies exact argv arrays', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: true }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).toHaveBeenCalledWith([
+          ['brew', 'update'],
+          ['brew', 'upgrade', 'xcodebuildmcp'],
+        ]);
+      });
+
+      it('prompts in TTY and runs upgrade when confirmed', async () => {
+        mockedConfirm.mockResolvedValue(true);
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(clack.confirm).toHaveBeenCalled();
+        expect(spawnMock).toHaveBeenCalled();
+      });
+
+      it('exits 0 without running when TTY confirm is declined', async () => {
+        mockedConfirm.mockResolvedValue(false);
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+
+      it('exits 0 without running when TTY confirm is cancelled', async () => {
+        mockedConfirm.mockResolvedValue(Symbol('cancel') as unknown as boolean);
+        mockedIsCancel.mockReturnValue(true);
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+
+      it('non-TTY without --yes exits 1 and suggests --yes', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(spawnMock).not.toHaveBeenCalled();
+        expect(collectStdout(stdoutSpy)).toContain('--yes');
+      });
+
+      it('propagates non-zero exit code from upgrade process', async () => {
+        const spawnMock = vi.fn(async () => 42);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: true }, deps);
+        expect(code).toBe(42);
+      });
+    });
+
+    describe('npm-global install method', () => {
+      it('runs upgrade with --yes and verifies exact argv array', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => npmGlobalMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: true }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).toHaveBeenCalledWith([['npm', 'install', '-g', 'xcodebuildmcp@latest']]);
+      });
+
+      it('non-TTY without --yes exits 1', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => npmGlobalMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+
+      it('prompts in TTY and runs upgrade when confirmed', async () => {
+        mockedConfirm.mockResolvedValue(true);
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          detectInstallMethod: vi.fn(() => npmGlobalMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).toHaveBeenCalled();
+      });
+    });
+
+    describe('npx install method', () => {
+      it('exits 0 with --yes without spawning', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => npxMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: true }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+
+      it('explains ephemeral install limitation (non-TTY)', async () => {
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => npxMethod()),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('npx always fetches the latest');
+      });
+
+      it('explains ephemeral install limitation (TTY)', async () => {
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          detectInstallMethod: vi.fn(() => npxMethod()),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(clack.log.info).toHaveBeenCalledWith(
+          expect.stringContaining('npx always fetches the latest'),
+        );
+      });
+    });
+
+    describe('unknown install method', () => {
+      it('exits 0 and shows manual options', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => unknownMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+        expect(collectStdout(stdoutSpy)).toContain('Could not detect install method');
+      });
+
+      it('no auto-run even with --yes', async () => {
+        const spawnMock = vi.fn(async () => 0);
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => unknownMethod()),
+          spawnUpgradeProcess: spawnMock,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: true }, deps);
+        expect(code).toBe(0);
+        expect(spawnMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('GitHub API failures', () => {
+      it('exits 1 on network error', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('fetch failed');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('fetch failed');
+      });
+
+      it('exits 1 on timeout', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('Request timed out after 10 seconds');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('timed out');
+      });
+
+      it('exits 1 on rate limit (403)', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('GitHub API rate limit exceeded. Try again later.');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('rate limit');
+      });
+
+      it('exits 1 on non-200 response', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('GitHub API returned HTTP 500');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('HTTP 500');
+      });
+
+      it('exits 1 on missing tag_name', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('GitHub release response missing tag_name');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('missing tag_name');
+      });
+
+      it('shows manual upgrade command on failure when install method is known', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('network error');
+          }),
+          detectInstallMethod: vi.fn(() => homebrewMethod()),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStdout(stdoutSpy)).toContain('brew update && brew upgrade xcodebuildmcp');
+      });
+
+      it('shows failure info via clack in TTY mode', async () => {
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          fetchLatestRelease: vi.fn(async () => {
+            throw new Error('GitHub release response missing tag_name');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(clack.log.error).toHaveBeenCalledWith(expect.stringContaining('missing tag_name'));
+      });
+    });
+
+    describe('version parse errors', () => {
+      it('exits 1 when current version is malformed', async () => {
+        const deps = baseDeps({
+          currentVersion: 'bad',
+          fetchLatestRelease: vi.fn(async () => createMockRelease()),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Cannot compare versions');
+      });
+
+      it('exits 1 when latest version is malformed', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: 'invalid' })),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Cannot compare versions');
+      });
+
+      it('exits 1 via clack in TTY mode for malformed versions', async () => {
+        const deps = baseDeps({
+          isInteractive: vi.fn(() => true),
+          currentVersion: 'garbage',
+          fetchLatestRelease: vi.fn(async () => createMockRelease()),
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(clack.log.error).toHaveBeenCalledWith(
+          expect.stringContaining('Cannot compare versions'),
+        );
+      });
+    });
+
+    describe('release notes in output', () => {
+      it('includes release notes and URL when update is available (non-TTY)', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () =>
+            createMockRelease({ body: 'Fixed a critical bug.' }),
+          ),
+        });
+
+        await runUpgradeCommand({ check: true, yes: false }, deps);
+        const stdout = collectStdout(stdoutSpy);
+        expect(stdout).toContain('Fixed a critical bug.');
+        expect(stdout).toContain('Full release notes:');
+      });
+
+      it('includes published date when available', async () => {
+        const deps = baseDeps({
+          fetchLatestRelease: vi.fn(async () =>
+            createMockRelease({ publishedAt: '2025-06-01T10:00:00Z' }),
+          ),
+        });
+
+        await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(collectStdout(stdoutSpy)).toContain('Published: 2025-06-01');
+      });
+    });
+  });
+});

--- a/src/cli/commands/__tests__/upgrade.test.ts
+++ b/src/cli/commands/__tests__/upgrade.test.ts
@@ -301,6 +301,15 @@ describe('upgrade command', () => {
       ).toBe('older');
     });
 
+    it('compares prerelease identifiers in ASCII order (uppercase before lowercase)', () => {
+      expect(
+        compareVersions(
+          { major: 1, minor: 0, patch: 0, prerelease: 'Alpha' },
+          { major: 1, minor: 0, patch: 0, prerelease: 'alpha' },
+        ),
+      ).toBe('older');
+    });
+
     it('numeric prerelease identifier is less than string identifier', () => {
       expect(
         compareVersions(

--- a/src/cli/commands/__tests__/upgrade.test.ts
+++ b/src/cli/commands/__tests__/upgrade.test.ts
@@ -27,7 +27,8 @@ import {
   compareVersions,
   detectInstallMethodFromPaths,
   truncateReleaseNotes,
-  type LatestReleaseInfo,
+  type ReleaseNotes,
+  type ChannelLookupResult,
   type UpgradeDependencies,
   type InstallMethod,
 } from '../upgrade.ts';
@@ -37,13 +38,11 @@ const mockedIsCancel = vi.mocked(clack.isCancel);
 
 // --- Fixtures ---
 
-function createMockRelease(overrides?: Partial<LatestReleaseInfo>): LatestReleaseInfo {
+function createMockReleaseNotes(overrides?: Partial<ReleaseNotes>): ReleaseNotes {
   return {
-    tagName: 'v3.0.0',
-    version: '3.0.0',
-    name: 'Release 3.0.0',
     body: 'Bug fixes and improvements.',
     htmlUrl: 'https://github.com/getsentry/XcodeBuildMCP/releases/tag/v3.0.0',
+    name: 'Release 3.0.0',
     publishedAt: '2025-01-15T12:00:00Z',
     ...overrides,
   };
@@ -95,7 +94,9 @@ function baseDeps(overrides?: Partial<UpgradeDependencies>): Partial<UpgradeDepe
     packageName: 'xcodebuildmcp',
     repositoryOwner: 'getsentry',
     repositoryName: 'XcodeBuildMCP',
-    fetchLatestRelease: vi.fn(async () => createMockRelease()),
+    fetchLatestVersionForChannel: vi.fn(async () => '3.0.0'),
+    fetchReleaseNotesForTag: vi.fn(async () => createMockReleaseNotes()),
+    runChannelLookupCommand: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
     detectInstallMethod: vi.fn(() => homebrewMethod()),
     spawnUpgradeProcess: vi.fn(async () => 0),
     isInteractive: vi.fn(() => false),
@@ -103,11 +104,34 @@ function baseDeps(overrides?: Partial<UpgradeDependencies>): Partial<UpgradeDepe
   };
 }
 
-function collectStdout(spy: ReturnType<typeof vi.spyOn>): string {
+/**
+ * Create deps that do NOT provide fetchLatestVersionForChannel so the default
+ * channel fetcher is rebuilt using the mocked runChannelLookupCommand.
+ */
+function channelDeps(
+  method: InstallMethod,
+  lookupResult: ChannelLookupResult,
+  overrides?: Partial<UpgradeDependencies>,
+): Partial<UpgradeDependencies> {
+  return {
+    currentVersion: '2.0.0',
+    packageName: 'xcodebuildmcp',
+    repositoryOwner: 'getsentry',
+    repositoryName: 'XcodeBuildMCP',
+    runChannelLookupCommand: vi.fn(async () => lookupResult),
+    fetchReleaseNotesForTag: vi.fn(async () => createMockReleaseNotes()),
+    detectInstallMethod: vi.fn(() => method),
+    spawnUpgradeProcess: vi.fn(async () => 0),
+    isInteractive: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+function collectStdout(spy: MockInstance): string {
   return spy.mock.calls.map((c) => String(c[0])).join('');
 }
 
-function collectStderr(spy: ReturnType<typeof vi.spyOn>): string {
+function collectStderr(spy: MockInstance): string {
   return spy.mock.calls.map((c) => String(c[0])).join('');
 }
 
@@ -409,7 +433,7 @@ describe('upgrade command', () => {
       it('exits 0 when versions match (non-TTY)', async () => {
         const deps = baseDeps({
           currentVersion: '3.0.0',
-          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+          fetchLatestVersionForChannel: vi.fn(async () => '3.0.0'),
         });
 
         const code = await runUpgradeCommand({ check: false, yes: false }, deps);
@@ -420,7 +444,7 @@ describe('upgrade command', () => {
       it('exits 0 when versions match (TTY)', async () => {
         const deps = baseDeps({
           currentVersion: '3.0.0',
-          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+          fetchLatestVersionForChannel: vi.fn(async () => '3.0.0'),
           isInteractive: vi.fn(() => true),
         });
 
@@ -437,7 +461,7 @@ describe('upgrade command', () => {
         const spawnMock = vi.fn(async () => 0);
         const deps = baseDeps({
           currentVersion: '4.0.0',
-          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: '3.0.0' })),
+          fetchLatestVersionForChannel: vi.fn(async () => '3.0.0'),
           spawnUpgradeProcess: spawnMock,
         });
 
@@ -666,11 +690,11 @@ describe('upgrade command', () => {
       });
     });
 
-    describe('GitHub API failures', () => {
+    describe('channel lookup failures', () => {
       it('exits 1 on network error', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('fetch failed');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from npm: fetch failed");
           }),
         });
 
@@ -681,8 +705,8 @@ describe('upgrade command', () => {
 
       it('exits 1 on timeout', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('Request timed out after 10 seconds');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from npm: request timed out");
           }),
         });
 
@@ -691,10 +715,10 @@ describe('upgrade command', () => {
         expect(collectStderr(stderrSpy)).toContain('timed out');
       });
 
-      it('exits 1 on rate limit (403)', async () => {
+      it('exits 1 on rate limit', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('GitHub API rate limit exceeded. Try again later.');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from GitHub: rate limit exceeded");
           }),
         });
 
@@ -703,10 +727,10 @@ describe('upgrade command', () => {
         expect(collectStderr(stderrSpy)).toContain('rate limit');
       });
 
-      it('exits 1 on non-200 response', async () => {
+      it('exits 1 on HTTP error', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('GitHub API returned HTTP 500');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from GitHub: HTTP 500");
           }),
         });
 
@@ -717,8 +741,8 @@ describe('upgrade command', () => {
 
       it('exits 1 on missing tag_name', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('GitHub release response missing tag_name');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from GitHub: missing tag_name");
           }),
         });
 
@@ -729,8 +753,8 @@ describe('upgrade command', () => {
 
       it('shows manual upgrade command on failure when install method is known', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('network error');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from Homebrew: network error");
           }),
           detectInstallMethod: vi.fn(() => homebrewMethod()),
         });
@@ -743,8 +767,8 @@ describe('upgrade command', () => {
       it('shows failure info via clack in TTY mode', async () => {
         const deps = baseDeps({
           isInteractive: vi.fn(() => true),
-          fetchLatestRelease: vi.fn(async () => {
-            throw new Error('GitHub release response missing tag_name');
+          fetchLatestVersionForChannel: vi.fn(async () => {
+            throw new Error("couldn't determine latest version from GitHub: missing tag_name");
           }),
         });
 
@@ -758,7 +782,6 @@ describe('upgrade command', () => {
       it('exits 1 when current version is malformed', async () => {
         const deps = baseDeps({
           currentVersion: 'bad',
-          fetchLatestRelease: vi.fn(async () => createMockRelease()),
         });
 
         const code = await runUpgradeCommand({ check: false, yes: false }, deps);
@@ -768,7 +791,7 @@ describe('upgrade command', () => {
 
       it('exits 1 when latest version is malformed', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () => createMockRelease({ version: 'invalid' })),
+          fetchLatestVersionForChannel: vi.fn(async () => 'invalid'),
         });
 
         const code = await runUpgradeCommand({ check: false, yes: false }, deps);
@@ -780,7 +803,6 @@ describe('upgrade command', () => {
         const deps = baseDeps({
           isInteractive: vi.fn(() => true),
           currentVersion: 'garbage',
-          fetchLatestRelease: vi.fn(async () => createMockRelease()),
         });
 
         const code = await runUpgradeCommand({ check: false, yes: false }, deps);
@@ -794,8 +816,8 @@ describe('upgrade command', () => {
     describe('release notes in output', () => {
       it('includes release notes and URL when update is available (non-TTY)', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () =>
-            createMockRelease({ body: 'Fixed a critical bug.' }),
+          fetchReleaseNotesForTag: vi.fn(async () =>
+            createMockReleaseNotes({ body: 'Fixed a critical bug.' }),
           ),
         });
 
@@ -807,13 +829,185 @@ describe('upgrade command', () => {
 
       it('includes published date when available', async () => {
         const deps = baseDeps({
-          fetchLatestRelease: vi.fn(async () =>
-            createMockRelease({ publishedAt: '2025-06-01T10:00:00Z' }),
+          fetchReleaseNotesForTag: vi.fn(async () =>
+            createMockReleaseNotes({ publishedAt: '2025-06-01T10:00:00Z' }),
           ),
         });
 
         await runUpgradeCommand({ check: true, yes: false }, deps);
         expect(collectStdout(stdoutSpy)).toContain('Published: 2025-06-01');
+      });
+
+      it('shows fallback URL when notes return null (tag not released)', async () => {
+        const deps = baseDeps({
+          fetchReleaseNotesForTag: vi.fn(async () => null),
+        });
+
+        await runUpgradeCommand({ check: true, yes: false }, deps);
+        const stdout = collectStdout(stdoutSpy);
+        expect(stdout).toContain('Release notes:');
+        expect(stdout).toContain('github.com');
+      });
+
+      it('continues without notes when fetch throws (network failure)', async () => {
+        const deps = baseDeps({
+          fetchReleaseNotesForTag: vi.fn(async () => {
+            throw new Error('network error');
+          }),
+        });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Update available');
+        expect(collectStdout(stdoutSpy)).toContain('Release notes:');
+      });
+    });
+
+    // ── Channel-specific version lookup ───────────────────────────────
+
+    describe('channel-specific version lookup', () => {
+      it('npm-global: parses version from npm view JSON output', async () => {
+        const deps = channelDeps(npmGlobalMethod(), {
+          stdout: '"3.0.0"\n',
+          stderr: '',
+          exitCode: 0,
+        });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Update available');
+        expect(collectStdout(stdoutSpy)).toContain('3.0.0');
+      });
+
+      it('npx: uses npm view for version lookup', async () => {
+        const runner = vi.fn(async () => ({
+          stdout: '"3.0.0"\n',
+          stderr: '',
+          exitCode: 0,
+        }));
+        const deps = channelDeps(
+          npxMethod(),
+          { stdout: '', stderr: '', exitCode: 0 },
+          {
+            runChannelLookupCommand: runner,
+          },
+        );
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(runner).toHaveBeenCalledWith(expect.arrayContaining(['npm', 'view']));
+      });
+
+      it('homebrew: parses version from brew info JSON output', async () => {
+        const brewOutput = JSON.stringify({
+          formulae: [{ versions: { stable: '3.0.0' } }],
+        });
+        const deps = channelDeps(homebrewMethod(), {
+          stdout: brewOutput,
+          stderr: '',
+          exitCode: 0,
+        });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Update available');
+        expect(collectStdout(stdoutSpy)).toContain('3.0.0');
+      });
+
+      it('homebrew: exits 1 when formula is not found (empty formulae array)', async () => {
+        const brewOutput = JSON.stringify({ formulae: [] });
+        const deps = channelDeps(homebrewMethod(), {
+          stdout: brewOutput,
+          stderr: 'Error: No available formula with the name "xcodebuildmcp"',
+          exitCode: 0,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Homebrew');
+        expect(collectStderr(stderrSpy)).toContain('tap installed');
+      });
+
+      it('homebrew: exits 1 on invalid JSON output', async () => {
+        const deps = channelDeps(homebrewMethod(), {
+          stdout: 'not valid json at all',
+          stderr: '',
+          exitCode: 0,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Homebrew');
+        expect(collectStderr(stderrSpy)).toContain('invalid JSON');
+      });
+
+      it('npm-global: exits 1 when npm view exits non-zero', async () => {
+        const deps = channelDeps(npmGlobalMethod(), {
+          stdout: '',
+          stderr: 'npm ERR! 404 Not Found',
+          exitCode: 1,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('npm');
+        expect(collectStderr(stderrSpy)).toContain('exited with code 1');
+      });
+
+      it('npm-global: exits 1 on invalid JSON output', async () => {
+        const deps = channelDeps(npmGlobalMethod(), {
+          stdout: 'not json',
+          stderr: '',
+          exitCode: 0,
+        });
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('npm');
+        expect(collectStderr(stderrSpy)).toContain('invalid JSON');
+      });
+
+      it('unknown: falls through to GitHub (mocked at fetchLatestVersionForChannel)', async () => {
+        const deps = baseDeps({
+          detectInstallMethod: vi.fn(() => unknownMethod()),
+          fetchLatestVersionForChannel: vi.fn(async () => '3.0.0'),
+        });
+
+        const code = await runUpgradeCommand({ check: true, yes: false }, deps);
+        expect(code).toBe(0);
+        expect(collectStdout(stdoutSpy)).toContain('Update available');
+      });
+
+      it('homebrew: exits 1 on lookup timeout', async () => {
+        const runner = vi
+          .fn()
+          .mockRejectedValue(new Error('Command timed out after 15 seconds: brew'));
+        const deps = channelDeps(
+          homebrewMethod(),
+          { stdout: '', stderr: '', exitCode: 0 },
+          { runChannelLookupCommand: runner },
+        );
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('Homebrew');
+        expect(collectStderr(stderrSpy)).toContain('timed out');
+      });
+
+      it('npm-global: exits 1 on lookup timeout', async () => {
+        const runner = vi
+          .fn()
+          .mockRejectedValue(new Error('Command timed out after 15 seconds: npm'));
+        const deps = channelDeps(
+          npmGlobalMethod(),
+          { stdout: '', stderr: '', exitCode: 0 },
+          { runChannelLookupCommand: runner },
+        );
+
+        const code = await runUpgradeCommand({ check: false, yes: false }, deps);
+        expect(code).toBe(1);
+        expect(collectStderr(stderrSpy)).toContain('npm');
+        expect(collectStderr(stderrSpy)).toContain('timed out');
       });
     });
   });

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -69,7 +69,7 @@ export interface UpgradeOptions {
 
 export function parseVersion(raw: string): ParsedVersion | undefined {
   const stripped = raw.startsWith('v') ? raw.slice(1) : raw;
-  const match = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.]+))?(?:\+[a-zA-Z0-9.]+)?$/);
+  const match = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.-]+))?(?:\+[a-zA-Z0-9.-]+)?$/);
   if (!match) return undefined;
   return {
     major: Number(match[1]),
@@ -256,6 +256,12 @@ async function fetchLatestVersionFromHomebrew(
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`couldn't determine latest version from Homebrew: ${reason}`);
+  }
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `couldn't determine latest version from Homebrew: command exited with code ${result.exitCode}`,
+    );
   }
 
   let data: unknown;

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,0 +1,624 @@
+import type { Argv } from 'yargs';
+import * as fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import * as clack from '@clack/prompts';
+import {
+  version as currentVersion,
+  packageName,
+  repositoryOwner,
+  repositoryName,
+} from '../../utils/version/index.ts';
+import { isInteractiveTTY } from '../interactive/prompts.ts';
+
+// --- Types ---
+
+interface AutoUpgradeMethod {
+  kind: 'homebrew' | 'npm-global';
+  manualCommand: string;
+  autoCommands: string[][];
+}
+
+interface ManualOnlyMethod {
+  kind: 'npx' | 'unknown';
+  manualInstructions: string[];
+}
+
+export type InstallMethod = AutoUpgradeMethod | ManualOnlyMethod;
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | undefined;
+}
+
+export type VersionComparison = 'older' | 'equal' | 'newer';
+
+export interface LatestReleaseInfo {
+  tagName: string;
+  version: string;
+  name: string | undefined;
+  body: string;
+  htmlUrl: string;
+  publishedAt: string | undefined;
+}
+
+export interface UpgradeDependencies {
+  currentVersion: string;
+  packageName: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  fetchLatestRelease: () => Promise<LatestReleaseInfo>;
+  detectInstallMethod: () => InstallMethod;
+  spawnUpgradeProcess: (commands: string[][]) => Promise<number>;
+  isInteractive: () => boolean;
+}
+
+export interface UpgradeOptions {
+  check: boolean;
+  yes: boolean;
+}
+
+// --- Version comparison ---
+
+export function parseVersion(raw: string): ParsedVersion | undefined {
+  const stripped = raw.startsWith('v') ? raw.slice(1) : raw;
+  const match = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.]+))?(?:\+[a-zA-Z0-9.]+)?$/);
+  if (!match) return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4],
+  };
+}
+
+function comparePrereleaseIdentifiers(a: string, b: string): number {
+  const aParts = a.split('.');
+  const bParts = b.split('.');
+  const len = Math.max(aParts.length, bParts.length);
+
+  for (let i = 0; i < len; i++) {
+    if (i >= aParts.length) return -1;
+    if (i >= bParts.length) return 1;
+
+    const aIsNum = /^\d+$/.test(aParts[i]);
+    const bIsNum = /^\d+$/.test(bParts[i]);
+
+    if (aIsNum && bIsNum) {
+      const diff = Number(aParts[i]) - Number(bParts[i]);
+      if (diff !== 0) return diff;
+      continue;
+    }
+
+    if (aIsNum) return -1;
+    if (bIsNum) return 1;
+
+    const cmp = aParts[i].localeCompare(bParts[i]);
+    if (cmp !== 0) return cmp;
+  }
+
+  return 0;
+}
+
+export function compareVersions(current: ParsedVersion, latest: ParsedVersion): VersionComparison {
+  for (const field of ['major', 'minor', 'patch'] as const) {
+    if (current[field] < latest[field]) return 'older';
+    if (current[field] > latest[field]) return 'newer';
+  }
+
+  if (current.prerelease !== undefined && latest.prerelease !== undefined) {
+    const cmp = comparePrereleaseIdentifiers(current.prerelease, latest.prerelease);
+    if (cmp < 0) return 'older';
+    if (cmp > 0) return 'newer';
+    return 'equal';
+  }
+
+  if (current.prerelease !== undefined && latest.prerelease === undefined) return 'older';
+  if (current.prerelease === undefined && latest.prerelease !== undefined) return 'newer';
+
+  return 'equal';
+}
+
+// --- Install method detection ---
+
+export function collectCandidatePaths(): string[] {
+  const candidates: string[] = [];
+
+  if (process.argv[1]) {
+    candidates.push(process.argv[1]);
+    try {
+      candidates.push(fs.realpathSync(process.argv[1]));
+    } catch {
+      // Symlink resolution may fail
+    }
+  }
+
+  if (process.execPath) {
+    candidates.push(process.execPath);
+    try {
+      candidates.push(fs.realpathSync(process.execPath));
+    } catch {
+      // Skip
+    }
+  }
+
+  return candidates;
+}
+
+export function detectInstallMethodFromPaths(
+  pkgName: string,
+  candidatePaths: string[],
+): InstallMethod {
+  const normalized = candidatePaths.map((p) => p.toLowerCase());
+
+  const isNpx = normalized.some(
+    (p) => p.includes('/_npx/') && p.includes(`/node_modules/${pkgName}/`),
+  );
+  if (isNpx) {
+    return {
+      kind: 'npx',
+      manualInstructions: [
+        'npx always fetches the latest version by default when using @latest.',
+        'If you pinned a specific version, update the version in your MCP client config.',
+      ],
+    };
+  }
+
+  const isHomebrew = normalized.some(
+    (p) => p.includes(`/cellar/${pkgName}/`) || p.includes(`/homebrew/cellar/${pkgName}/`),
+  );
+  if (isHomebrew) {
+    return {
+      kind: 'homebrew',
+      manualCommand: `brew update && brew upgrade ${pkgName}`,
+      autoCommands: [
+        ['brew', 'update'],
+        ['brew', 'upgrade', pkgName],
+      ],
+    };
+  }
+
+  const isNpmGlobal = normalized.some((p) => p.includes(`/node_modules/${pkgName}/`));
+  if (isNpmGlobal) {
+    return {
+      kind: 'npm-global',
+      manualCommand: `npm install -g ${pkgName}@latest`,
+      autoCommands: [['npm', 'install', '-g', `${pkgName}@latest`]],
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    manualInstructions: [
+      `Homebrew:   brew update && brew upgrade ${pkgName}`,
+      `npm:        npm install -g ${pkgName}@latest`,
+      `npx:        npx always fetches the latest when using @latest`,
+    ],
+  };
+}
+
+// --- Release fetch ---
+
+interface GitHubReleaseResponse {
+  tag_name?: string;
+  name?: string;
+  body?: string;
+  html_url?: string;
+  published_at?: string;
+}
+
+export async function fetchLatestReleaseFromGitHub(
+  owner: string,
+  name: string,
+  pkgVersion: string,
+): Promise<LatestReleaseInfo> {
+  const url = `https://api.github.com/repos/${owner}/${name}/releases/latest`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': `xcodebuildmcp/${pkgVersion}`,
+        },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('Request timed out after 10 seconds');
+      }
+      throw error;
+    }
+
+    if (response.status === 403 || response.status === 429) {
+      throw new Error('GitHub API rate limit exceeded. Try again later.');
+    }
+
+    if (!response.ok) {
+      throw new Error(`GitHub API returned HTTP ${response.status}`);
+    }
+
+    const data = (await response.json()) as GitHubReleaseResponse;
+
+    if (!data.tag_name) {
+      throw new Error('GitHub release response missing tag_name');
+    }
+
+    if (!data.html_url) {
+      throw new Error('GitHub release response missing html_url');
+    }
+
+    const version = data.tag_name.startsWith('v') ? data.tag_name.slice(1) : data.tag_name;
+
+    return {
+      tagName: data.tag_name,
+      version,
+      name: data.name ?? undefined,
+      body: data.body ?? '',
+      htmlUrl: data.html_url,
+      publishedAt: data.published_at ?? undefined,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// --- Release notes rendering ---
+
+export function truncateReleaseNotes(body: string, releaseUrl: string): string {
+  const MAX_LINES = 20;
+  const MAX_CHARS = 2000;
+
+  const normalized = body.replace(/\r\n/g, '\n').trim();
+  if (normalized.length === 0) {
+    return `Full release notes: ${releaseUrl}`;
+  }
+
+  const lines = normalized.split('\n');
+  const included: string[] = [];
+  let charCount = 0;
+  let truncated = false;
+
+  for (const line of lines) {
+    if (included.length >= MAX_LINES) {
+      truncated = true;
+      break;
+    }
+    const nextCharCount = charCount + (included.length > 0 ? 1 : 0) + line.length;
+    if (nextCharCount > MAX_CHARS && included.length > 0) {
+      truncated = true;
+      break;
+    }
+    included.push(line);
+    charCount = nextCharCount;
+  }
+
+  let result = included.join('\n');
+  if (truncated) {
+    result += '\n\n... (truncated)';
+  }
+  result += `\n\nFull release notes: ${releaseUrl}`;
+  return result;
+}
+
+// --- Spawn runner ---
+
+function defaultSpawnUpgradeProcess(commands: string[][]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let currentIndex = 0;
+
+    function runNext(): void {
+      if (currentIndex >= commands.length) {
+        resolve(0);
+        return;
+      }
+
+      const [cmd, ...args] = commands[currentIndex];
+      const child = spawn(cmd, args, { stdio: 'inherit' });
+
+      const forwardSigint = (): void => {
+        child.kill('SIGINT');
+      };
+      const forwardSigterm = (): void => {
+        child.kill('SIGTERM');
+      };
+
+      process.on('SIGINT', forwardSigint);
+      process.on('SIGTERM', forwardSigterm);
+
+      const cleanup = (): void => {
+        process.removeListener('SIGINT', forwardSigint);
+        process.removeListener('SIGTERM', forwardSigterm);
+      };
+
+      child.on('error', (err) => {
+        cleanup();
+        reject(err);
+      });
+
+      child.on('close', (code) => {
+        cleanup();
+        if (code !== 0) {
+          resolve(code ?? 1);
+          return;
+        }
+        currentIndex++;
+        runNext();
+      });
+    }
+
+    runNext();
+  });
+}
+
+// --- Default dependencies ---
+
+function createDefaultDependencies(): UpgradeDependencies {
+  return {
+    currentVersion,
+    packageName,
+    repositoryOwner,
+    repositoryName,
+    fetchLatestRelease: () =>
+      fetchLatestReleaseFromGitHub(repositoryOwner, repositoryName, currentVersion),
+    detectInstallMethod: () => detectInstallMethodFromPaths(packageName, collectCandidatePaths()),
+    spawnUpgradeProcess: defaultSpawnUpgradeProcess,
+    isInteractive: isInteractiveTTY,
+  };
+}
+
+// --- Helpers ---
+
+function isAutoUpgradeMethod(method: InstallMethod): method is AutoUpgradeMethod {
+  return method.kind === 'homebrew' || method.kind === 'npm-global';
+}
+
+function writeLine(text: string): void {
+  process.stdout.write(`${text}\n`);
+}
+
+function writeError(text: string): void {
+  process.stderr.write(`${text}\n`);
+}
+
+// --- Main command logic ---
+
+export async function runUpgradeCommand(
+  options: UpgradeOptions,
+  deps?: Partial<UpgradeDependencies>,
+): Promise<number> {
+  const d = { ...createDefaultDependencies(), ...deps };
+  const isTTY = d.isInteractive();
+
+  if (isTTY) {
+    clack.intro('XcodeBuildMCP Upgrade');
+  }
+
+  const installMethod = d.detectInstallMethod();
+
+  let release: LatestReleaseInfo;
+  try {
+    if (isTTY) {
+      const s = clack.spinner();
+      s.start('Checking for updates...');
+      try {
+        release = await d.fetchLatestRelease();
+        s.stop('Update check complete.');
+      } catch (error) {
+        s.stop('Update check failed.');
+        throw error;
+      }
+    } else {
+      release = await d.fetchLatestRelease();
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+
+    if (isTTY) {
+      clack.log.error(`Failed to check for updates: ${reason}`);
+      clack.log.info(`Current version: ${d.currentVersion}`);
+      clack.log.info(`Install method: ${installMethod.kind}`);
+      if (isAutoUpgradeMethod(installMethod)) {
+        clack.log.info(`Manual upgrade: ${installMethod.manualCommand}`);
+      }
+      clack.outro('');
+    } else {
+      writeError(`Failed to check for updates: ${reason}`);
+      writeLine(`Current version: ${d.currentVersion}`);
+      writeLine(`Install method: ${installMethod.kind}`);
+      if (isAutoUpgradeMethod(installMethod)) {
+        writeLine(`Manual upgrade: ${installMethod.manualCommand}`);
+      }
+    }
+
+    return 1;
+  }
+
+  const parsedCurrent = parseVersion(d.currentVersion);
+  const parsedLatest = parseVersion(release.version);
+
+  if (!parsedCurrent || !parsedLatest) {
+    const msg = `Cannot compare versions: current=${d.currentVersion}, latest=${release.version}`;
+    if (isTTY) {
+      clack.log.error(msg);
+      clack.outro('');
+    } else {
+      writeError(msg);
+    }
+    return 1;
+  }
+
+  const comparison = compareVersions(parsedCurrent, parsedLatest);
+
+  if (comparison === 'equal') {
+    const msg = `Already up to date (${d.currentVersion}).`;
+    if (isTTY) {
+      clack.log.success(msg);
+      clack.outro('');
+    } else {
+      writeLine(msg);
+    }
+    return 0;
+  }
+
+  if (comparison === 'newer') {
+    const msg = `Local version (${d.currentVersion}) is ahead of latest release (${release.version}).`;
+    if (isTTY) {
+      clack.log.info(msg);
+      clack.outro('');
+    } else {
+      writeLine(msg);
+    }
+    return 0;
+  }
+
+  const versionLine = `${d.currentVersion} → ${release.version}`;
+  const releaseName = release.name ? ` — ${release.name}` : '';
+  const publishedLine = release.publishedAt
+    ? `Published: ${release.publishedAt.split('T')[0]}`
+    : '';
+  const notes = truncateReleaseNotes(release.body, release.htmlUrl);
+
+  if (isTTY) {
+    clack.log.step(`Update available: ${versionLine}${releaseName}`);
+    if (publishedLine) clack.log.info(publishedLine);
+    clack.log.info(`Install method: ${installMethod.kind}`);
+    clack.note(notes, 'Release Notes');
+  } else {
+    writeLine(`Update available: ${versionLine}${releaseName}`);
+    if (publishedLine) writeLine(publishedLine);
+    writeLine(`Install method: ${installMethod.kind}`);
+    writeLine('');
+    writeLine(notes);
+    writeLine('');
+  }
+
+  if (options.check) {
+    if (isTTY) clack.outro('');
+    return 0;
+  }
+
+  if (installMethod.kind === 'npx') {
+    for (const instruction of installMethod.manualInstructions) {
+      if (isTTY) {
+        clack.log.info(instruction);
+      } else {
+        writeLine(instruction);
+      }
+    }
+    if (isTTY) clack.outro('');
+    return 0;
+  }
+
+  if (installMethod.kind === 'unknown') {
+    if (isTTY) {
+      clack.log.info('Could not detect install method. Upgrade manually:');
+      for (const instruction of installMethod.manualInstructions) {
+        clack.log.message(`  ${instruction}`);
+      }
+      clack.outro('');
+    } else {
+      writeLine('Could not detect install method. Upgrade manually:');
+      for (const instruction of installMethod.manualInstructions) {
+        writeLine(`  ${instruction}`);
+      }
+    }
+    return 0;
+  }
+
+  if (!isAutoUpgradeMethod(installMethod)) {
+    return 0;
+  }
+
+  if (options.yes) {
+    return executeUpgrade(installMethod, d, isTTY);
+  }
+
+  if (!isTTY) {
+    writeLine(`Run: ${installMethod.manualCommand}`);
+    writeLine('Or re-run with --yes to upgrade automatically.');
+    return 1;
+  }
+
+  const confirmed = await clack.confirm({
+    message: `Upgrade via ${installMethod.kind}?`,
+    initialValue: true,
+  });
+
+  if (clack.isCancel(confirmed) || !confirmed) {
+    clack.log.info('Upgrade skipped.');
+    clack.outro('');
+    return 0;
+  }
+
+  return executeUpgrade(installMethod, d, isTTY);
+}
+
+async function executeUpgrade(
+  method: AutoUpgradeMethod,
+  deps: UpgradeDependencies,
+  isTTY: boolean,
+): Promise<number> {
+  if (isTTY) {
+    clack.log.step(`Running: ${method.manualCommand}`);
+  } else {
+    writeLine(`Running: ${method.manualCommand}`);
+  }
+
+  const exitCode = await deps.spawnUpgradeProcess(method.autoCommands);
+
+  if (exitCode !== 0) {
+    const msg = `Upgrade process exited with code ${exitCode}.`;
+    if (isTTY) {
+      clack.log.error(msg);
+      clack.outro('');
+    } else {
+      writeError(msg);
+    }
+    return exitCode;
+  }
+
+  if (isTTY) {
+    clack.log.success('Upgrade complete.');
+    clack.outro('');
+  } else {
+    writeLine('Upgrade complete.');
+  }
+
+  return 0;
+}
+
+// --- Yargs registration ---
+
+export function registerUpgradeCommand(app: Argv): void {
+  app.command(
+    'upgrade',
+    'Check for updates and upgrade XcodeBuildMCP',
+    (yargs) =>
+      yargs
+        .option('check', {
+          type: 'boolean',
+          default: false,
+          describe: 'Check for updates without upgrading',
+        })
+        .option('yes', {
+          type: 'boolean',
+          alias: 'y',
+          default: false,
+          describe: 'Skip confirmation and upgrade automatically',
+        }),
+    async (argv) => {
+      const exitCode = await runUpgradeCommand({
+        check: argv.check as boolean,
+        yes: argv.yes as boolean,
+      });
+      if (exitCode !== 0) {
+        process.exit(exitCode);
+      }
+    },
+  );
+}

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -100,7 +100,7 @@ function comparePrereleaseIdentifiers(a: string, b: string): number {
     if (aIsNum) return -1;
     if (bIsNum) return 1;
 
-    const cmp = aParts[i].localeCompare(bParts[i]);
+    const cmp = aParts[i] < bParts[i] ? -1 : aParts[i] > bParts[i] ? 1 : 0;
     if (cmp !== 0) return cmp;
   }
 

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -34,13 +34,17 @@ export interface ParsedVersion {
 
 export type VersionComparison = 'older' | 'equal' | 'newer';
 
-export interface LatestReleaseInfo {
-  tagName: string;
-  version: string;
-  name: string | undefined;
+export interface ReleaseNotes {
   body: string;
   htmlUrl: string;
+  name: string | undefined;
   publishedAt: string | undefined;
+}
+
+export interface ChannelLookupResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
 }
 
 export interface UpgradeDependencies {
@@ -48,7 +52,9 @@ export interface UpgradeDependencies {
   packageName: string;
   repositoryOwner: string;
   repositoryName: string;
-  fetchLatestRelease: () => Promise<LatestReleaseInfo>;
+  fetchLatestVersionForChannel: (channel: InstallMethod['kind']) => Promise<string>;
+  fetchReleaseNotesForTag: (tag: string) => Promise<ReleaseNotes | null>;
+  runChannelLookupCommand: (argv: string[]) => Promise<ChannelLookupResult>;
   detectInstallMethod: () => InstallMethod;
   spawnUpgradeProcess: (commands: string[][]) => Promise<number>;
   isInteractive: () => boolean;
@@ -198,7 +204,7 @@ export function detectInstallMethodFromPaths(
   };
 }
 
-// --- Release fetch ---
+// --- Channel version lookup ---
 
 interface GitHubReleaseResponse {
   tag_name?: string;
@@ -208,11 +214,84 @@ interface GitHubReleaseResponse {
   published_at?: string;
 }
 
-export async function fetchLatestReleaseFromGitHub(
+async function fetchLatestVersionFromNpm(
+  pkgName: string,
+  run: (argv: string[]) => Promise<ChannelLookupResult>,
+): Promise<string> {
+  let result: ChannelLookupResult;
+  try {
+    result = await run(['npm', 'view', `${pkgName}@latest`, 'version', '--json']);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`couldn't determine latest version from npm: ${reason}`);
+  }
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `couldn't determine latest version from npm: command exited with code ${result.exitCode}`,
+    );
+  }
+
+  let version: unknown;
+  try {
+    version = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("couldn't determine latest version from npm: invalid JSON output");
+  }
+
+  if (typeof version !== 'string') {
+    throw new Error("couldn't determine latest version from npm: unexpected output format");
+  }
+
+  return version;
+}
+
+async function fetchLatestVersionFromHomebrew(
+  pkgName: string,
+  run: (argv: string[]) => Promise<ChannelLookupResult>,
+): Promise<string> {
+  let result: ChannelLookupResult;
+  try {
+    result = await run(['brew', 'info', '--json=v2', pkgName]);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`couldn't determine latest version from Homebrew: ${reason}`);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("couldn't determine latest version from Homebrew: invalid JSON output");
+  }
+
+  if (!data || typeof data !== 'object') {
+    throw new Error("couldn't determine latest version from Homebrew: unexpected output format");
+  }
+
+  const formulae = (data as Record<string, unknown>).formulae;
+  if (!Array.isArray(formulae) || formulae.length === 0) {
+    throw new Error(`couldn't find ${pkgName} in Homebrew (is the tap installed?)`);
+  }
+
+  const versions = (formulae[0] as Record<string, unknown>)?.versions;
+  if (!versions || typeof versions !== 'object') {
+    throw new Error("couldn't determine latest version from Homebrew: missing versions field");
+  }
+
+  const stable = (versions as Record<string, unknown>).stable;
+  if (typeof stable !== 'string') {
+    throw new Error("couldn't determine latest version from Homebrew: missing versions.stable");
+  }
+
+  return stable;
+}
+
+async function fetchLatestVersionFromGitHub(
   owner: string,
   name: string,
   pkgVersion: string,
-): Promise<LatestReleaseInfo> {
+): Promise<string> {
   const url = `https://api.github.com/repos/${owner}/${name}/releases/latest`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
@@ -229,37 +308,105 @@ export async function fetchLatestReleaseFromGitHub(
       });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error('Request timed out after 10 seconds');
+        throw new Error("couldn't determine latest version from GitHub: request timed out");
       }
-      throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`couldn't determine latest version from GitHub: ${reason}`);
     }
 
     if (response.status === 403 || response.status === 429) {
-      throw new Error('GitHub API rate limit exceeded. Try again later.');
+      throw new Error("couldn't determine latest version from GitHub: rate limit exceeded");
     }
 
     if (!response.ok) {
-      throw new Error(`GitHub API returned HTTP ${response.status}`);
+      throw new Error(`couldn't determine latest version from GitHub: HTTP ${response.status}`);
     }
 
     const data = (await response.json()) as GitHubReleaseResponse;
 
     if (!data.tag_name) {
-      throw new Error('GitHub release response missing tag_name');
+      throw new Error("couldn't determine latest version from GitHub: missing tag_name");
     }
 
-    if (!data.html_url) {
-      throw new Error('GitHub release response missing html_url');
+    return data.tag_name.startsWith('v') ? data.tag_name.slice(1) : data.tag_name;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+interface ChannelFetcherDeps {
+  runChannelLookupCommand: (argv: string[]) => Promise<ChannelLookupResult>;
+  packageName: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  currentVersion: string;
+}
+
+function defaultFetchLatestVersionForChannel(
+  channel: InstallMethod['kind'],
+  deps: ChannelFetcherDeps,
+): Promise<string> {
+  switch (channel) {
+    case 'npm-global':
+    case 'npx':
+      return fetchLatestVersionFromNpm(deps.packageName, deps.runChannelLookupCommand);
+    case 'homebrew':
+      return fetchLatestVersionFromHomebrew(deps.packageName, deps.runChannelLookupCommand);
+    case 'unknown':
+      return fetchLatestVersionFromGitHub(
+        deps.repositoryOwner,
+        deps.repositoryName,
+        deps.currentVersion,
+      );
+  }
+}
+
+// --- Release notes fetch ---
+
+interface NotesFetcherDeps {
+  repositoryOwner: string;
+  repositoryName: string;
+  currentVersion: string;
+}
+
+async function defaultFetchReleaseNotesForTag(
+  tag: string,
+  deps: NotesFetcherDeps,
+): Promise<ReleaseNotes | null> {
+  const url = `https://api.github.com/repos/${deps.repositoryOwner}/${deps.repositoryName}/releases/tags/${tag}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': `xcodebuildmcp/${deps.currentVersion}`,
+        },
+        signal: controller.signal,
+      });
+    } catch {
+      return null;
     }
 
-    const version = data.tag_name.startsWith('v') ? data.tag_name.slice(1) : data.tag_name;
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as GitHubReleaseResponse;
 
     return {
-      tagName: data.tag_name,
-      version,
-      name: data.name ?? undefined,
       body: data.body ?? '',
-      htmlUrl: data.html_url,
+      htmlUrl:
+        data.html_url ??
+        `https://github.com/${deps.repositoryOwner}/${deps.repositoryName}/releases/tag/${tag}`,
+      name: data.name ?? undefined,
       publishedAt: data.published_at ?? undefined,
     };
   } finally {
@@ -305,7 +452,44 @@ export function truncateReleaseNotes(body: string, releaseUrl: string): string {
   return result;
 }
 
-// --- Spawn runner ---
+// --- Spawn runners ---
+
+function defaultRunChannelLookupCommand(argv: string[]): Promise<ChannelLookupResult> {
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = argv;
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, 15_000);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(new Error(`Command timed out after 15 seconds: ${cmd}`));
+        return;
+      }
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+  });
+}
 
 function defaultSpawnUpgradeProcess(commands: string[][]): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -355,20 +539,36 @@ function defaultSpawnUpgradeProcess(commands: string[][]): Promise<number> {
   });
 }
 
-// --- Default dependencies ---
+// --- Dependency factory ---
 
-function createDefaultDependencies(): UpgradeDependencies {
-  return {
+function resolveDependencies(overrides?: Partial<UpgradeDependencies>): UpgradeDependencies {
+  const base: UpgradeDependencies = {
     currentVersion,
     packageName,
     repositoryOwner,
     repositoryName,
-    fetchLatestRelease: () =>
-      fetchLatestReleaseFromGitHub(repositoryOwner, repositoryName, currentVersion),
+    runChannelLookupCommand: defaultRunChannelLookupCommand,
+    fetchLatestVersionForChannel: undefined!,
+    fetchReleaseNotesForTag: undefined!,
     detectInstallMethod: () => detectInstallMethodFromPaths(packageName, collectCandidatePaths()),
     spawnUpgradeProcess: defaultSpawnUpgradeProcess,
     isInteractive: isInteractiveTTY,
   };
+
+  if (overrides) {
+    Object.assign(base, overrides);
+  }
+
+  if (!overrides?.fetchLatestVersionForChannel) {
+    base.fetchLatestVersionForChannel = (channel) =>
+      defaultFetchLatestVersionForChannel(channel, base);
+  }
+
+  if (!overrides?.fetchReleaseNotesForTag) {
+    base.fetchReleaseNotesForTag = (tag) => defaultFetchReleaseNotesForTag(tag, base);
+  }
+
+  return base;
 }
 
 // --- Helpers ---
@@ -391,7 +591,7 @@ export async function runUpgradeCommand(
   options: UpgradeOptions,
   deps?: Partial<UpgradeDependencies>,
 ): Promise<number> {
-  const d = { ...createDefaultDependencies(), ...deps };
+  const d = resolveDependencies(deps);
   const isTTY = d.isInteractive();
 
   if (isTTY) {
@@ -400,26 +600,26 @@ export async function runUpgradeCommand(
 
   const installMethod = d.detectInstallMethod();
 
-  let release: LatestReleaseInfo;
+  let latestVersion: string;
   try {
     if (isTTY) {
       const s = clack.spinner();
       s.start('Checking for updates...');
       try {
-        release = await d.fetchLatestRelease();
+        latestVersion = await d.fetchLatestVersionForChannel(installMethod.kind);
         s.stop('Update check complete.');
       } catch (error) {
         s.stop('Update check failed.');
         throw error;
       }
     } else {
-      release = await d.fetchLatestRelease();
+      latestVersion = await d.fetchLatestVersionForChannel(installMethod.kind);
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
 
     if (isTTY) {
-      clack.log.error(`Failed to check for updates: ${reason}`);
+      clack.log.error(reason);
       clack.log.info(`Current version: ${d.currentVersion}`);
       clack.log.info(`Install method: ${installMethod.kind}`);
       if (isAutoUpgradeMethod(installMethod)) {
@@ -427,7 +627,7 @@ export async function runUpgradeCommand(
       }
       clack.outro('');
     } else {
-      writeError(`Failed to check for updates: ${reason}`);
+      writeError(reason);
       writeLine(`Current version: ${d.currentVersion}`);
       writeLine(`Install method: ${installMethod.kind}`);
       if (isAutoUpgradeMethod(installMethod)) {
@@ -439,10 +639,10 @@ export async function runUpgradeCommand(
   }
 
   const parsedCurrent = parseVersion(d.currentVersion);
-  const parsedLatest = parseVersion(release.version);
+  const parsedLatest = parseVersion(latestVersion);
 
   if (!parsedCurrent || !parsedLatest) {
-    const msg = `Cannot compare versions: current=${d.currentVersion}, latest=${release.version}`;
+    const msg = `Cannot compare versions: current=${d.currentVersion}, latest=${latestVersion}`;
     if (isTTY) {
       clack.log.error(msg);
       clack.outro('');
@@ -466,7 +666,7 @@ export async function runUpgradeCommand(
   }
 
   if (comparison === 'newer') {
-    const msg = `Local version (${d.currentVersion}) is ahead of latest release (${release.version}).`;
+    const msg = `Local version (${d.currentVersion}) is ahead of latest release (${latestVersion}).`;
     if (isTTY) {
       clack.log.info(msg);
       clack.outro('');
@@ -476,24 +676,41 @@ export async function runUpgradeCommand(
     return 0;
   }
 
-  const versionLine = `${d.currentVersion} → ${release.version}`;
-  const releaseName = release.name ? ` — ${release.name}` : '';
-  const publishedLine = release.publishedAt
-    ? `Published: ${release.publishedAt.split('T')[0]}`
+  const releaseUrl = `https://github.com/${d.repositoryOwner}/${d.repositoryName}/releases/tag/v${latestVersion}`;
+  let releaseNotes: ReleaseNotes | null = null;
+  try {
+    releaseNotes = await d.fetchReleaseNotesForTag(`v${latestVersion}`);
+  } catch {
+    // Non-fatal — notes unavailable
+  }
+
+  const versionLine = `${d.currentVersion} → ${latestVersion}`;
+  const releaseName = releaseNotes?.name ? ` — ${releaseNotes.name}` : '';
+  const publishedLine = releaseNotes?.publishedAt
+    ? `Published: ${releaseNotes.publishedAt.split('T')[0]}`
     : '';
-  const notes = truncateReleaseNotes(release.body, release.htmlUrl);
 
   if (isTTY) {
     clack.log.step(`Update available: ${versionLine}${releaseName}`);
     if (publishedLine) clack.log.info(publishedLine);
     clack.log.info(`Install method: ${installMethod.kind}`);
-    clack.note(notes, 'Release Notes');
+
+    if (releaseNotes && releaseNotes.body.trim().length > 0) {
+      clack.note(truncateReleaseNotes(releaseNotes.body, releaseNotes.htmlUrl), 'Release Notes');
+    } else {
+      clack.log.info(`Release notes: ${releaseUrl}`);
+    }
   } else {
     writeLine(`Update available: ${versionLine}${releaseName}`);
     if (publishedLine) writeLine(publishedLine);
     writeLine(`Install method: ${installMethod.kind}`);
     writeLine('');
-    writeLine(notes);
+
+    if (releaseNotes && releaseNotes.body.trim().length > 0) {
+      writeLine(truncateReleaseNotes(releaseNotes.body, releaseNotes.htmlUrl));
+    } else {
+      writeLine(`Release notes: ${releaseUrl}`);
+    }
     writeLine('');
   }
 

--- a/src/cli/yargs-app.ts
+++ b/src/cli/yargs-app.ts
@@ -7,6 +7,7 @@ import { registerInitCommand } from './commands/init.ts';
 import { registerMcpCommand } from './commands/mcp.ts';
 import { registerSetupCommand } from './commands/setup.ts';
 import { registerToolsCommand } from './commands/tools.ts';
+import { registerUpgradeCommand } from './commands/upgrade.ts';
 import { registerToolCommands } from './register-tool-commands.ts';
 import { version } from '../version.ts';
 import { coerceLogLevel, setLogLevel, type LogLevel } from '../utils/logger.ts';
@@ -75,6 +76,7 @@ export function buildYargsApp(opts: YargsAppOptions): ReturnType<typeof yargs> {
   registerMcpCommand(app);
   registerInitCommand(app, { workspaceRoot: opts.workspaceRoot });
   registerSetupCommand(app);
+  registerUpgradeCommand(app);
   registerToolsCommand(app);
   registerToolCommands(app, opts.catalog, {
     workspaceRoot: opts.workspaceRoot,

--- a/src/utils/version/index.ts
+++ b/src/utils/version/index.ts
@@ -1,1 +1,1 @@
-export { version } from '../../version.ts';
+export { version, packageName, repositoryOwner, repositoryName } from '../../version.ts';


### PR DESCRIPTION
Adds a new top-level `xcodebuildmcp upgrade` command that compares the
installed version against the latest GitHub release, detects the install
method (Homebrew, npm-global, npx, or unknown), shows a truncated release
notes excerpt, and either runs the correct upgrade command with inherited
stdio or prints the manual command for unsupported channels.

## Behavior

- `--check` reports current vs. latest without prompting (CI-friendly).
- `--yes` / `-y` skips the confirmation and auto-runs the upgrade.
- Homebrew: `brew update` then `brew upgrade xcodebuildmcp`.
- npm-global: `npm install -g xcodebuildmcp@latest`.
- npx: never auto-runs — prints the ephemeral-install note and exits 0
  so `--yes` does not error in scripts.
- Unknown install: prints manual options, never auto-runs.
- Non-TTY callers that could auto-upgrade but omit `--yes` exit 1 so
  scripts do not hang on an invisible confirm.
- GitHub failures (timeout, non-200, 403 rate limit, malformed JSON) are
  reported with a clear message plus the manual upgrade command when
  detection succeeded.

## Implementation notes

- The command short-circuits in `src/cli.ts` mirroring `init` / `setup`,
  so no runtime/daemon bootstrap runs for this path.
- Version generator (`scripts/generate-version.ts`) now emits
  `packageName`, `repositoryOwner`, `repositoryName` parsed from
  `package.json`; the command reads these from `src/utils/version`
  instead of hardcoding identifiers. Generator fails the build if
  `repository.url` is not a parseable GitHub URL.
- Upgrade execution uses `spawn(..., { stdio: 'inherit' })` with
  SIGINT/SIGTERM forwarding; the buffered `CommandExecutor` is
  deliberately not used because package-manager output and prompts need
  to stream live.
- Semver comparison is done locally (leading `v` stripped, prerelease
  suffixes supported) to avoid adding a `semver` dependency for one
  command.
- Install detection is conservative: realpath-based on
  `process.argv[1]` and `process.execPath`, matching Homebrew Cellar
  paths (Intel and Apple Silicon), global `node_modules/xcodebuildmcp`,
  and the npx `_npx` cache. Unknown paths never auto-run.

## Tests

67 unit tests cover the full matrix: version parsing/compare edge cases,
detection for each channel with exact argv assertions, TTY and non-TTY
paths for every flag combination, release-notes truncation at both the
20-line and 2000-char caps, and every GitHub failure class. All
dependencies are injected through `UpgradeDependencies` — no real
network, spawn, or filesystem access in tests.