### PR TITLE
fix(version): Extract shared validation and fix generated formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added `toggle_connect_hardware_keyboard` tool to toggle the iOS Simulator hardware keyboard connection ([#346](https://github.com/getsentry/XcodeBuildMCP/issues/346)).
 - Fixed `xcode_tools_bridge_disconnect` immediately re-syncing proxied tools after a manual disconnect ([#343](https://github.com/getsentry/XcodeBuildMCP/issues/343)).
 - Stopped suggesting an unsupported `--device-id`/`deviceId` argument in the `device list` next-step hint for `device build`/`build_device`; device targeting flows through session defaults ([#350](https://github.com/getsentry/XcodeBuildMCP/pull/350) by [@MukundaKatta](https://github.com/MukundaKatta)).
+- Extracted shared version validation (`VERSION_REGEX`/`validateVersion`) for version generation and tests, and switched generated `src/version.ts` literals back to single quotes to avoid Prettier conflicts ([#368](https://github.com/getsentry/XcodeBuildMCP/issues/368), [#369](https://github.com/getsentry/XcodeBuildMCP/issues/369)).
 
 ## [2.3.2]
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,6 @@ export default [
       'coverage/**',
       'src/core/generated-plugins.ts',
       'src/core/generated-resources.ts',
-      'src/version.ts',
     ],
   },
   {

--- a/scripts/generate-version.ts
+++ b/scripts/generate-version.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { validateVersion } from '../src/utils/version/version-validation.ts';
 
 interface PackageJson {
   name: string;
@@ -17,16 +18,6 @@ function parseGitHubOwnerAndName(url: string): { owner: string; name: string } {
     throw new Error(`Cannot parse GitHub owner/name from repository URL: ${url}`);
   }
   return { owner: match[1], name: match[2] };
-}
-
-const VERSION_REGEX = /^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.\-]+)?(\+[a-zA-Z0-9.\-]+)?$/;
-
-function validateVersion(name: string, value: string): void {
-  if (!VERSION_REGEX.test(value)) {
-    throw new Error(
-      `Invalid ${name} in package.json: ${JSON.stringify(value)}. Expected a version string.`,
-    );
-  }
 }
 
 async function main(): Promise<void> {
@@ -49,12 +40,12 @@ async function main(): Promise<void> {
   validateVersion('macOSTemplateVersion', pkg.macOSTemplateVersion);
 
   const content =
-    `export const version = ${JSON.stringify(pkg.version)};\n` +
-    `export const iOSTemplateVersion = ${JSON.stringify(pkg.iOSTemplateVersion)};\n` +
-    `export const macOSTemplateVersion = ${JSON.stringify(pkg.macOSTemplateVersion)};\n` +
-    `export const packageName = ${JSON.stringify(pkg.name)};\n` +
-    `export const repositoryOwner = ${JSON.stringify(repo.owner)};\n` +
-    `export const repositoryName = ${JSON.stringify(repo.name)};\n`;
+    `export const version = '${pkg.version}';\n` +
+    `export const iOSTemplateVersion = '${pkg.iOSTemplateVersion}';\n` +
+    `export const macOSTemplateVersion = '${pkg.macOSTemplateVersion}';\n` +
+    `export const packageName = '${pkg.name}';\n` +
+    `export const repositoryOwner = '${repo.owner}';\n` +
+    `export const repositoryName = '${repo.name}';\n`;
 
   await writeFile(versionPath, content, 'utf8');
 }

--- a/src/utils/__tests__/generate-version-validation.test.ts
+++ b/src/utils/__tests__/generate-version-validation.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-
-// We cannot easily import the generate-version script (it runs main() immediately),
-// so we extract and test the core logic: VERSION_REGEX and JSON.stringify defense.
-
-const VERSION_REGEX = /^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.\-]+)?(\+[a-zA-Z0-9.\-]+)?$/;
+import { VERSION_REGEX, validateVersion } from '../version/version-validation.ts';
 
 describe('generate-version: VERSION_REGEX validation', () => {
   it('accepts standard semver', () => {
@@ -47,25 +43,14 @@ describe('generate-version: VERSION_REGEX validation', () => {
   });
 });
 
-describe('generate-version: JSON.stringify defense-in-depth', () => {
-  it('produces safe code even if a value somehow contains quotes', () => {
-    const malicious = "1.0.0'; process.exit(1); //";
-    const generated = `const version = ${JSON.stringify(malicious)};\n`;
-    // The output should use escaped double-quoted string, not break out
-    expect(generated).toContain('"1.0.0');
-    expect(generated).not.toContain("'1.0.0'; process.exit(1)");
-    // Should be parseable JS (using const instead of export for Function() compat)
-    expect(() => new Function(generated)).not.toThrow();
+describe('generate-version: validateVersion', () => {
+  it('throws for invalid versions', () => {
+    expect(() => validateVersion('version', "1.0.0'; process.exit(1); //")).toThrow(
+      /Invalid version in package\.json/,
+    );
   });
 
-  it('JSON.stringify properly escapes backslashes and control characters', () => {
-    const tricky = '1.0.0\n";process.exit(1);//';
-    const serialized = JSON.stringify(tricky);
-    // The newline should be escaped as \\n, and the quote should be escaped
-    expect(serialized).toContain('\\n');
-    expect(serialized).toContain('\\"');
-    // The resulting assignment should be valid JS
-    const code = `const v = ${serialized};`;
-    expect(() => new Function(code)).not.toThrow();
+  it('does not throw for valid versions', () => {
+    expect(() => validateVersion('version', '1.0.0-alpha.1+meta')).not.toThrow();
   });
 });

--- a/src/utils/version/version-validation.ts
+++ b/src/utils/version/version-validation.ts
@@ -1,0 +1,9 @@
+export const VERSION_REGEX = /^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.\-]+)?(\+[a-zA-Z0-9.\-]+)?$/;
+
+export function validateVersion(name: string, value: string): void {
+  if (!VERSION_REGEX.test(value)) {
+    throw new Error(
+      `Invalid ${name} in package.json: ${JSON.stringify(value)}. Expected a version string.`,
+    );
+  }
+}


### PR DESCRIPTION
Extract the version regex and validation into a shared module, then reuse it from both the version generator script and its validation test.

This removes duplicate semver validation logic that previously had to be kept in sync manually, and it closes the follow-up maintainability gap left after #289.

The generated `src/version.ts` output now uses single-quoted literals again instead of `JSON.stringify(...)` output. That resolves the Prettier formatting conflict directly, so the temporary `eslint` ignore for `src/version.ts` is removed.

Fixes #368
Fixes #369