### PR TITLE
ci(release): skip homebrew tap and mcp registry on prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           files: |
             xcodebuildmcp-${{ steps.get_version.outputs.VERSION }}.tgz
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(steps.get_version.outputs.VERSION, '-') }}
 
       - name: Summary
         env:
@@ -176,7 +176,7 @@ jobs:
           fi
 
   mcp_registry:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !contains(needs.release.outputs.version, '-')
     needs: release
     runs-on: ubuntu-latest
     env:
@@ -391,7 +391,7 @@ jobs:
             --repo "$REPOSITORY"
 
   update_homebrew_tap:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !contains(needs.release.outputs.version, '-')
     needs: [release, build_and_package_macos, publish_portable_assets]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Mark GitHub releases as prereleases when the tag carries a SemVer prerelease suffix (e.g. `2.4.0-beta.1`), and skip the `update_homebrew_tap` and `mcp_registry` jobs for those tags.

Without this, pushing a beta tag would:
- overwrite `Formula/xcodebuildmcp.rb` in the `homebrew-xcodebuildmcp` tap, pushing every `brew install`/`brew upgrade` user onto the beta build, and
- publish the prerelease to the MCP Registry as the canonical version.

npm continues to publish under the `beta`/`alpha`/`rc` dist-tag (the resolver in `Resolve npm tag from version` is unchanged), and the portable tarballs are still attached to the GitHub release. Only the channels that have no separate prerelease lane are gated.

The condition uses `contains(..., '-')` because every SemVer prerelease has a `-` and no stable release does, matching the validation regex in `Get version from tag or input`.