### PR TITLE
fix(cli): Suppress false compiler errors in test summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed CLI test summaries showing false-positive compiler errors from xcodebuild NSError dump lines, and added compiler-error snapshot coverage for simulator, device, and macOS build-style flows ([#383](https://github.com/getsentry/XcodeBuildMCP/issues/383)).
 - Fixed simulator OSLog helper cleanup so server and daemon startup reconcile same-workspace orphaned log streams without stopping helpers owned by live sessions in other workspaces ([#382](https://github.com/getsentry/XcodeBuildMCP/issues/382)).
 
 ## [2.5.0-beta.1]

--- a/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift
+++ b/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift
@@ -28,3 +28,7 @@ struct CalculatorApp: App {
 #Preview {
     ContentView()
 }
+
+#if SNAPSHOT_COMPILER_ERROR
+private let snapshotCompilerError: Int = "not an int"
+#endif

--- a/example_projects/macOS/MCPTest/MCPTestApp.swift
+++ b/example_projects/macOS/MCPTest/MCPTestApp.swift
@@ -15,3 +15,7 @@ struct MCPTestApp: App {
         }
     }
 }
+
+#if SNAPSHOT_COMPILER_ERROR
+private let snapshotCompilerError: Int = "not an int"
+#endif

--- a/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🔨 Build
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
@@ -10,7 +10,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🚀 Build & Run
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Device: <DEVICE> (<UUID>)
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
@@ -11,7 +11,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
@@ -16,7 +16,7 @@ Discovered 1 test(s):
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
@@ -1,0 +1,22 @@
+
+🧪 Test
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Device: <DEVICE> (<UUID>)
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+   Selective Testing:
+     CalculatorAppTests/CalculatorAppTests/testAddition
+
+Discovered 1 test(s):
+   CalculatorAppTests/CalculatorAppTests/testAddition
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
@@ -10,7 +10,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+    example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🔨 Build
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🚀 Build & Run
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
@@ -10,7 +10,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+    example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
@@ -1,0 +1,23 @@
+
+🧪 Test
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+   Selective Testing:
+     MCPTestTests/MCPTestTests/appNameIsCorrect()
+     MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
+
+Discovered 2 test(s):
+   MCPTestTests/MCPTestTests/appNameIsCorrect
+   MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
@@ -17,7 +17,7 @@ Discovered 2 test(s):
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/macOS/MCPTest/MCPTestApp.swift:19:42
+    example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
@@ -11,7 +11,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🔨 Build
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🚀 Build & Run
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
@@ -11,7 +11,7 @@
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
@@ -16,7 +16,7 @@ Discovered 1 test(s):
 Compiler Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
@@ -1,0 +1,22 @@
+
+🧪 Test
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+   Selective Testing:
+     CalculatorAppTests/CalculatorAppTests/testAddition
+
+Discovered 1 test(s):
+   CalculatorAppTests/CalculatorAppTests/testAddition
+
+Compiler Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32:42
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
@@ -1,0 +1,33 @@
+{
+  "schema": "xcodebuildmcp.output.build-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS",
+      "target": "device"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "device"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
@@ -25,7 +25,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
@@ -27,7 +27,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
@@ -1,0 +1,35 @@
+{
+  "schema": "xcodebuildmcp.output.build-run-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS",
+      "deviceId": "<UUID>",
+      "target": "device"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "device"
+    },
+    "artifacts": {
+      "deviceId": "<UUID>",
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
@@ -42,7 +42,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ],
       "testFailures": []

--- a/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
@@ -1,0 +1,51 @@
+{
+  "schema": "xcodebuildmcp.output.test-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Tests failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS",
+      "deviceId": "<UUID>",
+      "target": "device",
+      "onlyTesting": [
+        "CalculatorAppTests/CalculatorAppTests/testAddition"
+      ],
+      "skipTesting": []
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "device"
+    },
+    "artifacts": {
+      "deviceId": "<UUID>",
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/test_device_<TIMESTAMP>_pid<PID>.log"
+    },
+    "tests": {
+      "selected": [
+        "CalculatorAppTests/CalculatorAppTests/testAddition"
+      ],
+      "discovered": {
+        "total": 1,
+        "items": [
+          "CalculatorAppTests/CalculatorAppTests/testAddition"
+        ]
+      }
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ],
+      "testFailures": []
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
@@ -25,7 +25,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
@@ -1,0 +1,33 @@
+{
+  "schema": "xcodebuildmcp.output.build-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "MCPTest",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
+      "configuration": "Debug",
+      "platform": "macOS",
+      "target": "macos"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "macos"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
@@ -25,7 +25,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
@@ -1,0 +1,33 @@
+{
+  "schema": "xcodebuildmcp.output.build-run-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "MCPTest",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
+      "configuration": "Debug",
+      "platform": "macOS",
+      "target": "macos"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "macos"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
@@ -42,7 +42,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20"
         }
       ],
       "testFailures": []

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
@@ -1,0 +1,51 @@
+{
+  "schema": "xcodebuildmcp.output.test-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Tests failed",
+  "data": {
+    "request": {
+      "scheme": "MCPTest",
+      "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>",
+      "configuration": "Debug",
+      "platform": "macOS",
+      "onlyTesting": [
+        "MCPTestTests/MCPTestTests/appNameIsCorrect()",
+        "MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect"
+      ],
+      "skipTesting": []
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "macos"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log"
+    },
+    "tests": {
+      "selected": [
+        "MCPTestTests/MCPTestTests/appNameIsCorrect",
+        "MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect"
+      ],
+      "discovered": {
+        "total": 2,
+        "items": [
+          "MCPTestTests/MCPTestTests/appNameIsCorrect",
+          "MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect"
+        ]
+      }
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19"
+        }
+      ],
+      "testFailures": []
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
@@ -1,0 +1,33 @@
+{
+  "schema": "xcodebuildmcp.output.build-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS Simulator",
+      "simulatorName": "iPhone 17"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "simulator"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
@@ -25,7 +25,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
@@ -1,0 +1,33 @@
+{
+  "schema": "xcodebuildmcp.output.build-run-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Build failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS Simulator",
+      "simulatorName": "iPhone 17"
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "simulator"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log"
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ]
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
@@ -25,7 +25,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ]
     }

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
@@ -40,7 +40,7 @@
       "errors": [
         {
           "message": "cannot convert value of type 'String' to specified type 'Int'",
-          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33"
         }
       ],
       "testFailures": []

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
@@ -1,0 +1,49 @@
+{
+  "schema": "xcodebuildmcp.output.test-result",
+  "schemaVersion": "1",
+  "didError": true,
+  "error": "Tests failed",
+  "data": {
+    "request": {
+      "scheme": "CalculatorApp",
+      "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
+      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>",
+      "configuration": "Debug",
+      "platform": "iOS Simulator",
+      "simulatorName": "iPhone 17",
+      "onlyTesting": [
+        "CalculatorAppTests/CalculatorAppTests/testAddition"
+      ],
+      "skipTesting": []
+    },
+    "summary": {
+      "status": "FAILED",
+      "durationMs": 1234,
+      "target": "simulator"
+    },
+    "artifacts": {
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
+    },
+    "tests": {
+      "selected": [
+        "CalculatorAppTests/CalculatorAppTests/testAddition"
+      ],
+      "discovered": {
+        "total": 1,
+        "items": [
+          "CalculatorAppTests/CalculatorAppTests/testAddition"
+        ]
+      }
+    },
+    "diagnostics": {
+      "warnings": [],
+      "errors": [
+        {
+          "message": "cannot convert value of type 'String' to specified type 'Int'",
+          "location": "<ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32"
+        }
+      ],
+      "testFailures": []
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🔨 Build
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
@@ -10,7 +10,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
@@ -11,7 +11,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🚀 Build & Run
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Device: <DEVICE> (<UUID>)
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
@@ -1,0 +1,22 @@
+
+🧪 Test
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS
+   Device: <DEVICE> (<UUID>)
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+   Selective Testing:
+     CalculatorAppTests/CalculatorAppTests/testAddition
+
+Discovered 1 test(s):
+   CalculatorAppTests/CalculatorAppTests/testAddition
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
@@ -16,7 +16,7 @@ Discovered 1 test(s):
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
@@ -10,7 +10,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🔨 Build
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
@@ -1,0 +1,16 @@
+
+🚀 Build & Run
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
@@ -10,7 +10,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
@@ -17,7 +17,7 @@ Discovered 2 test(s):
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
@@ -1,0 +1,23 @@
+
+🧪 Test
+
+   Scheme: MCPTest
+   Project: example_projects/macOS/MCPTest.xcodeproj
+   Configuration: Debug
+   Platform: macOS
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/MCPTest-<HASH>
+   Selective Testing:
+     MCPTestTests/MCPTestTests/appNameIsCorrect()
+     MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
+
+Discovered 2 test(s):
+   MCPTestTests/MCPTestTests/appNameIsCorrect
+   MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:19
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
@@ -11,7 +11,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🔨 Build
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
@@ -1,0 +1,17 @@
+
+🚀 Build & Run
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Build failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
@@ -11,7 +11,7 @@
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
@@ -1,0 +1,22 @@
+
+🧪 Test
+
+   Scheme: CalculatorApp
+   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
+   Configuration: Debug
+   Platform: iOS Simulator
+   Simulator: iPhone 17
+   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/DerivedData/CalculatorApp-<HASH>
+   Selective Testing:
+     CalculatorAppTests/CalculatorAppTests/testAddition
+
+Discovered 1 test(s):
+   CalculatorAppTests/CalculatorAppTests/testAddition
+
+Errors (1):
+
+  ✗ cannot convert value of type 'String' to specified type 'Int'
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+
+❌ Test failed. (⏱️ <DURATION>)
+  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
@@ -16,7 +16,7 @@ Discovered 1 test(s):
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
-    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:32
+    <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Test failed. (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/suites/device-suite.ts
+++ b/src/snapshot-tests/suites/device-suite.ts
@@ -5,7 +5,11 @@ import {
   extractAppPathFromSnapshotOutput,
   extractProcessIdFromSnapshotOutput,
 } from '../output-parsers.ts';
-import { createHarnessForRuntime, createWorkflowFixtureMatcher } from './helpers.ts';
+import {
+  createHarnessForRuntime,
+  createWorkflowFixtureMatcher,
+  withCalculatorAppCompilerError,
+} from './helpers.ts';
 
 const WORKSPACE = 'example_projects/iOS_Calculator/CalculatorApp.xcworkspace';
 const BUNDLE_ID = 'io.sentry.calculatorapp';
@@ -60,6 +64,17 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
         });
         expect(isError).toBe(true);
         expectFixture(text, 'build--error-wrong-scheme');
+      });
+
+      it('error - compiler error', async () => {
+        const { text, isError } = await withCalculatorAppCompilerError(() =>
+          harness.invoke('device', 'build', {
+            workspacePath: WORKSPACE,
+            scheme: 'CalculatorApp',
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'build--error-compiler');
       });
     });
 
@@ -139,6 +154,18 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
         expect(isError).toBe(true);
         expectFixture(text, 'build-and-run--error-wrong-scheme');
       });
+
+      it('error - compiler error', async () => {
+        const { text, isError } = await withCalculatorAppCompilerError(() =>
+          harness.invoke('device', 'build-and-run', {
+            workspacePath: WORKSPACE,
+            scheme: 'CalculatorApp',
+            deviceId: DEVICE_ID,
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'build-and-run--error-compiler');
+      });
     });
 
     describe.runIf(DEVICE_READY)('install (requires device)', () => {
@@ -215,6 +242,19 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
         expect(isError).toBe(true);
         expect(text.length).toBeGreaterThan(10);
         expectFixture(text, 'test--failure');
+      }, 300_000);
+
+      it('error - compiler error', async () => {
+        const { text, isError } = await withCalculatorAppCompilerError(() =>
+          harness.invoke('device', 'test', {
+            workspacePath: WORKSPACE,
+            scheme: 'CalculatorApp',
+            deviceId: DEVICE_ID,
+            extraArgs: ['-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition'],
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'test--error-compiler');
       }, 300_000);
     });
   });

--- a/src/snapshot-tests/suites/device-suite.ts
+++ b/src/snapshot-tests/suites/device-suite.ts
@@ -6,9 +6,9 @@ import {
   extractProcessIdFromSnapshotOutput,
 } from '../output-parsers.ts';
 import {
+  compilerErrorExtraArgs,
   createHarnessForRuntime,
   createWorkflowFixtureMatcher,
-  withCalculatorAppCompilerError,
 } from './helpers.ts';
 
 const WORKSPACE = 'example_projects/iOS_Calculator/CalculatorApp.xcworkspace';
@@ -67,12 +67,11 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
       });
 
       it('error - compiler error', async () => {
-        const { text, isError } = await withCalculatorAppCompilerError(() =>
-          harness.invoke('device', 'build', {
-            workspacePath: WORKSPACE,
-            scheme: 'CalculatorApp',
-          }),
-        );
+        const { text, isError } = await harness.invoke('device', 'build', {
+          workspacePath: WORKSPACE,
+          scheme: 'CalculatorApp',
+          extraArgs: compilerErrorExtraArgs(),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'build--error-compiler');
       });
@@ -156,13 +155,12 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
       });
 
       it('error - compiler error', async () => {
-        const { text, isError } = await withCalculatorAppCompilerError(() =>
-          harness.invoke('device', 'build-and-run', {
-            workspacePath: WORKSPACE,
-            scheme: 'CalculatorApp',
-            deviceId: DEVICE_ID,
-          }),
-        );
+        const { text, isError } = await harness.invoke('device', 'build-and-run', {
+          workspacePath: WORKSPACE,
+          scheme: 'CalculatorApp',
+          deviceId: DEVICE_ID,
+          extraArgs: compilerErrorExtraArgs(),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'build-and-run--error-compiler');
       });
@@ -245,14 +243,14 @@ export function registerDeviceSnapshotSuite(runtime: SnapshotRuntime): void {
       }, 300_000);
 
       it('error - compiler error', async () => {
-        const { text, isError } = await withCalculatorAppCompilerError(() =>
-          harness.invoke('device', 'test', {
-            workspacePath: WORKSPACE,
-            scheme: 'CalculatorApp',
-            deviceId: DEVICE_ID,
-            extraArgs: ['-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition'],
-          }),
-        );
+        const { text, isError } = await harness.invoke('device', 'test', {
+          workspacePath: WORKSPACE,
+          scheme: 'CalculatorApp',
+          deviceId: DEVICE_ID,
+          extraArgs: compilerErrorExtraArgs([
+            '-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition',
+          ]),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'test--error-compiler');
       }, 300_000);

--- a/src/snapshot-tests/suites/helpers.ts
+++ b/src/snapshot-tests/suites/helpers.ts
@@ -1,8 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { createFixtureMatcher, type FixtureMatchOptions } from '../fixture-io.ts';
 import { createSnapshotHarness } from '../harness.ts';
 import { createJsonSnapshotHarness } from '../json-harness.ts';
 import { createMcpSnapshotHarness } from '../mcp-harness.ts';
+
+const CALCULATOR_APP_SOURCE_PATH = path.resolve(
+  process.cwd(),
+  'example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift',
+);
+const MACOS_APP_SOURCE_PATH = path.resolve(
+  process.cwd(),
+  'example_projects/macOS/MCPTest/MCPTestApp.swift',
+);
+const COMPILER_ERROR_SNIPPET = 'private let snapshotCompilerError: Int = "not an int"';
 
 export function createHarnessForRuntime(
   runtime: SnapshotRuntime,
@@ -20,6 +32,38 @@ export function createHarnessForRuntime(
 
 export interface WorkflowFixtureMatcherOptions extends FixtureMatchOptions {
   fixtureRuntime?: SnapshotRuntime;
+}
+
+export async function withCalculatorAppCompilerError<T>(action: () => Promise<T>): Promise<T> {
+  const originalSource = fs.readFileSync(CALCULATOR_APP_SOURCE_PATH, 'utf8');
+
+  try {
+    fs.writeFileSync(
+      CALCULATOR_APP_SOURCE_PATH,
+      `${originalSource}\n${COMPILER_ERROR_SNIPPET}\n`,
+      'utf8',
+    );
+
+    return await action();
+  } finally {
+    fs.writeFileSync(CALCULATOR_APP_SOURCE_PATH, originalSource, 'utf8');
+  }
+}
+
+export async function withMacosAppCompilerError<T>(action: () => Promise<T>): Promise<T> {
+  const originalSource = fs.readFileSync(MACOS_APP_SOURCE_PATH, 'utf8');
+
+  try {
+    fs.writeFileSync(
+      MACOS_APP_SOURCE_PATH,
+      `${originalSource}\n${COMPILER_ERROR_SNIPPET}\n`,
+      'utf8',
+    );
+
+    return await action();
+  } finally {
+    fs.writeFileSync(MACOS_APP_SOURCE_PATH, originalSource, 'utf8');
+  }
 }
 
 export function createWorkflowFixtureMatcher(

--- a/src/snapshot-tests/suites/helpers.ts
+++ b/src/snapshot-tests/suites/helpers.ts
@@ -1,20 +1,10 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { createFixtureMatcher, type FixtureMatchOptions } from '../fixture-io.ts';
 import { createSnapshotHarness } from '../harness.ts';
 import { createJsonSnapshotHarness } from '../json-harness.ts';
 import { createMcpSnapshotHarness } from '../mcp-harness.ts';
 
-const CALCULATOR_APP_SOURCE_PATH = path.resolve(
-  process.cwd(),
-  'example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift',
-);
-const MACOS_APP_SOURCE_PATH = path.resolve(
-  process.cwd(),
-  'example_projects/macOS/MCPTest/MCPTestApp.swift',
-);
-const COMPILER_ERROR_SNIPPET = 'private let snapshotCompilerError: Int = "not an int"';
+const COMPILER_ERROR_EXTRA_ARGS = ['OTHER_SWIFT_FLAGS=$(inherited) -D SNAPSHOT_COMPILER_ERROR'];
 
 export function createHarnessForRuntime(
   runtime: SnapshotRuntime,
@@ -34,36 +24,8 @@ export interface WorkflowFixtureMatcherOptions extends FixtureMatchOptions {
   fixtureRuntime?: SnapshotRuntime;
 }
 
-export async function withCalculatorAppCompilerError<T>(action: () => Promise<T>): Promise<T> {
-  const originalSource = fs.readFileSync(CALCULATOR_APP_SOURCE_PATH, 'utf8');
-
-  try {
-    fs.writeFileSync(
-      CALCULATOR_APP_SOURCE_PATH,
-      `${originalSource}\n${COMPILER_ERROR_SNIPPET}\n`,
-      'utf8',
-    );
-
-    return await action();
-  } finally {
-    fs.writeFileSync(CALCULATOR_APP_SOURCE_PATH, originalSource, 'utf8');
-  }
-}
-
-export async function withMacosAppCompilerError<T>(action: () => Promise<T>): Promise<T> {
-  const originalSource = fs.readFileSync(MACOS_APP_SOURCE_PATH, 'utf8');
-
-  try {
-    fs.writeFileSync(
-      MACOS_APP_SOURCE_PATH,
-      `${originalSource}\n${COMPILER_ERROR_SNIPPET}\n`,
-      'utf8',
-    );
-
-    return await action();
-  } finally {
-    fs.writeFileSync(MACOS_APP_SOURCE_PATH, originalSource, 'utf8');
-  }
+export function compilerErrorExtraArgs(extraArgs: string[] = []): string[] {
+  return [...extraArgs, ...COMPILER_ERROR_EXTRA_ARGS];
 }
 
 export function createWorkflowFixtureMatcher(

--- a/src/snapshot-tests/suites/macos-suite.ts
+++ b/src/snapshot-tests/suites/macos-suite.ts
@@ -5,9 +5,9 @@ import path from 'node:path';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { extractAppPathFromSnapshotOutput } from '../output-parsers.ts';
 import {
+  compilerErrorExtraArgs,
   createHarnessForRuntime,
   createWorkflowFixtureMatcher,
-  withMacosAppCompilerError,
 } from './helpers.ts';
 
 const PROJECT = 'example_projects/macOS/MCPTest.xcodeproj';
@@ -74,12 +74,11 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
       });
 
       it('error - compiler error', { timeout: 120000 }, async () => {
-        const { text, isError } = await withMacosAppCompilerError(() =>
-          harness.invoke('macos', 'build', {
-            projectPath: PROJECT,
-            scheme: 'MCPTest',
-          }),
-        );
+        const { text, isError } = await harness.invoke('macos', 'build', {
+          projectPath: PROJECT,
+          scheme: 'MCPTest',
+          extraArgs: compilerErrorExtraArgs(),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'build--error-compiler');
       });
@@ -106,12 +105,11 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
       });
 
       it('error - compiler error', { timeout: 120000 }, async () => {
-        const { text, isError } = await withMacosAppCompilerError(() =>
-          harness.invoke('macos', 'build-and-run', {
-            projectPath: PROJECT,
-            scheme: 'MCPTest',
-          }),
-        );
+        const { text, isError } = await harness.invoke('macos', 'build-and-run', {
+          projectPath: PROJECT,
+          scheme: 'MCPTest',
+          extraArgs: compilerErrorExtraArgs(),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'build-and-run--error-compiler');
       });
@@ -152,16 +150,14 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
       });
 
       it('error - compiler error', { timeout: 120000 }, async () => {
-        const { text, isError } = await withMacosAppCompilerError(() =>
-          harness.invoke('macos', 'test', {
-            projectPath: PROJECT,
-            scheme: 'MCPTest',
-            extraArgs: [
-              '-only-testing:MCPTestTests/MCPTestTests/appNameIsCorrect()',
-              '-only-testing:MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect',
-            ],
-          }),
-        );
+        const { text, isError } = await harness.invoke('macos', 'test', {
+          projectPath: PROJECT,
+          scheme: 'MCPTest',
+          extraArgs: compilerErrorExtraArgs([
+            '-only-testing:MCPTestTests/MCPTestTests/appNameIsCorrect()',
+            '-only-testing:MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect',
+          ]),
+        });
         expect(isError).toBe(true);
         expectFixture(text, 'test--error-compiler');
       });

--- a/src/snapshot-tests/suites/macos-suite.ts
+++ b/src/snapshot-tests/suites/macos-suite.ts
@@ -4,7 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { extractAppPathFromSnapshotOutput } from '../output-parsers.ts';
-import { createHarnessForRuntime, createWorkflowFixtureMatcher } from './helpers.ts';
+import {
+  createHarnessForRuntime,
+  createWorkflowFixtureMatcher,
+  withMacosAppCompilerError,
+} from './helpers.ts';
 
 const PROJECT = 'example_projects/macOS/MCPTest.xcodeproj';
 
@@ -68,6 +72,17 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
         expect(isError).toBe(true);
         expectFixture(text, 'build--error-wrong-scheme');
       });
+
+      it('error - compiler error', { timeout: 120000 }, async () => {
+        const { text, isError } = await withMacosAppCompilerError(() =>
+          harness.invoke('macos', 'build', {
+            projectPath: PROJECT,
+            scheme: 'MCPTest',
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'build--error-compiler');
+      });
     });
 
     describe('build-and-run', () => {
@@ -88,6 +103,17 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
         });
         expect(isError).toBe(true);
         expectFixture(text, 'build-and-run--error-wrong-scheme');
+      });
+
+      it('error - compiler error', { timeout: 120000 }, async () => {
+        const { text, isError } = await withMacosAppCompilerError(() =>
+          harness.invoke('macos', 'build-and-run', {
+            projectPath: PROJECT,
+            scheme: 'MCPTest',
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'build-and-run--error-compiler');
       });
     });
 
@@ -123,6 +149,21 @@ export function registerMacosSnapshotSuite(runtime: SnapshotRuntime): void {
         });
         expect(isError).toBe(true);
         expectFixture(text, 'test--error-wrong-scheme');
+      });
+
+      it('error - compiler error', { timeout: 120000 }, async () => {
+        const { text, isError } = await withMacosAppCompilerError(() =>
+          harness.invoke('macos', 'test', {
+            projectPath: PROJECT,
+            scheme: 'MCPTest',
+            extraArgs: [
+              '-only-testing:MCPTestTests/MCPTestTests/appNameIsCorrect()',
+              '-only-testing:MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect',
+            ],
+          }),
+        );
+        expect(isError).toBe(true);
+        expectFixture(text, 'test--error-compiler');
       });
     });
 

--- a/src/snapshot-tests/suites/simulator-suite.ts
+++ b/src/snapshot-tests/suites/simulator-suite.ts
@@ -5,7 +5,11 @@ import path from 'node:path';
 import { ensureSimulatorBooted } from '../harness.ts';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { extractAppPathFromSnapshotOutput } from '../output-parsers.ts';
-import { createHarnessForRuntime, createWorkflowFixtureMatcher } from './helpers.ts';
+import {
+  createHarnessForRuntime,
+  createWorkflowFixtureMatcher,
+  withCalculatorAppCompilerError,
+} from './helpers.ts';
 
 const TEST_TIMEOUT_MS = 120_000;
 const WORKSPACE = 'example_projects/iOS_Calculator/CalculatorApp.xcworkspace';
@@ -63,6 +67,22 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
         },
         TEST_TIMEOUT_MS,
       );
+
+      it(
+        'error - compiler error',
+        async () => {
+          const { text, isError } = await withCalculatorAppCompilerError(() =>
+            harness.invoke('simulator', 'build', {
+              workspacePath: WORKSPACE,
+              scheme: SCHEME,
+              simulatorName: SIMULATOR_NAME,
+            }),
+          );
+          expect(isError).toBe(true);
+          expectFixture(text, 'build--error-compiler');
+        },
+        TEST_TIMEOUT_MS,
+      );
     });
 
     describe('build-and-run', () => {
@@ -91,6 +111,22 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
           });
           expect(isError).toBe(true);
           expectFixture(text, 'build-and-run--error-wrong-scheme');
+        },
+        TEST_TIMEOUT_MS,
+      );
+
+      it(
+        'error - compiler error',
+        async () => {
+          const { text, isError } = await withCalculatorAppCompilerError(() =>
+            harness.invoke('simulator', 'build-and-run', {
+              workspacePath: WORKSPACE,
+              scheme: SCHEME,
+              simulatorName: SIMULATOR_NAME,
+            }),
+          );
+          expect(isError).toBe(true);
+          expectFixture(text, 'build-and-run--error-compiler');
         },
         TEST_TIMEOUT_MS,
       );
@@ -138,6 +174,23 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
           });
           expect(isError).toBe(true);
           expectFixture(text, 'test--error-wrong-scheme');
+        },
+        TEST_TIMEOUT_MS,
+      );
+
+      it(
+        'error - compiler error',
+        async () => {
+          const { text, isError } = await withCalculatorAppCompilerError(() =>
+            harness.invoke('simulator', 'test', {
+              workspacePath: WORKSPACE,
+              scheme: SCHEME,
+              simulatorName: SIMULATOR_NAME,
+              extraArgs: ['-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition'],
+            }),
+          );
+          expect(isError).toBe(true);
+          expectFixture(text, 'test--error-compiler');
         },
         TEST_TIMEOUT_MS,
       );

--- a/src/snapshot-tests/suites/simulator-suite.ts
+++ b/src/snapshot-tests/suites/simulator-suite.ts
@@ -6,9 +6,9 @@ import { ensureSimulatorBooted } from '../harness.ts';
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { extractAppPathFromSnapshotOutput } from '../output-parsers.ts';
 import {
+  compilerErrorExtraArgs,
   createHarnessForRuntime,
   createWorkflowFixtureMatcher,
-  withCalculatorAppCompilerError,
 } from './helpers.ts';
 
 const TEST_TIMEOUT_MS = 120_000;
@@ -71,13 +71,12 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
       it(
         'error - compiler error',
         async () => {
-          const { text, isError } = await withCalculatorAppCompilerError(() =>
-            harness.invoke('simulator', 'build', {
-              workspacePath: WORKSPACE,
-              scheme: SCHEME,
-              simulatorName: SIMULATOR_NAME,
-            }),
-          );
+          const { text, isError } = await harness.invoke('simulator', 'build', {
+            workspacePath: WORKSPACE,
+            scheme: SCHEME,
+            simulatorName: SIMULATOR_NAME,
+            extraArgs: compilerErrorExtraArgs(),
+          });
           expect(isError).toBe(true);
           expectFixture(text, 'build--error-compiler');
         },
@@ -118,13 +117,12 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
       it(
         'error - compiler error',
         async () => {
-          const { text, isError } = await withCalculatorAppCompilerError(() =>
-            harness.invoke('simulator', 'build-and-run', {
-              workspacePath: WORKSPACE,
-              scheme: SCHEME,
-              simulatorName: SIMULATOR_NAME,
-            }),
-          );
+          const { text, isError } = await harness.invoke('simulator', 'build-and-run', {
+            workspacePath: WORKSPACE,
+            scheme: SCHEME,
+            simulatorName: SIMULATOR_NAME,
+            extraArgs: compilerErrorExtraArgs(),
+          });
           expect(isError).toBe(true);
           expectFixture(text, 'build-and-run--error-compiler');
         },
@@ -181,14 +179,14 @@ export function registerSimulatorSnapshotSuite(runtime: SnapshotRuntime): void {
       it(
         'error - compiler error',
         async () => {
-          const { text, isError } = await withCalculatorAppCompilerError(() =>
-            harness.invoke('simulator', 'test', {
-              workspacePath: WORKSPACE,
-              scheme: SCHEME,
-              simulatorName: SIMULATOR_NAME,
-              extraArgs: ['-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition'],
-            }),
-          );
+          const { text, isError } = await harness.invoke('simulator', 'test', {
+            workspacePath: WORKSPACE,
+            scheme: SCHEME,
+            simulatorName: SIMULATOR_NAME,
+            extraArgs: compilerErrorExtraArgs([
+              '-only-testing:CalculatorAppTests/CalculatorAppTests/testAddition',
+            ]),
+          });
           expect(isError).toBe(true);
           expectFixture(text, 'test--error-compiler');
         },

--- a/src/utils/__tests__/xcodebuild-event-parser.test.ts
+++ b/src/utils/__tests__/xcodebuild-event-parser.test.ts
@@ -262,6 +262,34 @@ describe('xcodebuild-event-parser', () => {
     });
   });
 
+  it('does not emit compiler errors for NSError selector dump lines', () => {
+    const events = collectEvents('TEST', [
+      { source: 'stderr', text: 'pid:error:,\n' },
+      {
+        source: 'stderr',
+        text: '} (error = Error Domain=FBSOpenApplicationServiceErrorDomain Code=1 "The request was denied" UserInfo={BSErrorCodeDescription=RequestDenied, SimCallingSelector=launchApplicationWithID:options:pid:error:, NSLocalizedDescription=The request was denied})\n',
+      },
+      {
+        source: 'stdout',
+        text: "Test Case '-[WeatherTests.WeatherTests testLoadsForecast]' passed (0.002 seconds)\n",
+      },
+    ]);
+
+    const errors = events.filter(
+      (e) => e.fragment === 'compiler-diagnostic' && e.severity === 'error',
+    );
+    const cases = events.filter((e) => e.fragment === 'test-case-result');
+
+    expect(errors).toHaveLength(0);
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toMatchObject({
+      fragment: 'test-case-result',
+      status: 'passed',
+      suite: 'WeatherTests',
+      test: 'testLoadsForecast',
+    });
+  });
+
   it('emits swift-testing issue fallbacks as test failures with the full raw line', () => {
     const line =
       '✘ Test "Parameterized failure" recorded an issue with 1 argument value → key:value: opaque failure';

--- a/src/utils/__tests__/xcodebuild-line-parsers.test.ts
+++ b/src/utils/__tests__/xcodebuild-line-parsers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isBuildErrorDiagnosticLine,
   parseBuildErrorDiagnostic,
   parseDurationMs,
   parseRawTestName,
@@ -18,6 +19,35 @@ describe('parseDurationMs', () => {
 });
 
 describe('parseBuildErrorDiagnostic', () => {
+  it('parses structured compiler and xcodebuild errors', () => {
+    expect(
+      parseBuildErrorDiagnostic(
+        "/tmp/App.swift:8:17: error: cannot convert value of type 'String' to specified type 'Int'",
+      ),
+    ).toEqual({
+      location: '/tmp/App.swift:8',
+      message: "cannot convert value of type 'String' to specified type 'Int'",
+      renderedLine:
+        "/tmp/App.swift:8:17: error: cannot convert value of type 'String' to specified type 'Int'",
+    });
+
+    expect(parseBuildErrorDiagnostic('/tmp/MyApp.xcodeproj: error: No such project')).toEqual({
+      location: '/tmp/MyApp.xcodeproj',
+      message: 'No such project',
+      renderedLine: '/tmp/MyApp.xcodeproj: error: No such project',
+    });
+
+    expect(parseBuildErrorDiagnostic('xcodebuild: error: Unable to find destination')).toEqual({
+      message: 'Unable to find destination',
+      renderedLine: 'xcodebuild: error: Unable to find destination',
+    });
+
+    expect(parseBuildErrorDiagnostic('error: emit-module command failed')).toEqual({
+      message: 'emit-module command failed',
+      renderedLine: 'error: emit-module command failed',
+    });
+  });
+
   it('preserves the full raw line for diagnostic-looking errors without a known structure', () => {
     const line = '2026-04-23 12:00:00.000 xcodebuild[123:456] error: IDE operation failed';
 
@@ -25,6 +55,19 @@ describe('parseBuildErrorDiagnostic', () => {
       message: line,
       renderedLine: line,
     });
+  });
+
+  it('does not classify Objective-C selector fragments or NSError dump lines as build errors', () => {
+    const selectorLine = 'pid:error:,';
+    const nserrorLine =
+      '} (error = Error Domain=FBSOpenApplicationServiceErrorDomain Code=1 "The request was denied" UserInfo={BSErrorCodeDescription=RequestDenied, SimCallingSelector=launchApplicationWithID:options:pid:error:, NSLocalizedDescription=The request was denied})';
+    const nsMachLine =
+      '} (error = Error Domain=NSMachErrorDomain Code=3 "No such process" UserInfo={NSLocalizedDescription=No such process})';
+
+    for (const line of [selectorLine, nserrorLine, nsMachLine]) {
+      expect(isBuildErrorDiagnosticLine(line)).toBe(false);
+      expect(parseBuildErrorDiagnostic(line)).toBeNull();
+    }
   });
 });
 

--- a/src/utils/renderers/__tests__/cli-text-renderer.test.ts
+++ b/src/utils/renderers/__tests__/cli-text-renderer.test.ts
@@ -191,6 +191,81 @@ describe('cli-text-renderer', () => {
     expect(output).toContain('\u{274C} Build failed. (\u{23F1}\u{FE0F} 1.2s)');
   });
 
+  it('does not flush buffered compiler errors after a successful final summary', () => {
+    const output = renderCliTextTranscript({
+      items: [
+        {
+          kind: 'test-result',
+          fragment: 'compiler-diagnostic',
+          severity: 'error',
+          operation: 'TEST',
+          message: 'SimCallingSelector=launchApplicationWithID:options:pid:error:,',
+          rawLine: 'SimCallingSelector=launchApplicationWithID:options:pid:error:,',
+        },
+        {
+          kind: 'test-result',
+          fragment: 'build-summary',
+          operation: 'TEST',
+          status: 'SUCCEEDED',
+          totalTests: 1,
+          passedTests: 1,
+          failedTests: 0,
+          skippedTests: 0,
+        },
+      ],
+    });
+
+    expect(output).toContain('✅ 1 test passed, 0 skipped');
+    expect(output).not.toContain('Compiler Errors (1):');
+    expect(output).not.toContain('SimCallingSelector=launchApplicationWithID:options:pid:error:,');
+  });
+
+  it('flushes buffered compiler errors after a failed final summary', () => {
+    const output = renderCliTextTranscript({
+      items: [
+        {
+          kind: 'test-result',
+          fragment: 'compiler-diagnostic',
+          severity: 'error',
+          operation: 'TEST',
+          message: 'unterminated string literal',
+          rawLine: '/tmp/MCPTest/ContentView.swift:16:18: error: unterminated string literal',
+        },
+        {
+          kind: 'test-result',
+          fragment: 'build-summary',
+          operation: 'TEST',
+          status: 'FAILED',
+          totalTests: 1,
+          passedTests: 0,
+          failedTests: 1,
+          skippedTests: 0,
+        },
+      ],
+    });
+
+    expect(output).toContain('Compiler Errors (1):');
+    expect(output).toContain('unterminated string literal');
+  });
+
+  it('flushes buffered compiler errors when final status is unknown', () => {
+    const output = renderCliTextTranscript({
+      items: [
+        {
+          kind: 'build-result',
+          fragment: 'compiler-diagnostic',
+          severity: 'error',
+          operation: 'BUILD',
+          message: 'unknown build failure',
+          rawLine: 'error: unknown build failure',
+        },
+      ],
+    });
+
+    expect(output).toContain('Errors (1):');
+    expect(output).toContain('unknown build failure');
+  });
+
   it('groups compiler diagnostics under a nested failure header before the failed summary', () => {
     const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     const renderer = createCliTextRenderer({ interactive: false });

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -105,6 +105,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
   let hasDurableRuntimeContent = false;
   let lastVisibleEventType: TextRenderableItem['type'] | null = null;
   let lastStatusLineLevel: StatusRenderItem['level'] | null = null;
+  let lastSummaryStatus: 'SUCCEEDED' | 'FAILED' | null = null;
   let structuredOutput: StructuredToolOutput | undefined;
   let sawIncomingHeaderEvent = false;
   let sawIncomingNonHeaderEvent = false;
@@ -281,6 +282,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       }
 
       case 'summary': {
+        lastSummaryStatus = item.status;
         const renderedDiagnostics = flushGroupedDiagnostics(item.status === 'FAILED');
 
         if (!renderedDiagnostics && item.status === 'FAILED') {
@@ -417,7 +419,10 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
           }
         }
       }
-      flushGroupedDiagnostics(true);
+      flushGroupedDiagnostics(lastSummaryStatus !== 'SUCCEEDED');
+      groupedCompilerErrors.length = 0;
+      groupedTestFailures.length = 0;
+      groupedWarnings.length = 0;
       const nextStepsBlock = createNextStepsBlock(nextSteps, nextStepsRuntime);
       if (nextStepsBlock && !sawProgressNextSteps) {
         processItem(nextStepsBlock);
@@ -428,6 +433,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       hasDurableRuntimeContent = false;
       lastVisibleEventType = null;
       lastStatusLineLevel = null;
+      lastSummaryStatus = null;
       structuredOutput = undefined;
       sawIncomingHeaderEvent = false;
       sawIncomingNonHeaderEvent = false;

--- a/src/utils/xcodebuild-line-parsers.ts
+++ b/src/utils/xcodebuild-line-parsers.ts
@@ -49,7 +49,7 @@ export interface ParsedBuildError {
   renderedLine: string;
 }
 
-const BUILD_ERROR_DIAGNOSTIC_PATTERN = /(?:^|[\s:])(?:fatal error|error):\s*\S/iu;
+const BUILD_ERROR_DIAGNOSTIC_PATTERN = /(?:^|\s)(?:fatal error|error):\s+\S/iu;
 
 export function isBuildErrorDiagnosticLine(line: string): boolean {
   return BUILD_ERROR_DIAGNOSTIC_PATTERN.test(line);


### PR DESCRIPTION
Fix false compiler-error sections in CLI test summaries when xcodebuild emits noisy NSError dump lines.

The parser previously treated embedded Objective-C selector labels such as `pid:error:,` as build diagnostics, which could turn simulator launch-service noise into a buffered compiler error. The CLI renderer could then flush that buffered error after a successful test summary, producing contradictory output.

This tightens build-error classification, aligns streaming finalization with successful summaries, and adds compiler-error snapshot coverage for simulator, device, and macOS build-style flows across CLI, MCP, and JSON output. The snapshot tests temporarily patch fixture source files and restore the original contents in `finally`; snapshot execution is configured serially via `vitest.snapshot.config.ts`.

Fixes #383
