### PR TITLE
test(smoke): Isolate xcodebuild log capture

### DIFF
--- a/src/smoke-tests/mcp-test-harness.ts
+++ b/src/smoke-tests/mcp-test-harness.ts
@@ -1,5 +1,7 @@
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import type { ChildProcess } from 'node:child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -35,6 +37,7 @@ import {
 } from '../utils/debugger/index.ts';
 import { getPackageRoot } from '../core/manifest/load-manifest.ts';
 import { shutdownXcodeToolsBridge } from '../integrations/xcode-tools-bridge/index.ts';
+import { setXcodebuildLogDirOverrideForTests } from '../utils/xcodebuild-log-capture.ts';
 
 export interface CapturedCommand {
   command: string[];
@@ -100,6 +103,9 @@ export async function createMcpTestHarness(opts?: McpTestHarnessOptions): Promis
   sessionStore.clear();
 
   const mockFs = createMockFileSystemExecutor();
+  const logDir = await mkdtemp(join(tmpdir(), 'xcodebuildmcp-smoke-logs-'));
+
+  setXcodebuildLogDirOverrideForTests(logDir);
 
   // Set executor overrides on the vitest-resolved source modules
   __setTestCommandExecutorOverride(capturingExecutor);
@@ -124,6 +130,13 @@ export async function createMcpTestHarness(opts?: McpTestHarnessOptions): Promis
   };
   builtCommandModule.__setTestCommandExecutorOverride(capturingExecutor);
   builtCommandModule.__setTestFileSystemExecutorOverride(mockFs);
+
+  const builtLogCaptureModule = (await import(
+    pathToFileURL(resolve(buildRoot, 'utils/xcodebuild-log-capture.js')).href
+  )) as {
+    setXcodebuildLogDirOverrideForTests: typeof setXcodebuildLogDirOverrideForTests;
+  };
+  builtLogCaptureModule.setXcodebuildLogDirOverrideForTests(logDir);
 
   // Set interactive spawner override (built module)
   const builtInteractiveModule = (await import(
@@ -238,6 +251,9 @@ export async function createMcpTestHarness(opts?: McpTestHarnessOptions): Promis
       builtInteractiveModule.__clearTestInteractiveSpawnerOverride();
       __clearTestDebuggerToolContextOverride();
       builtDebuggerModule.__clearTestDebuggerToolContextOverride();
+      setXcodebuildLogDirOverrideForTests(null);
+      builtLogCaptureModule.setXcodebuildLogDirOverrideForTests(null);
+      await rm(logDir, { recursive: true, force: true });
       __resetConfigStoreForTests();
       builtConfigStoreModule.__resetConfigStoreForTests();
       __resetServerStateForTests();


### PR DESCRIPTION
Isolate smoke-test xcodebuild log capture with a per-harness temporary log directory.

The workspace filesystem cleanup change made production log capture depend on configured runtime workspace state. That is correct for the real server, but the smoke harness mixes source-side bootstrap code with built tool modules. The source runtime singleton is configured, while the built log-capture module used by tool handlers is separate, so build-like smoke tests failed before reaching the mocked command executor.

This configures the source and built `xcodebuild-log-capture` test overrides to the same temporary directory and clears/removes it during harness cleanup. That keeps smoke tests isolated without weakening production runtime workspace requirements.

Validated locally with `npm run test:smoke`, `npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run test`.
