### PR TITLE
feat(xcode-ide): Persist bridge response artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ ESM TypeScript project (`type: module`). Key layers:
 - No `.js` imports in `src/` (enforced by ESLint)
 - No barrel imports from `utils/index` - import from specific submodules (e.g., `src/utils/execution/index.ts`, `src/utils/logging/index.ts`)
 
+
+## Rendering and Streaming Contract
+- Streaming fragments are transient output only. They MUST NOT be used as internal state, cached for final responses, or promoted into final MCP/JSON/CLI text output.
+- Non-streaming runtimes/output modes, including MCP final responses, MUST render only from the final structured result and next-step metadata. If final output needs data, add it to the final result type instead of reading it from fragments.
+- Only streaming-capable renderers may observe fragment callbacks, and only to print live progress. Their fragment handling must not affect final structured output or final rendered text.
+
 ## Test Conventions
 - Vitest with colocated `__tests__/` directories using `*.test.ts`
 - Smoke tests in `src/smoke-tests/__tests__/` (separate Vitest config, serial execution)
@@ -88,6 +94,7 @@ When reading issues:
 - Use shared lock and atomic-write helpers for mutable shared files.
 - Prefer one-record-per-file registries over shared aggregate files.
 - Cleanup must verify ownership before deleting shared artifacts.
+- User-facing artifact/log paths in final text or structured output must use `displayPath()` from `src/utils/build-preflight.ts`, so paths are cwd-relative when possible or `~/...` instead of absolute home paths. Keep stored files at their real absolute paths; only normalize response/display values.
 
 ## Style
 - Keep answers short and concise
@@ -98,6 +105,7 @@ When reading issues:
 ## Docs
 - Do not commit transient investigation notes, prompt exports, or scratch analysis docs after the work is complete.
 - If an investigation leaves unresolved follow-up work, move it to a GitHub issue instead of preserving the transient doc in the branch.
+- Structured output JSON schemas are auto-published to the website/public schema mirror when merged; do not manually update public schema copies unless explicitly asked.
 
 ### Changelog
 Location: `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 ### Changed
 
+- Updated Xcode IDE `call-tool` output to save raw remote responses as transient workspace-state JSON artifacts, summarize text output without embedding large relayed payloads, and support `--output json` / `--output jsonl` through the generic CLI output path.
 - Centralized workspace log retention and startup/shutdown filesystem cleanup so XcodeBuildMCP-owned logs are pruned consistently while preserving active daemon and simulator OSLog outputs.
+- Removed internal streaming-fragment context flags so final tool state now comes from explicit structured outputs instead of transient progress fragments ([#360](https://github.com/getsentry/XcodeBuildMCP/issues/360)).
 
 ## [2.5.0-beta.1]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ When reading issues:
 - Use shared lock and atomic-write helpers for mutable shared files.
 - Prefer one-record-per-file registries over shared aggregate files.
 - Cleanup must verify ownership before deleting shared artifacts.
+- User-facing artifact/log paths in final text or structured output must use `displayPath()` from `src/utils/build-preflight.ts`, so paths are cwd-relative when possible or `~/...` instead of absolute home paths. Keep stored files at their real absolute paths; only normalize response/display values.
 
 ## Style
 - Keep answers short and concise
@@ -39,6 +40,7 @@ When reading issues:
 ## Docs
 - Do not commit transient investigation notes, prompt exports, or scratch analysis docs after the work is complete.
 - If an investigation leaves unresolved follow-up work, move it to a GitHub issue instead of preserving the transient doc in the branch.
+- Structured output JSON schemas are auto-published to the website/public schema mirror when merged; do not manually update public schema copies unless explicitly asked.
 
 ### Changelog
 Location: `CHANGELOG.md`
@@ -61,6 +63,12 @@ Use these sections under `## [Unreleased]`:
 #### Attribution
 - **Internal changes (from issues)**: `Fixed foo bar ([#123](https://github.com/cameroncook/XcodeBuildMCP/issues/123))`
 - **External contributions**: `Added feature X ([#456](https://github.com/cameroncook/XcodeBuildMCP/pull/456) by [@username](https://github.com/username))`
+
+
+## Rendering and Streaming Contract
+- Streaming fragments are transient output only. They MUST NOT be used as internal state, cached for final responses, or promoted into final MCP/JSON/CLI text output.
+- Non-streaming runtimes/output modes, including MCP final responses, MUST render only from the final structured result and next-step metadata. If final output needs data, add it to the final result type instead of reading it from fragments.
+- Only streaming-capable renderers may observe fragment callbacks, and only to print live progress. Their fragment handling must not affect final structured output or final rendered text.
 
 ## Test Execution Rules
 - When running long test suites (snapshot tests, smoke tests), ALWAYS write full output to a log file and read it afterwards. NEVER pipe through `tail` or `grep` directly — that loses output you may need to debug failures.

--- a/manifests/tools/xcode_ide_call_tool.yaml
+++ b/manifests/tools/xcode_ide_call_tool.yaml
@@ -6,7 +6,7 @@ names:
 description: Call a remote Xcode IDE MCP tool.
 outputSchema:
   schema: xcodebuildmcp.output.xcode-bridge-call-result
-  version: "1"
+  version: '2'
 routing:
   stateful: true
 annotations:

--- a/manifests/tools/xcode_ide_list_tools.yaml
+++ b/manifests/tools/xcode_ide_list_tools.yaml
@@ -6,7 +6,7 @@ names:
 description: "Lists Xcode-IDE-only MCP capabilities (Use for: SwiftUI previews image capture, code snippet execution, issue Navigator/build logs, and window/tab context)."
 outputSchema:
   schema: xcodebuildmcp.output.xcode-bridge-tool-list
-  version: "1"
+  version: "2"
 routing:
   stateful: true
 annotations:

--- a/schemas/structured-output/xcodebuildmcp.output.error/1.schema.json
+++ b/schemas/structured-output/xcodebuildmcp.output.error/1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://xcodebuildmcp.com/schemas/structured-output/xcodebuildmcp.output.error/1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "https://xcodebuildmcp.com/schemas/structured-output/_defs/common.schema.json#/$defs/errorConsistency"
+    }
+  ],
+  "properties": {
+    "schema": {
+      "const": "xcodebuildmcp.output.error"
+    },
+    "schemaVersion": {
+      "const": "1"
+    },
+    "didError": {
+      "const": true
+    },
+    "error": {
+      "type": "string",
+      "minLength": 1
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "enum": ["runtime", "validation", "schema"]
+        },
+        "code": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["category", "code"]
+    }
+  },
+  "required": ["schema", "schemaVersion", "didError", "error", "data"]
+}

--- a/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-call-result/2.schema.json
+++ b/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-call-result/2.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://xcodebuildmcp.com/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-call-result/2.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "https://xcodebuildmcp.com/schemas/structured-output/_defs/common.schema.json#/$defs/errorConsistency"
+    }
+  ],
+  "$defs": {
+    "relayedContentItem": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string" }
+      },
+      "required": ["type"]
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rawResponseJsonPath": { "type": "string" }
+      },
+      "required": ["rawResponseJsonPath"]
+    }
+  },
+  "properties": {
+    "schema": { "const": "xcodebuildmcp.output.xcode-bridge-call-result" },
+    "schemaVersion": { "const": "2" },
+    "didError": { "type": "boolean" },
+    "error": { "type": ["string", "null"] },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "remoteTool": { "type": "string" },
+        "succeeded": { "type": "boolean" },
+        "content": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/relayedContentItem" }
+        },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
+      },
+      "required": ["remoteTool", "succeeded", "content"]
+    }
+  },
+  "required": ["schema", "schemaVersion", "didError", "error", "data"]
+}

--- a/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-tool-list/2.schema.json
+++ b/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-tool-list/2.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://xcodebuildmcp.com/schemas/structured-output/xcodebuildmcp.output.xcode-bridge-tool-list/2.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "https://xcodebuildmcp.com/schemas/structured-output/_defs/common.schema.json#/$defs/errorConsistency"
+    }
+  ],
+  "$defs": {
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rawResponseJsonPath": { "type": "string" }
+      },
+      "required": ["rawResponseJsonPath"]
+    }
+  },
+  "properties": {
+    "schema": { "const": "xcodebuildmcp.output.xcode-bridge-tool-list" },
+    "schemaVersion": { "const": "2" },
+    "didError": { "type": "boolean" },
+    "error": { "type": ["string", "null"] },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "toolCount": { "type": "integer", "minimum": 0 },
+        "artifacts": { "$ref": "#/$defs/artifacts" }
+      },
+      "required": ["toolCount"]
+    }
+  },
+  "required": ["schema", "schemaVersion", "didError", "error", "data"]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,23 @@ function findTopLevelCommand(argv: string[]): string | undefined {
   return undefined;
 }
 
+function findGlobalSocketOverride(argv: string[]): string | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--socket') {
+      const value = argv[index + 1];
+      return value && !value.startsWith('-') ? value : undefined;
+    }
+
+    if (token.startsWith('--socket=')) {
+      const value = token.slice('--socket='.length);
+      return value || undefined;
+    }
+  }
+
+  return undefined;
+}
+
 async function buildLightweightYargsApp(): Promise<ReturnType<typeof import('yargs').default>> {
   const yargs = (await import('yargs')).default;
   const { hideBin } = await import('yargs/helpers');
@@ -120,10 +137,12 @@ async function main(): Promise<void> {
 
   const { workspaceRoot, workspaceKey } = result;
 
-  const defaultSocketPath = getSocketPath({
-    cwd: result.runtime.cwd,
-    projectConfigPath: result.configPath,
-  });
+  const socketPath =
+    findGlobalSocketOverride(process.argv.slice(2)) ??
+    getSocketPath({
+      cwd: result.runtime.cwd,
+      projectConfigPath: result.configPath,
+    });
 
   const cliExposedWorkflowIds = await listCliWorkflowIdsFromManifest({
     excludeWorkflows: ['session-management', 'workflow-discovery'],
@@ -133,7 +152,7 @@ async function main(): Promise<void> {
 
   // CLI uses a manifest-resolved catalog plus daemon-backed xcode-ide dynamic tools.
   const catalog = await buildCliToolCatalog({
-    socketPath: defaultSocketPath,
+    socketPath,
     workspaceRoot,
     cliExposedWorkflowIds,
     discoveryMode,
@@ -142,7 +161,7 @@ async function main(): Promise<void> {
   const yargsApp = buildYargsApp({
     catalog,
     runtimeConfig: result.runtime.config,
-    defaultSocketPath,
+    defaultSocketPath: socketPath,
     workspaceRoot,
     workspaceKey,
     workflowNames: cliExposedWorkflowIds,

--- a/src/cli/__tests__/register-tool-commands.test.ts
+++ b/src/cli/__tests__/register-tool-commands.test.ts
@@ -493,20 +493,18 @@ describe('registerToolCommands', () => {
     );
   });
 
-  it('does not duplicate daemon-streamed fragments in the render session for jsonl output', async () => {
+  it('does not duplicate daemon-streamed fragments for jsonl output', async () => {
     const streamedFragment = {
       kind: 'transcript',
       fragment: 'process-line',
       stream: 'stderr',
       line: 'Build Log: /tmp/build.log\n',
     } as const;
-    let observedSessionFragmentCount = 0;
 
     vi.spyOn(DefaultToolInvoker.prototype, 'invokeDirect').mockImplementation(
       async (_tool, _args, opts) => {
         opts.renderSession?.emit(streamedFragment);
         opts.onProgress?.(streamedFragment);
-        observedSessionFragmentCount = opts.renderSession?.getFragments().length ?? 0;
         opts.onStructuredOutput?.({
           schema: 'xcodebuildmcp.output.simulator-list',
           schemaVersion: '1',
@@ -533,7 +531,6 @@ describe('registerToolCommands', () => {
       app.parseAsync(['simulator', 'run-tool', '--output', 'jsonl']),
     ).resolves.toBeDefined();
 
-    expect(observedSessionFragmentCount).toBe(1);
     expect(stdoutChunks.join('')).toBe(
       `${JSON.stringify({
         event: 'transcript.process-line',

--- a/src/cli/__tests__/register-tool-commands.test.ts
+++ b/src/cli/__tests__/register-tool-commands.test.ts
@@ -97,8 +97,6 @@ function mockInvokeDirectThroughHandler() {
         attach: (image) => {
           opts.renderSession?.attach(image);
         },
-        liveProgressEnabled: Boolean(opts.onProgress),
-        streamingFragmentsEnabled: Boolean(opts.onProgress),
       };
 
       await tool.handler(args, handlerContext);
@@ -576,7 +574,10 @@ describe('registerToolCommands', () => {
           schemaVersion: '1',
           didError: true,
           error: 'Tool did not produce structured output for --output json',
-          data: null,
+          data: {
+            category: 'runtime',
+            code: 'STRUCTURED_OUTPUT_MISSING',
+          },
         },
         null,
         2,
@@ -585,9 +586,38 @@ describe('registerToolCommands', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('rejects json and jsonl output for xcode-ide tools', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const tool = createTool({ workflow: 'xcode-ide' });
+  it('supports json and jsonl output for xcode-ide tools through the generic output path', async () => {
+    mockInvokeDirectThroughHandler();
+    const stdoutChunks: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    const tool = createTool({
+      workflow: 'xcode-ide',
+      cliSchema: {},
+      mcpSchema: {},
+      handler: vi.fn(async (_args, ctx) => {
+        if (ctx) {
+          ctx.structuredOutput = {
+            schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+            schemaVersion: '2',
+            result: {
+              kind: 'xcode-bridge-call-result',
+              didError: false,
+              error: null,
+              remoteTool: 'DocumentationSearch',
+              succeeded: true,
+              content: [],
+              artifacts: {
+                rawResponseJsonPath: '/tmp/xcode-ide-response.json',
+              },
+            },
+          };
+        }
+      }) as ToolDefinition['handler'],
+    });
     const app = yargs()
       .scriptName('xcodebuildmcp')
       .exitProcess(false)
@@ -605,19 +635,34 @@ describe('registerToolCommands', () => {
     await expect(
       app.parseAsync(['xcode-ide', 'run-tool', '--output', 'json']),
     ).resolves.toBeDefined();
-    expect(consoleError).toHaveBeenLastCalledWith(
-      'Error: --output json is not supported for xcode-ide tools yet',
+    expect(stdoutChunks.join('')).toBe(
+      `${JSON.stringify(
+        {
+          schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+          schemaVersion: '2',
+          didError: false,
+          error: null,
+          data: {
+            remoteTool: 'DocumentationSearch',
+            succeeded: true,
+            content: [],
+            artifacts: {
+              rawResponseJsonPath: '/tmp/xcode-ide-response.json',
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
     );
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBeUndefined();
 
-    process.exitCode = undefined;
+    stdoutChunks.length = 0;
 
     await expect(
       app.parseAsync(['xcode-ide', 'run-tool', '--output', 'jsonl']),
     ).resolves.toBeDefined();
-    expect(consoleError).toHaveBeenLastCalledWith(
-      'Error: --output jsonl is not supported for xcode-ide tools yet',
-    );
-    expect(process.exitCode).toBe(1);
+    expect(stdoutChunks.join('')).toBe('');
+    expect(process.exitCode).toBeUndefined();
   });
 });

--- a/src/cli/cli-tool-catalog.ts
+++ b/src/cli/cli-tool-catalog.ts
@@ -83,6 +83,18 @@ type DynamicBridgeTool = {
   annotations?: ToolAnnotations;
 };
 
+function getBridgeDiscoveryTimeoutMs(quickMode: boolean): number {
+  const configured = process.env.XCODEBUILDMCP_XCODE_IDE_DISCOVERY_TIMEOUT_MS;
+  if (configured !== undefined) {
+    const parsed = Number(configured);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return quickMode ? 400 : 250;
+}
+
 function createCliXcodeProxyTool(remoteTool: DynamicBridgeTool): ToolDefinition {
   const cliSchema = jsonSchemaToToolSchemaShape(remoteTool.inputSchema);
 
@@ -109,7 +121,7 @@ async function loadDaemonBackedXcodeProxyTools(
   const quickMode = discoveryMode === 'quick';
   const daemonClient = new DaemonClient({
     socketPath: opts.socketPath,
-    timeout: quickMode ? 400 : 250,
+    timeout: getBridgeDiscoveryTimeoutMs(quickMode),
   });
 
   try {

--- a/src/cli/register-tool-commands.ts
+++ b/src/cli/register-tool-commands.ts
@@ -18,6 +18,11 @@ import {
 } from './session-defaults.ts';
 import { createRenderSession } from '../rendering/render.ts';
 import { toStructuredEnvelope } from '../utils/structured-output-envelope.ts';
+import {
+  createStructuredErrorOutput,
+  STRUCTURED_ERROR_SCHEMA,
+  STRUCTURED_ERROR_SCHEMA_VERSION,
+} from '../utils/structured-error.ts';
 import { toCliJsonlEvent } from './jsonl-event.ts';
 
 export interface RegisterToolCommandsOptions {
@@ -73,11 +78,9 @@ function setEnvScoped(key: string, value: string): () => void {
 
 function createBufferedHandlerContext(
   session: ReturnType<typeof createRenderSession>,
-  opts: { liveProgressEnabled: boolean; onProgress?: (fragment: AnyFragment) => void },
+  opts: { onProgress?: (fragment: AnyFragment) => void },
 ): ToolHandlerContext {
   return {
-    liveProgressEnabled: opts.liveProgressEnabled,
-    streamingFragmentsEnabled: opts.liveProgressEnabled,
     emit: (fragment) => {
       session.emit(fragment);
       opts?.onProgress?.(fragment);
@@ -88,9 +91,6 @@ function createBufferedHandlerContext(
   };
 }
 
-const JSON_ERROR_SCHEMA = 'xcodebuildmcp.output.error';
-const JSON_ERROR_SCHEMA_VERSION = '1';
-
 function writeJsonOutput(handlerContext: ToolHandlerContext): boolean {
   const structuredOutput = handlerContext.structuredOutput;
 
@@ -100,13 +100,15 @@ function writeJsonOutput(handlerContext: ToolHandlerContext): boolean {
         structuredOutput.schema,
         structuredOutput.schemaVersion,
       )
-    : {
-        schema: JSON_ERROR_SCHEMA,
-        schemaVersion: JSON_ERROR_SCHEMA_VERSION,
-        didError: true,
-        error: 'Tool did not produce structured output for --output json',
-        data: null,
-      };
+    : toStructuredEnvelope(
+        createStructuredErrorOutput({
+          category: 'runtime',
+          code: 'STRUCTURED_OUTPUT_MISSING',
+          message: 'Tool did not produce structured output for --output json',
+        }).result,
+        STRUCTURED_ERROR_SCHEMA,
+        STRUCTURED_ERROR_SCHEMA_VERSION,
+      );
 
   process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
   return envelope.didError;
@@ -269,12 +271,6 @@ function registerToolSubcommand(
       const socketPath = argv.socket as string;
       const logLevel = argv['log-level'] as string | undefined;
 
-      if (tool.workflow === 'xcode-ide' && (outputFormat === 'json' || outputFormat === 'jsonl')) {
-        console.error(`Error: --output ${outputFormat} is not supported for xcode-ide tools yet`);
-        process.exitCode = 1;
-        return;
-      }
-
       if (
         profileOverride &&
         !isKnownCliSessionDefaultsProfile(opts.runtimeConfig, profileOverride)
@@ -359,7 +355,6 @@ function registerToolSubcommand(
               }
             : undefined;
         const handlerContext = createBufferedHandlerContext(session, {
-          liveProgressEnabled: outputFormat === 'text' || outputFormat === 'jsonl',
           onProgress: writeJsonlFragment,
         });
 

--- a/src/core/__tests__/structured-output-schema.test.ts
+++ b/src/core/__tests__/structured-output-schema.test.ts
@@ -78,6 +78,20 @@ describe('structured output schema bundling', () => {
     expectStandaloneCompile(schema);
   });
 
+  it('bundles the shared structured error schema', () => {
+    const schema = getMcpOutputSchema({
+      schema: 'xcodebuildmcp.output.error',
+      version: '1',
+    });
+
+    expect(schema.$id).toBe(
+      'https://xcodebuildmcp.com/schemas/structured-output/xcodebuildmcp.output.error/1.schema.json',
+    );
+    expect((schema.$defs as JsonObject).errorConsistency).toBeDefined();
+    expectNoExternalCommonRefs(schema);
+    expectStandaloneCompile(schema);
+  });
+
   it('returns fresh schema objects from the cache', () => {
     const first = getMcpOutputSchema({
       schema: 'xcodebuildmcp.output.simulator-list',
@@ -92,7 +106,7 @@ describe('structured output schema bundling', () => {
     expect(second.mutated).toBeUndefined();
   });
 
-  it('advertises the bundled schema through the registration wrapper', () => {
+  it('advertises tool-specific and shared error schemas through the registration wrapper', () => {
     const ref = {
       schema: 'xcodebuildmcp.output.simulator-list',
       version: '1',
@@ -100,8 +114,66 @@ describe('structured output schema bundling', () => {
     const outputSchema = getMcpOutputSchemaForRegistration(ref);
     const jsonSchema = z.toJSONSchema(outputSchema) as JsonObject;
 
-    expect(jsonSchema).toEqual(getMcpOutputSchema(ref));
+    expect(jsonSchema).toEqual({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://xcodebuildmcp.com/schemas/structured-output/xcodebuildmcp.output.simulator-list/1.registration.schema.json',
+      type: 'object',
+      oneOf: [
+        getMcpOutputSchema(ref),
+        getMcpOutputSchema({ schema: 'xcodebuildmcp.output.error', version: '1' }),
+      ],
+    });
     expectNoExternalCommonRefs(jsonSchema);
+    expectStandaloneCompile(jsonSchema);
+  });
+
+  it('accepts structured error envelopes in registered output schemas', () => {
+    const outputSchema = getMcpOutputSchemaForRegistration({
+      schema: 'xcodebuildmcp.output.simulator-list',
+      version: '1',
+    });
+    const jsonSchema = z.toJSONSchema(outputSchema) as JsonObject;
+    const ajv = new Ajv2020({ allErrors: true, strict: true, validateSchema: true });
+    const validate = ajv.compile(jsonSchema);
+
+    expect(
+      validate({
+        schema: 'xcodebuildmcp.output.error',
+        schemaVersion: '1',
+        didError: true,
+        error: 'Parameter validation failed',
+        data: {
+          category: 'validation',
+          code: 'PARAMETER_VALIDATION_FAILED',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts xcode bridge call-result artifacts', () => {
+    const schema = getMcpOutputSchema({
+      schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+      version: '2',
+    });
+    const ajv = new Ajv2020({ allErrors: true, strict: true, validateSchema: true });
+    const validate = ajv.compile(schema);
+
+    expect(
+      validate({
+        schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+        schemaVersion: '2',
+        didError: false,
+        error: null,
+        data: {
+          remoteTool: 'DocumentationSearch',
+          succeeded: true,
+          content: [],
+          artifacts: {
+            rawResponseJsonPath: '/tmp/xcode-ide-response.json',
+          },
+        },
+      }),
+    ).toBe(true);
   });
 
   it('resolves every manifest-declared output schema', () => {

--- a/src/core/structured-output-schema.ts
+++ b/src/core/structured-output-schema.ts
@@ -17,6 +17,11 @@ export interface StructuredOutputSchemaRef {
 export type JsonObject = Record<string, unknown>;
 export type McpOutputSchema = ZodType;
 
+const STRUCTURED_ERROR_SCHEMA_REF: StructuredOutputSchemaRef = {
+  schema: 'xcodebuildmcp.output.error',
+  version: '1',
+};
+
 const bundledSchemaCache = new Map<string, JsonObject>();
 
 function isRecord(value: unknown): value is JsonObject {
@@ -216,6 +221,20 @@ export function getMcpOutputSchema(ref: StructuredOutputSchemaRef): JsonObject {
   return cloneJson(bundled);
 }
 
+function getMcpOutputSchemaForRegistrationJson(ref: StructuredOutputSchemaRef): JsonObject {
+  const toolSchema = getMcpOutputSchema(ref);
+  if (ref.schema === STRUCTURED_ERROR_SCHEMA_REF.schema) {
+    return toolSchema;
+  }
+
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://xcodebuildmcp.com/schemas/structured-output/${ref.schema}/${ref.version}.registration.schema.json`,
+    type: 'object',
+    oneOf: [toolSchema, getMcpOutputSchema(STRUCTURED_ERROR_SCHEMA_REF)],
+  };
+}
+
 export function getMcpOutputSchemaForRegistration(ref: StructuredOutputSchemaRef): McpOutputSchema {
   const zodSchema = z.object({}).passthrough();
   const schemaWithJsonHook = zodSchema as ZodType & {
@@ -225,7 +244,7 @@ export function getMcpOutputSchemaForRegistration(ref: StructuredOutputSchemaRef
     throw new Error('Zod schema internals are unavailable for MCP output schema registration.');
   }
 
-  schemaWithJsonHook._zod.toJSONSchema = () => getMcpOutputSchema(ref);
+  schemaWithJsonHook._zod.toJSONSchema = () => getMcpOutputSchemaForRegistrationJson(ref);
   return zodSchema;
 }
 

--- a/src/daemon/__tests__/tool-invoke-streaming.test.ts
+++ b/src/daemon/__tests__/tool-invoke-streaming.test.ts
@@ -2,10 +2,22 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import type net from 'node:net';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DaemonClient } from '../../cli/daemon-client.ts';
 import { startDaemonServer } from '../daemon-server.ts';
 import type { ToolCatalog, ToolDefinition } from '../../runtime/types.ts';
+
+const xcodeIdeInvokeToolMock = vi.hoisted(() => vi.fn());
+const xcodeIdeDisconnectMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('../../integrations/xcode-tools-bridge/tool-service.ts', () => ({
+  XcodeIdeToolService: vi.fn().mockImplementation(() => ({
+    setWorkflowEnabled: vi.fn(),
+    listTools: vi.fn(async () => []),
+    invokeTool: xcodeIdeInvokeToolMock,
+    disconnect: xcodeIdeDisconnectMock,
+  })),
+}));
 
 function createCatalog(tools: ToolDefinition[]): ToolCatalog {
   return {
@@ -55,6 +67,8 @@ describe('daemon tool.invoke streaming', () => {
         await rm(path.dirname(socketPath), { recursive: true, force: true });
       }),
     );
+    xcodeIdeInvokeToolMock.mockReset();
+    xcodeIdeDisconnectMock.mockClear();
   });
 
   it('streams fragments to the daemon client callback and still returns a terminal structured result', async () => {
@@ -164,7 +178,7 @@ describe('daemon tool.invoke streaming', () => {
     });
   });
 
-  it('returns an error frame when the handler throws', async () => {
+  it('returns a terminal structured error when the handler throws', async () => {
     const tool: ToolDefinition = {
       cliName: 'failing-tool',
       mcpName: 'failing_tool',
@@ -195,7 +209,52 @@ describe('daemon tool.invoke streaming', () => {
     await listen(server, socketPath);
 
     const client = new DaemonClient({ socketPath, timeout: 1000 });
+    const result = await client.invokeTool('failing_tool', {});
 
-    await expect(client.invokeTool('failing_tool', {})).rejects.toThrow('INTERNAL: boom');
+    expect(result.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        didError: true,
+        code: 'DIRECT_HANDLER_FAILED',
+        error: 'Tool execution failed: boom',
+      }),
+    );
+  });
+
+  it('returns a terminal xcode-ide structured error when bridge invocation throws', async () => {
+    xcodeIdeInvokeToolMock.mockRejectedValueOnce(new Error('bridge unavailable'));
+
+    const socketPath = await createSocketPath();
+    cleanupPaths.push(socketPath);
+
+    const server = startDaemonServer({
+      socketPath,
+      startedAt: new Date().toISOString(),
+      enabledWorkflows: ['xcode-ide'],
+      catalog: createCatalog([]),
+      workspaceRoot: '/repo',
+      workspaceKey: 'repo-key',
+      xcodeIdeWorkflowEnabled: true,
+      requestShutdown: () => {},
+    });
+    cleanupServers.push(server);
+    await listen(server, socketPath);
+
+    const client = new DaemonClient({ socketPath, timeout: 1000 });
+    const result = await client.invokeXcodeIdeTool('FailingRemote', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredOutput).toEqual({
+      schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+      schemaVersion: '2',
+      result: {
+        kind: 'xcode-bridge-call-result',
+        remoteTool: 'FailingRemote',
+        didError: true,
+        error: 'bridge unavailable',
+        succeeded: false,
+        content: [{ type: 'text', text: 'bridge unavailable' }],
+      },
+    });
   });
 });

--- a/src/daemon/daemon-server.ts
+++ b/src/daemon/daemon-server.ts
@@ -1,9 +1,8 @@
 import net from 'node:net';
 import { writeFrame, createFrameReader } from './framing.ts';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolCatalog } from '../runtime/types.ts';
-import type { ToolResponse } from '../types/common.ts';
 import type { AnyFragment } from '../types/domain-fragments.ts';
-import type { RuntimeStatusFragment } from '../types/runtime-status.ts';
 import type {
   DaemonRequest,
   DaemonResponse,
@@ -24,7 +23,12 @@ import type { ToolHandlerContext } from '../rendering/types.ts';
 
 import { log } from '../utils/logger.ts';
 import { XcodeIdeToolService } from '../integrations/xcode-tools-bridge/tool-service.ts';
+import {
+  callToolResultToBridgeResultWithArtifact,
+  type BridgeToolResult,
+} from '../integrations/xcode-tools-bridge/bridge-tool-result.ts';
 import { toLocalToolName } from '../integrations/xcode-tools-bridge/registry.ts';
+import { toBridgeCallResultDomainResult } from '../mcp/tools/xcode-ide/shared.ts';
 
 export interface DaemonServerContext {
   socketPath: string;
@@ -44,25 +48,44 @@ export interface DaemonServerContext {
   onRequestFinished?: () => void;
 }
 
-function toolResponseToDaemonResult(response: ToolResponse): DaemonToolResult {
-  const fragments: AnyFragment[] = [];
-  for (const item of response.content) {
-    if (item.type === 'text' && item.text) {
-      const statusFragment: RuntimeStatusFragment = {
-        kind: 'infrastructure',
-        fragment: 'status',
-        level: response.isError ? 'error' : 'success',
-        message: item.text,
-      };
-      fragments.push(statusFragment);
-    }
-  }
+function bridgeResultToDaemonResult(
+  remoteTool: string,
+  bridgeResult: BridgeToolResult,
+): DaemonToolResult {
+  const result = toBridgeCallResultDomainResult(bridgeResult, remoteTool);
   return {
-    ...(fragments.length > 0 ? { fragments } : {}),
-    isError: response.isError === true,
-    nextStepParams: response.nextStepParams,
-    nextSteps: response.nextSteps,
+    structuredOutput: {
+      schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+      schemaVersion: '2',
+      result,
+    },
+    isError: result.didError,
+    nextStepParams: bridgeResult.nextStepParams,
   };
+}
+
+async function toolResponseToDaemonResult(
+  remoteTool: string,
+  response: CallToolResult,
+  args: Record<string, unknown>,
+): Promise<DaemonToolResult> {
+  return bridgeResultToDaemonResult(
+    remoteTool,
+    await callToolResultToBridgeResultWithArtifact(response, { remoteTool, arguments: args }),
+  );
+}
+
+function toolErrorToDaemonResult(remoteTool: string, error: unknown): DaemonToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return bridgeResultToDaemonResult(remoteTool, {
+    isError: true,
+    errorMessage: message,
+    payload: {
+      kind: 'call-result',
+      succeeded: false,
+      content: [{ type: 'text', text: message }],
+    },
+  });
 }
 
 /**
@@ -180,8 +203,6 @@ export function startDaemonServer(ctx: DaemonServerContext): net.Server {
               };
 
               const handlerContext: ToolHandlerContext = {
-                liveProgressEnabled: false,
-                streamingFragmentsEnabled: true,
                 emit: (fragment) => {
                   streamFragment(fragment);
                 },
@@ -219,8 +240,8 @@ export function startDaemonServer(ctx: DaemonServerContext): net.Server {
               }
 
               const params = (req.params ?? {}) as XcodeIdeListParams;
-              const refresh = params.refresh === true;
-              if (params.prefetch === true && !refresh) {
+              const refresh = params.refresh;
+              if (params.prefetch === true && refresh !== true) {
                 void xcodeIdeService.listTools({ refresh: true }).catch((error) => {
                   const message = error instanceof Error ? error.message : String(error);
                   log('debug', `[Daemon] xcode-ide prefetch failed: ${message}`);
@@ -264,11 +285,21 @@ export function startDaemonServer(ctx: DaemonServerContext): net.Server {
                 });
               }
 
-              const response = await xcodeIdeService.invokeTool(
-                params.remoteTool,
-                params.args ?? {},
-              );
-              const xcodeResult = toolResponseToDaemonResult(response as ToolResponse);
+              let xcodeResult: DaemonToolResult;
+              try {
+                const response = await xcodeIdeService.invokeTool(
+                  params.remoteTool,
+                  params.args ?? {},
+                );
+                xcodeResult = await toolResponseToDaemonResult(
+                  params.remoteTool,
+                  response,
+                  params.args ?? {},
+                );
+              } catch (error) {
+                xcodeResult = toolErrorToDaemonResult(params.remoteTool, error);
+              }
+
               const result: XcodeIdeInvokeResult = { result: xcodeResult };
               return writeFrame(socket, { ...base, result });
             }

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -2,7 +2,7 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { StructuredToolOutput } from '../rendering/types.ts';
 import type { NextStep, NextStepParamsMap } from '../types/common.ts';
 import type { AnyFragment } from '../types/domain-fragments.ts';
-export const DAEMON_PROTOCOL_VERSION = 6 as const;
+export const DAEMON_PROTOCOL_VERSION = 7 as const;
 
 export type DaemonMethod =
   | 'daemon.status'
@@ -65,7 +65,7 @@ export interface ToolInvokeResultFrame {
 }
 
 export interface DaemonToolResult {
-  fragments?: AnyFragment[];
+  structuredOutput: StructuredToolOutput | null;
   isError: boolean;
   nextStepParams?: NextStepParamsMap;
   nextSteps?: NextStep[];

--- a/src/integrations/xcode-tools-bridge/bridge-response-artifact.ts
+++ b/src/integrations/xcode-tools-bridge/bridge-response-artifact.ts
@@ -1,0 +1,79 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { SerializedBridgeTool } from './core.ts';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { displayPath } from '../../utils/build-preflight.ts';
+import { getWorkspaceFilesystemLayout } from '../../utils/log-paths.ts';
+import { formatLogTimestamp, shortRandomSuffix } from '../../utils/log-naming.ts';
+import { getRuntimeInstance } from '../../utils/runtime-instance.ts';
+
+export interface BridgeCallResponseArtifactInput {
+  remoteTool: string;
+  arguments: Record<string, unknown>;
+  timeoutMs?: number;
+  response: CallToolResult;
+}
+
+export interface BridgeToolListResponseArtifactInput {
+  refresh?: boolean;
+  tools: SerializedBridgeTool[];
+}
+
+export interface BridgeResponseArtifact {
+  path: string;
+}
+
+function sanitizeFilenameSegment(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
+  return sanitized.length > 0 ? sanitized : 'remote-tool';
+}
+
+function createArtifactPath(subject: string): string {
+  const runtime = getRuntimeInstance();
+  const stateDir = getWorkspaceFilesystemLayout(runtime.workspaceKey).state;
+  const ownerDir = `ownerpid${runtime.pid}_${sanitizeFilenameSegment(runtime.instanceId)}`;
+  const fileName = `${formatLogTimestamp()}-${sanitizeFilenameSegment(subject)}-${shortRandomSuffix()}.json`;
+  return path.join(stateDir, 'xcode-ide', 'call-tool', ownerDir, fileName);
+}
+
+async function writeArtifactFile(
+  subject: string,
+  artifact: Record<string, unknown>,
+): Promise<BridgeResponseArtifact> {
+  const artifactPath = createArtifactPath(subject);
+  const artifactDir = path.dirname(artifactPath);
+  await fs.mkdir(artifactDir, { recursive: true, mode: 0o700 });
+
+  await fs.writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+  return { path: displayPath(artifactPath) };
+}
+
+export async function writeBridgeCallResponseArtifact(
+  input: BridgeCallResponseArtifactInput,
+): Promise<BridgeResponseArtifact> {
+  return await writeArtifactFile(input.remoteTool, {
+    remoteTool: input.remoteTool,
+    arguments: input.arguments,
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    capturedAt: new Date().toISOString(),
+    response: input.response,
+  });
+}
+
+export async function writeBridgeToolListResponseArtifact(
+  input: BridgeToolListResponseArtifactInput,
+): Promise<BridgeResponseArtifact> {
+  return await writeArtifactFile('list-tools', {
+    operation: 'list-tools',
+    ...(input.refresh !== undefined ? { refresh: input.refresh } : {}),
+    capturedAt: new Date().toISOString(),
+    response: {
+      toolCount: input.tools.length,
+      tools: input.tools,
+    },
+  });
+}

--- a/src/integrations/xcode-tools-bridge/bridge-tool-result.ts
+++ b/src/integrations/xcode-tools-bridge/bridge-tool-result.ts
@@ -1,22 +1,39 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { NextStepParamsMap } from '../../types/common.ts';
-import type { SerializedBridgeTool, XcodeToolsBridgeStatus } from './core.ts';
+import type { XcodeToolsBridgeStatus } from './core.ts';
 import type { ProxySyncResult } from './registry.ts';
+import { writeBridgeCallResponseArtifact } from './bridge-response-artifact.ts';
 
 export interface BridgeCallContentItem {
   type: string;
   [key: string]: unknown;
 }
 
+export interface BridgeResponseArtifacts {
+  rawResponseJsonPath: string;
+}
+
+export type BridgeCallResultArtifacts = BridgeResponseArtifacts;
+
+export interface BridgeCallArtifactContext {
+  remoteTool: string;
+  arguments: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
 export type BridgeToolPayload =
   | { kind: 'status'; status: XcodeToolsBridgeStatus }
   | { kind: 'sync'; sync: ProxySyncResult; status?: XcodeToolsBridgeStatus }
-  | { kind: 'tool-list'; toolCount: number; tools: SerializedBridgeTool[] }
+  | {
+      kind: 'tool-list';
+      toolCount: number;
+      artifacts?: BridgeResponseArtifacts;
+    }
   | {
       kind: 'call-result';
       succeeded: boolean;
       content: BridgeCallContentItem[];
-      structuredContent?: Record<string, unknown> | null;
+      artifacts?: BridgeCallResultArtifacts;
     };
 
 export interface BridgeToolResult {
@@ -32,9 +49,6 @@ export function callToolResultToBridgeResult(result: CallToolResult): BridgeTool
   const content = Array.isArray(result.content)
     ? result.content.filter(isBridgeCallContentItem).map((item) => ({ ...item }))
     : [];
-  const structuredContent = toStructuredContent(
-    (result as Record<string, unknown>).structuredContent,
-  );
   const errorMessage = result.isError ? extractErrorMessage(content) : undefined;
 
   for (const item of result.content ?? []) {
@@ -52,9 +66,42 @@ export function callToolResultToBridgeResult(result: CallToolResult): BridgeTool
     payload: {
       kind: 'call-result',
       succeeded: !Boolean(result.isError),
-      content,
-      ...(structuredContent !== undefined ? { structuredContent } : {}),
+      content: [],
     },
+  };
+}
+
+export async function callToolResultToBridgeResultWithArtifact(
+  result: CallToolResult,
+  context: BridgeCallArtifactContext,
+): Promise<BridgeToolResult> {
+  const bridgeResult = callToolResultToBridgeResult(result);
+  let artifact: Awaited<ReturnType<typeof writeBridgeCallResponseArtifact>>;
+  try {
+    artifact = await writeBridgeCallResponseArtifact({
+      remoteTool: context.remoteTool,
+      arguments: context.arguments,
+      ...(context.timeoutMs !== undefined ? { timeoutMs: context.timeoutMs } : {}),
+      response: result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to write Xcode IDE bridge response artifact: ${message}`);
+  }
+
+  const payload = bridgeResult.payload;
+  return {
+    ...bridgeResult,
+    ...(payload?.kind === 'call-result'
+      ? {
+          payload: {
+            kind: 'call-result',
+            succeeded: payload.succeeded,
+            content: [],
+            artifacts: { rawResponseJsonPath: artifact.path },
+          },
+        }
+      : {}),
   };
 }
 
@@ -65,19 +112,6 @@ function isBridgeCallContentItem(value: unknown): value is BridgeCallContentItem
 
   const item = value as Record<string, unknown>;
   return typeof item.type === 'string';
-}
-
-function toStructuredContent(value: unknown): Record<string, unknown> | null | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value === null) {
-    return null;
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
 }
 
 function extractErrorMessage(content: BridgeCallContentItem[]): string | undefined {

--- a/src/integrations/xcode-tools-bridge/client.ts
+++ b/src/integrations/xcode-tools-bridge/client.ts
@@ -42,7 +42,7 @@ export class XcodeToolsBridgeClient {
   constructor(options: XcodeToolsBridgeClientOptions = {}) {
     this.options = {
       connectTimeoutMs: options.connectTimeoutMs ?? 15_000,
-      listToolsTimeoutMs: options.listToolsTimeoutMs ?? 15_000,
+      listToolsTimeoutMs: options.listToolsTimeoutMs ?? 60_000,
       callToolTimeoutMs: options.callToolTimeoutMs ?? 60_000,
       ...options,
     };

--- a/src/integrations/xcode-tools-bridge/manager.ts
+++ b/src/integrations/xcode-tools-bridge/manager.ts
@@ -1,7 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from '../../utils/logger.ts';
+import { writeBridgeToolListResponseArtifact } from './bridge-response-artifact.ts';
 import {
-  callToolResultToBridgeResult,
+  callToolResultToBridgeResultWithArtifact,
   type BridgeToolPayload,
   type BridgeToolResult,
 } from './bridge-tool-result.ts';
@@ -173,18 +174,23 @@ export class XcodeToolsBridgeManager {
       return this.createBridgeFailureResult(
         'XCODE_MCP_UNAVAILABLE',
         'xcode-ide workflow is not enabled',
-        { kind: 'tool-list', toolCount: 0, tools: [] },
+        { kind: 'tool-list', toolCount: 0 },
       );
     }
 
     try {
-      const tools = await this.service.listTools({ refresh: params.refresh !== false });
-      const payload = {
-        toolCount: tools.length,
-        tools: tools.map(serializeBridgeTool),
-      };
+      const tools = await this.service.listTools({ refresh: params.refresh });
+      const serializedTools = tools.map(serializeBridgeTool);
+      const artifact = await writeBridgeToolListResponseArtifact({
+        ...(params.refresh !== undefined ? { refresh: params.refresh } : {}),
+        tools: serializedTools,
+      });
       return {
-        payload: { kind: 'tool-list', ...payload },
+        payload: {
+          kind: 'tool-list',
+          toolCount: serializedTools.length,
+          artifacts: { rawResponseJsonPath: artifact.path },
+        },
       };
     } catch (error) {
       return this.createBridgeFailureResult(
@@ -192,7 +198,7 @@ export class XcodeToolsBridgeManager {
           connected: this.service.getClientStatus().connected,
         }),
         error,
-        { kind: 'tool-list', toolCount: 0, tools: [] },
+        { kind: 'tool-list', toolCount: 0 },
       );
     }
   }
@@ -214,7 +220,11 @@ export class XcodeToolsBridgeManager {
       const response = await this.service.invokeTool(params.remoteTool, params.arguments, {
         timeoutMs: params.timeoutMs,
       });
-      return callToolResultToBridgeResult(response);
+      return await callToolResultToBridgeResultWithArtifact(response, {
+        remoteTool: params.remoteTool,
+        arguments: params.arguments,
+        ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      });
     } catch (error) {
       return this.createBridgeFailureResult(
         classifyBridgeError(error, 'call', {

--- a/src/integrations/xcode-tools-bridge/standalone.ts
+++ b/src/integrations/xcode-tools-bridge/standalone.ts
@@ -1,4 +1,8 @@
-import { callToolResultToBridgeResult, type BridgeToolResult } from './bridge-tool-result.ts';
+import { writeBridgeToolListResponseArtifact } from './bridge-response-artifact.ts';
+import {
+  callToolResultToBridgeResultWithArtifact,
+  type BridgeToolResult,
+} from './bridge-tool-result.ts';
 import {
   buildXcodeToolsBridgeStatus,
   classifyBridgeError,
@@ -21,8 +25,8 @@ export class StandaloneXcodeToolsBridge {
 
   async getStatus(): Promise<XcodeToolsBridgeStatus> {
     return buildXcodeToolsBridgeStatus({
-      workflowEnabled: false,
-      proxiedToolCount: 0,
+      workflowEnabled: this.service.isWorkflowEnabled(),
+      proxiedToolCount: this.service.getCachedTools().length,
       lastError: this.service.getLastError(),
       clientStatus: this.service.getClientStatus(),
     });
@@ -61,8 +65,6 @@ export class StandaloneXcodeToolsBridge {
           ...(status ? { status } : {}),
         },
       };
-    } finally {
-      await this.service.disconnect();
     }
   }
 
@@ -86,13 +88,18 @@ export class StandaloneXcodeToolsBridge {
 
   async listToolsTool(params: { refresh?: boolean }): Promise<BridgeToolResult> {
     try {
-      const tools = await this.service.listTools({ refresh: params.refresh !== false });
-      const payload = {
-        toolCount: tools.length,
-        tools: tools.map(serializeBridgeTool),
-      };
+      const tools = await this.service.listTools({ refresh: params.refresh });
+      const serializedTools = tools.map(serializeBridgeTool);
+      const artifact = await writeBridgeToolListResponseArtifact({
+        ...(params.refresh !== undefined ? { refresh: params.refresh } : {}),
+        tools: serializedTools,
+      });
       return {
-        payload: { kind: 'tool-list', ...payload },
+        payload: {
+          kind: 'tool-list',
+          toolCount: serializedTools.length,
+          artifacts: { rawResponseJsonPath: artifact.path },
+        },
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -100,10 +107,8 @@ export class StandaloneXcodeToolsBridge {
       return {
         isError: true,
         errorMessage: `[${code}] ${message}`,
-        payload: { kind: 'tool-list', toolCount: 0, tools: [] },
+        payload: { kind: 'tool-list', toolCount: 0 },
       };
-    } finally {
-      await this.service.disconnect();
     }
   }
 
@@ -116,7 +121,11 @@ export class StandaloneXcodeToolsBridge {
       const response = await this.service.invokeTool(params.remoteTool, params.arguments, {
         timeoutMs: params.timeoutMs,
       });
-      return callToolResultToBridgeResult(response);
+      return await callToolResultToBridgeResultWithArtifact(response, {
+        remoteTool: params.remoteTool,
+        arguments: params.arguments,
+        ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const code = classifyBridgeError(error, 'call');
@@ -125,8 +134,6 @@ export class StandaloneXcodeToolsBridge {
         errorMessage: `[${code}] ${message}`,
         payload: { kind: 'call-result', succeeded: false, content: [] },
       };
-    } finally {
-      await this.service.disconnect();
     }
   }
 

--- a/src/integrations/xcode-tools-bridge/tool-service.ts
+++ b/src/integrations/xcode-tools-bridge/tool-service.ts
@@ -83,9 +83,15 @@ export class XcodeIdeToolService {
   }
 
   async listTools(opts: ListBridgeToolsOptions = {}): Promise<Tool[]> {
-    if (opts.refresh === false) {
-      return this.getCachedTools();
+    if (opts.refresh === true) {
+      return this.refreshTools();
     }
+
+    const cachedTools = this.getCachedTools();
+    if (opts.refresh === false || cachedTools.length > 0) {
+      return cachedTools;
+    }
+
     return this.refreshTools();
   }
 

--- a/src/mcp/resources/devices.ts
+++ b/src/mcp/resources/devices.ts
@@ -9,25 +9,16 @@ import { log } from '../../utils/logging/index.ts';
 import type { CommandExecutor } from '../../utils/execution/index.ts';
 import { getDefaultCommandExecutor } from '../../utils/execution/index.ts';
 import { list_devicesLogic } from '../tools/device/list_devices.ts';
-import { createRenderSession } from '../../rendering/render.ts';
 import { handlerContextStorage } from '../../utils/typed-tool-factory.ts';
 import type { ToolHandlerContext } from '../../rendering/types.ts';
-import type { AnyFragment } from '../../types/domain-fragments.ts';
 
 import { renderCliTextTranscript } from '../../utils/renderers/cli-text-renderer.ts';
 
 export async function devicesResourceLogic(
   executor: CommandExecutor = getDefaultCommandExecutor(),
 ): Promise<{ contents: Array<{ text: string }> }> {
-  const session = createRenderSession('text');
-  const items: AnyFragment[] = [];
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: false,
-    streamingFragmentsEnabled: false,
-    emit: (fragment: AnyFragment) => {
-      items.push(fragment);
-      session.emit(fragment);
-    },
+    emit: () => {},
     attach: () => {},
   };
 
@@ -35,11 +26,10 @@ export async function devicesResourceLogic(
     log('info', 'Processing devices resource request');
     await handlerContextStorage.run(ctx, () => list_devicesLogic({}, executor));
     const text = renderCliTextTranscript({
-      items,
       structuredOutput: ctx.structuredOutput,
       nextSteps: ctx.nextSteps,
     });
-    const isError = session.isError() || ctx.structuredOutput?.result.didError === true;
+    const isError = ctx.structuredOutput?.result.didError === true;
     if (isError) {
       throw new Error(text || 'Failed to retrieve device data');
     }

--- a/src/mcp/resources/simulators.ts
+++ b/src/mcp/resources/simulators.ts
@@ -9,25 +9,16 @@ import { log } from '../../utils/logging/index.ts';
 import { getDefaultCommandExecutor } from '../../utils/execution/index.ts';
 import type { CommandExecutor } from '../../utils/execution/index.ts';
 import { list_simsLogic } from '../tools/simulator/list_sims.ts';
-import { createRenderSession } from '../../rendering/render.ts';
 import { handlerContextStorage } from '../../utils/typed-tool-factory.ts';
 import type { ToolHandlerContext } from '../../rendering/types.ts';
-import type { AnyFragment } from '../../types/domain-fragments.ts';
 
 import { renderCliTextTranscript } from '../../utils/renderers/cli-text-renderer.ts';
 
 export async function simulatorsResourceLogic(
   executor: CommandExecutor = getDefaultCommandExecutor(),
 ): Promise<{ contents: Array<{ text: string }> }> {
-  const session = createRenderSession('text');
-  const items: AnyFragment[] = [];
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: false,
-    streamingFragmentsEnabled: false,
-    emit: (fragment: AnyFragment) => {
-      items.push(fragment);
-      session.emit(fragment);
-    },
+    emit: () => {},
     attach: () => {},
   };
 
@@ -35,14 +26,13 @@ export async function simulatorsResourceLogic(
     log('info', 'Processing simulators resource request');
     await handlerContextStorage.run(ctx, () => list_simsLogic({ enabled: true }, executor));
     const text = renderCliTextTranscript({
-      items,
       structuredOutput: ctx.structuredOutput,
       nextSteps: ctx.nextSteps,
     });
     const structuredError = ctx.structuredOutput?.result.didError
       ? (ctx.structuredOutput.result.error ?? null)
       : null;
-    const isError = session.isError() || ctx.structuredOutput?.result.didError === true;
+    const isError = ctx.structuredOutput?.result.didError === true;
     if (isError) {
       throw new Error(structuredError ?? (text || 'Failed to retrieve simulator data'));
     }

--- a/src/mcp/tools/device/__tests__/build_run_device.test.ts
+++ b/src/mcp/tools/device/__tests__/build_run_device.test.ts
@@ -325,5 +325,40 @@ describe('build_run_device tool', () => {
       expectPendingBuildRunResponse(result, true);
       expect(result.nextStepParams).toBeUndefined();
     });
+
+    it('sets structured output error when executor rejects after build preparation', async () => {
+      const mockExecutor: CommandExecutor = async (command) => {
+        if (command.includes('-showBuildSettings')) {
+          return createMockCommandResponse({
+            success: true,
+            output: 'BUILT_PRODUCTS_DIR = /tmp/build\\nFULL_PRODUCT_NAME = MyApp.app\\n',
+          });
+        }
+
+        if (command[0] === 'defaults' || command[0] === '/usr/libexec/PlistBuddy') {
+          return createMockCommandResponse({ success: true, output: 'io.sentry.MyApp' });
+        }
+
+        if (command.includes('install')) {
+          return Promise.reject(new Error('executor rejected during install'));
+        }
+
+        return createMockCommandResponse({ success: true, output: 'OK' });
+      };
+
+      const { response, result } = await runBuildRunDeviceLogic(
+        {
+          projectPath: '/tmp/MyApp.xcodeproj',
+          scheme: 'MyApp',
+          deviceId: 'DEVICE-UDID',
+        },
+        mockExecutor,
+        createMockFileSystemExecutor(),
+      );
+
+      expect(response).toBeUndefined();
+      expectPendingBuildRunResponse(result, true);
+      expect(result.nextStepParams).toBeUndefined();
+    });
   });
 });

--- a/src/mcp/tools/device/build_run_device.ts
+++ b/src/mcp/tools/device/build_run_device.ts
@@ -92,84 +92,178 @@ export function createBuildRunDeviceExecutor(
     };
     const started = createDomainStreamingPipeline('build_run_device', 'BUILD', ctx);
 
-    const buildResult = await executeXcodeBuildCommand(
-      sharedBuildParams,
-      {
-        platform,
-        logPrefix: `${platform} Device Build`,
-      },
-      params.preferXcodebuild ?? false,
-      'build',
-      executor,
-      undefined,
-      started.pipeline,
-    );
-
-    if (buildResult.isError) {
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'device',
-        artifacts: {
-          deviceId: params.deviceId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
-        request,
-      });
-    }
-
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'started',
-    });
-
-    let appPath: string;
     try {
-      appPath = await resolveAppPathFromBuildSettings(
+      const buildResult = await executeXcodeBuildCommand(
+        sharedBuildParams,
         {
-          projectPath: params.projectPath,
-          workspacePath: params.workspacePath,
-          scheme: params.scheme,
-          configuration,
           platform,
-          derivedDataPath: params.derivedDataPath,
-          extraArgs: params.extraArgs,
+          logPrefix: `${platform} Device Build`,
         },
+        params.preferXcodebuild ?? false,
+        'build',
         executor,
+        undefined,
+        started.pipeline,
       );
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'device',
-        artifacts: {
-          deviceId: params.deviceId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to get app path to launch: ${errorMessage}`,
-        ]),
-        request,
-      });
-    }
 
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'succeeded',
-    });
-
-    let bundleId: string;
-    try {
-      bundleId = (await extractBundleIdFromAppPath(appPath, executor)).trim();
-      if (bundleId.length === 0) {
-        throw new Error('Empty bundle ID returned');
+      if (buildResult.isError) {
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'device',
+          artifacts: {
+            deviceId: params.deviceId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
+          request,
+        });
       }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'started',
+      });
+
+      let appPath: string;
+      try {
+        appPath = await resolveAppPathFromBuildSettings(
+          {
+            projectPath: params.projectPath,
+            workspacePath: params.workspacePath,
+            scheme: params.scheme,
+            configuration,
+            platform,
+            derivedDataPath: params.derivedDataPath,
+            extraArgs: params.extraArgs,
+          },
+          executor,
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'device',
+          artifacts: {
+            deviceId: params.deviceId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to get app path to launch: ${errorMessage}`,
+          ]),
+          request,
+        });
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'succeeded',
+      });
+
+      let bundleId: string;
+      try {
+        bundleId = (await extractBundleIdFromAppPath(appPath, executor)).trim();
+        if (bundleId.length === 0) {
+          throw new Error('Empty bundle ID returned');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'device',
+          artifacts: {
+            deviceId: params.deviceId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to extract bundle ID: ${errorMessage}`,
+          ]),
+          request,
+        });
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'install-app',
+        status: 'started',
+      });
+      const installResult = await installAppOnDevice(params.deviceId, appPath, executor);
+      if (!installResult.success) {
+        const errorMessage = installResult.error ?? 'Failed to install app';
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'device',
+          artifacts: {
+            deviceId: params.deviceId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to install app on device: ${errorMessage}`,
+          ]),
+          request,
+        });
+      }
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'install-app',
+        status: 'succeeded',
+      });
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'launch-app',
+        status: 'started',
+      });
+      const launchResult = await launchAppOnDevice(
+        params.deviceId,
+        bundleId,
+        executor,
+        fileSystemExecutor,
+        { env: params.env },
+      );
+      if (!launchResult.success) {
+        const errorMessage = launchResult.error ?? 'Failed to launch app';
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'device',
+          artifacts: {
+            deviceId: params.deviceId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to launch app on device: ${errorMessage}`,
+          ]),
+          request,
+        });
+      }
+
+      const processId = launchResult.processId;
+      log('info', `Device build and run succeeded for scheme ${params.scheme}.`);
+
+      return createBuildRunDomainResult({
+        started,
+        succeeded: true,
+        target: 'device',
+        artifacts: {
+          appPath,
+          bundleId,
+          ...(processId !== undefined ? { processId } : {}),
+          deviceId: params.deviceId,
+          buildLogPath: started.pipeline.logPath,
+        },
+        request,
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       return createBuildRunDomainResult({
@@ -181,88 +275,11 @@ export function createBuildRunDeviceExecutor(
           buildLogPath: started.pipeline.logPath,
         },
         fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to extract bundle ID: ${errorMessage}`,
+          `Error during device build and run: ${errorMessage}`,
         ]),
         request,
       });
     }
-
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'install-app',
-      status: 'started',
-    });
-    const installResult = await installAppOnDevice(params.deviceId, appPath, executor);
-    if (!installResult.success) {
-      const errorMessage = installResult.error ?? 'Failed to install app';
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'device',
-        artifacts: {
-          deviceId: params.deviceId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to install app on device: ${errorMessage}`,
-        ]),
-        request,
-      });
-    }
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'install-app',
-      status: 'succeeded',
-    });
-
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'launch-app',
-      status: 'started',
-    });
-    const launchResult = await launchAppOnDevice(
-      params.deviceId,
-      bundleId,
-      executor,
-      fileSystemExecutor,
-      { env: params.env },
-    );
-    if (!launchResult.success) {
-      const errorMessage = launchResult.error ?? 'Failed to launch app';
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'device',
-        artifacts: {
-          deviceId: params.deviceId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to launch app on device: ${errorMessage}`,
-        ]),
-        request,
-      });
-    }
-
-    const processId = launchResult.processId;
-    log('info', `Device build and run succeeded for scheme ${params.scheme}.`);
-
-    return createBuildRunDomainResult({
-      started,
-      succeeded: true,
-      target: 'device',
-      artifacts: {
-        appPath,
-        bundleId,
-        ...(processId !== undefined ? { processId } : {}),
-        deviceId: params.deviceId,
-        buildLogPath: started.pipeline.logPath,
-      },
-      request,
-    });
   };
 }
 
@@ -287,6 +304,7 @@ export async function build_run_deviceLogic(
   ctx.emit(createBuildInvocationFragment('build-run-result', 'BUILD', invocationRequest));
   const executionContext = createStreamingExecutionContext(ctx);
   const executeBuildRunDevice = createBuildRunDeviceExecutor(executor, fileSystemExecutor);
+
   const result = await executeBuildRunDevice(params, executionContext);
 
   setXcodebuildStructuredOutput(ctx, 'build-run-result', result);

--- a/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
+++ b/src/mcp/tools/macos/__tests__/build_run_macos.test.ts
@@ -343,6 +343,61 @@ describe('build_run_macos', () => {
       expect(result.nextStepParams).toBeUndefined();
     });
 
+    it('should set structured output error when executor rejects after build preparation', async () => {
+      let callCount = 0;
+      const mockExecutor = (
+        command: string[],
+        description?: string,
+        logOutput?: boolean,
+        opts?: { cwd?: string },
+        detached?: boolean,
+      ) => {
+        callCount++;
+        void command;
+        void description;
+        void logOutput;
+        void opts;
+        void detached;
+
+        if (callCount === 1) {
+          return Promise.resolve({
+            success: true,
+            output: 'BUILD SUCCEEDED',
+            error: '',
+            process: mockProcess,
+          });
+        }
+
+        if (callCount === 2) {
+          return Promise.resolve({
+            success: true,
+            output: 'BUILT_PRODUCTS_DIR = /path/to/build\\nFULL_PRODUCT_NAME = MyApp.app',
+            error: '',
+            process: mockProcess,
+          });
+        }
+
+        if (callCount === 3) {
+          return Promise.reject(new Error('executor rejected during launch'));
+        }
+
+        return Promise.resolve({ success: true, output: '', error: '', process: mockProcess });
+      };
+
+      const args = {
+        projectPath: '/path/to/project.xcodeproj',
+        scheme: 'MyApp',
+        configuration: 'Debug',
+        preferXcodebuild: false,
+      };
+
+      const { response, result } = await runBuildRunMacOSLogic(args, mockExecutor);
+
+      expect(response).toBeUndefined();
+      expectPendingBuildRunResponse(result, true);
+      expect(result.nextStepParams).toBeUndefined();
+    });
+
     it('should use default configuration when not provided', async () => {
       let callCount = 0;
       const executorCalls: any[] = [];

--- a/src/mcp/tools/macos/build_run_macos.ts
+++ b/src/mcp/tools/macos/build_run_macos.ts
@@ -78,50 +78,123 @@ export function createBuildRunMacOSExecutor(
     const configuration = params.configuration ?? 'Debug';
     const request = createBuildRunMacOSRequest(params);
     const started = createDomainStreamingPipeline('build_run_macos', 'BUILD', ctx);
-    const buildResult = await executeXcodeBuildCommand(
-      { ...params, configuration },
-      { platform: XcodePlatform.macOS, arch: params.arch, logPrefix: 'macOS Build' },
-      params.preferXcodebuild ?? false,
-      'build',
-      executor,
-      undefined,
-      started.pipeline,
-    );
+    try {
+      const buildResult = await executeXcodeBuildCommand(
+        { ...params, configuration },
+        { platform: XcodePlatform.macOS, arch: params.arch, logPrefix: 'macOS Build' },
+        params.preferXcodebuild ?? false,
+        'build',
+        executor,
+        undefined,
+        started.pipeline,
+      );
 
-    if (buildResult.isError) {
+      if (buildResult.isError) {
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'macos',
+          artifacts: {
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
+          request,
+        });
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'started',
+      });
+
+      let appPath: string;
+      try {
+        appPath = await resolveAppPathFromBuildSettings(
+          {
+            projectPath: params.projectPath,
+            workspacePath: params.workspacePath,
+            scheme: params.scheme,
+            configuration,
+            platform: XcodePlatform.macOS,
+            derivedDataPath: params.derivedDataPath,
+            extraArgs: params.extraArgs,
+          },
+          executor,
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'macos',
+          artifacts: {
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to get app path to launch: ${errorMessage}`,
+          ]),
+          request,
+        });
+      }
+
+      log('info', `App path determined as: ${appPath}`);
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'succeeded',
+      });
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'launch-app',
+        status: 'started',
+      });
+
+      const macLaunchResult = await launchMacApp(appPath, executor);
+      if (!macLaunchResult.success) {
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'macos',
+          artifacts: {
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to launch app ${appPath}: ${macLaunchResult.error ?? 'Failed to launch app'}`,
+          ]),
+          request,
+        });
+      }
+
+      log('info', `macOS app launched successfully: ${appPath}`);
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'launch-app',
+        status: 'succeeded',
+      });
+
       return createBuildRunDomainResult({
         started,
-        succeeded: false,
+        succeeded: true,
         target: 'macos',
         artifacts: {
+          appPath,
+          ...(macLaunchResult.bundleId ? { bundleId: macLaunchResult.bundleId } : {}),
+          ...(macLaunchResult.processId !== undefined
+            ? { processId: macLaunchResult.processId }
+            : {}),
           buildLogPath: started.pipeline.logPath,
         },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
+        output: {
+          stdout: [],
+          stderr: [],
+        },
         request,
       });
-    }
-
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'started',
-    });
-
-    let appPath: string;
-    try {
-      appPath = await resolveAppPathFromBuildSettings(
-        {
-          projectPath: params.projectPath,
-          workspacePath: params.workspacePath,
-          scheme: params.scheme,
-          configuration,
-          platform: XcodePlatform.macOS,
-          derivedDataPath: params.derivedDataPath,
-          extraArgs: params.extraArgs,
-        },
-        executor,
-      );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       return createBuildRunDomainResult({
@@ -132,68 +205,11 @@ export function createBuildRunMacOSExecutor(
           buildLogPath: started.pipeline.logPath,
         },
         fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to get app path to launch: ${errorMessage}`,
+          `Error during macOS build and run: ${errorMessage}`,
         ]),
         request,
       });
     }
-
-    log('info', `App path determined as: ${appPath}`);
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'succeeded',
-    });
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'launch-app',
-      status: 'started',
-    });
-
-    const macLaunchResult = await launchMacApp(appPath, executor);
-    if (!macLaunchResult.success) {
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'macos',
-        artifacts: {
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to launch app ${appPath}: ${macLaunchResult.error ?? 'Failed to launch app'}`,
-        ]),
-        request,
-      });
-    }
-
-    log('info', `macOS app launched successfully: ${appPath}`);
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'launch-app',
-      status: 'succeeded',
-    });
-
-    return createBuildRunDomainResult({
-      started,
-      succeeded: true,
-      target: 'macos',
-      artifacts: {
-        appPath,
-        ...(macLaunchResult.bundleId ? { bundleId: macLaunchResult.bundleId } : {}),
-        ...(macLaunchResult.processId !== undefined
-          ? { processId: macLaunchResult.processId }
-          : {}),
-        buildLogPath: started.pipeline.logPath,
-      },
-      output: {
-        stdout: [],
-        stderr: [],
-      },
-      request,
-    });
   };
 }
 
@@ -207,6 +223,7 @@ export async function buildRunMacOSLogic(
   ctx.emit(createBuildInvocationFragment('build-run-result', 'BUILD', invocationRequest));
   const executionContext = createStreamingExecutionContext(ctx);
   const executeBuildRunMacOS = createBuildRunMacOSExecutor(executor);
+
   const result = await executeBuildRunMacOS(params, executionContext);
 
   setXcodebuildStructuredOutput(ctx, 'build-run-result', result);

--- a/src/mcp/tools/simulator/__tests__/build_run_sim.test.ts
+++ b/src/mcp/tools/simulator/__tests__/build_run_sim.test.ts
@@ -326,6 +326,41 @@ describe('build_run_sim tool', () => {
       const text = result.text();
       expect(text).toContain('Error during simulator build and run');
     });
+
+    it('sets structured output error when executor rejects after preparation', async () => {
+      let callCount = 0;
+      const mockExecutor: CommandExecutor = async (command) => {
+        callCount++;
+
+        if (callCount === 1 && command[0] === 'xcrun' && command[1] === 'simctl') {
+          return createMockCommandResponse({
+            success: true,
+            output: JSON.stringify({
+              devices: {
+                'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+                  { udid: 'SIM-UUID', name: 'iPhone 17', isAvailable: true },
+                ],
+              },
+            }),
+          });
+        }
+
+        return Promise.reject(new Error('executor rejected after preparation'));
+      };
+
+      const { response, result } = await runBuildRunSimLogic(
+        {
+          workspacePath: '/path/to/workspace',
+          scheme: 'MyScheme',
+          simulatorName: 'iPhone 17',
+        },
+        mockExecutor,
+      );
+
+      expect(response).toBeUndefined();
+      expect(result.isError()).toBe(true);
+      expect(result.nextStepParams).toBeUndefined();
+    });
   });
 
   describe('Command Generation', () => {

--- a/src/mcp/tools/simulator/build_run_sim.ts
+++ b/src/mcp/tools/simulator/build_run_sim.ts
@@ -190,9 +190,34 @@ export function createBuildRunSimExecutor(
 
     const started = createDomainStreamingPipeline('build_run_sim', 'BUILD', ctx);
 
-    if (params.simulatorId) {
-      const validation = await validateAvailableSimulatorId(params.simulatorId, executor);
-      if (validation.error) {
+    try {
+      if (params.simulatorId) {
+        const validation = await validateAvailableSimulatorId(params.simulatorId, executor);
+        if (validation.error) {
+          return createBuildRunDomainResult({
+            started,
+            succeeded: false,
+            target: 'simulator',
+            artifacts: {
+              buildLogPath: started.pipeline.logPath,
+            },
+            fallbackErrorMessages: collectFallbackErrorMessages(started, [validation.error]),
+            request: resolved.invocationRequest,
+          });
+        }
+      }
+
+      const buildResult = await executeXcodeBuildCommand(
+        resolved.sharedBuildParams,
+        resolved.platformOptions,
+        params.preferXcodebuild ?? false,
+        'build',
+        executor,
+        undefined,
+        started.pipeline,
+      );
+
+      if (buildResult.isError) {
         return createBuildRunDomainResult({
           started,
           succeeded: false,
@@ -200,221 +225,258 @@ export function createBuildRunSimExecutor(
           artifacts: {
             buildLogPath: started.pipeline.logPath,
           },
-          fallbackErrorMessages: collectFallbackErrorMessages(started, [validation.error]),
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
           request: resolved.invocationRequest,
         });
       }
-    }
 
-    const buildResult = await executeXcodeBuildCommand(
-      resolved.sharedBuildParams,
-      resolved.platformOptions,
-      params.preferXcodebuild ?? false,
-      'build',
-      executor,
-      undefined,
-      started.pipeline,
-    );
-
-    if (buildResult.isError) {
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'simulator',
-        artifacts: {
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [], buildResult.content),
-        request: resolved.invocationRequest,
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'started',
       });
-    }
 
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'started',
-    });
-
-    let destination: string;
-    if (params.simulatorId) {
-      destination = constructDestinationString(
-        resolved.detectedPlatform,
-        undefined,
-        params.simulatorId,
-      );
-    } else if (params.simulatorName) {
-      destination = constructDestinationString(
-        resolved.detectedPlatform,
-        params.simulatorName,
-        undefined,
-        params.useLatestOS ?? true,
-      );
-    } else {
-      destination = constructDestinationString(resolved.detectedPlatform);
-    }
-
-    let appBundlePath: string;
-    try {
-      appBundlePath = await resolveAppPathFromBuildSettings(
-        {
-          projectPath: params.projectPath,
-          workspacePath: params.workspacePath,
-          scheme: params.scheme,
-          configuration: resolved.configuration,
-          platform: resolved.detectedPlatform,
-          destination,
-          derivedDataPath: params.derivedDataPath,
-          extraArgs: params.extraArgs,
-        },
-        executor,
-      );
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'simulator',
-        artifacts: {
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to get app path to launch: ${errorMessage}`,
-        ]),
-        request: resolved.invocationRequest,
-      });
-    }
-
-    log('info', `App bundle path for run: ${appBundlePath}`);
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'resolve-app-path',
-      status: 'succeeded',
-    });
-
-    const uuidResult = await determineSimulatorUuid(
-      { simulatorId: params.simulatorId, simulatorName: params.simulatorName },
-      executor,
-    );
-
-    if (uuidResult.error || !uuidResult.uuid) {
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'simulator',
-        artifacts: {
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          uuidResult.error ?? 'Failed to resolve simulator: no simulator identifier provided',
-        ]),
-        request: resolved.invocationRequest,
-      });
-    }
-
-    if (uuidResult.warning) {
-      log('warn', uuidResult.warning);
-    }
-
-    const simulatorId = uuidResult.uuid;
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'boot-simulator',
-      status: 'started',
-    });
-
-    try {
-      const { simulator: targetSimulator, error: findError } = await findSimulatorById(
-        simulatorId,
-        executor,
-      );
-      if (!targetSimulator) {
-        throw new Error(findError ?? `Failed to find simulator with UUID: ${simulatorId}`);
-      }
-
-      if (targetSimulator.state !== 'Booted') {
-        const bootResult = await executor(
-          ['xcrun', 'simctl', 'boot', simulatorId],
-          'Boot Simulator',
+      let destination: string;
+      if (params.simulatorId) {
+        destination = constructDestinationString(
+          resolved.detectedPlatform,
+          undefined,
+          params.simulatorId,
         );
-        if (!bootResult.success) {
-          throw new Error(bootResult.error ?? 'Failed to boot simulator');
-        }
+      } else if (params.simulatorName) {
+        destination = constructDestinationString(
+          resolved.detectedPlatform,
+          params.simulatorName,
+          undefined,
+          params.useLatestOS ?? true,
+        );
+      } else {
+        destination = constructDestinationString(resolved.detectedPlatform);
       }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'simulator',
-        artifacts: {
-          simulatorId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to boot simulator: ${errorMessage}`,
-        ]),
-        request: resolved.invocationRequest,
+
+      let appBundlePath: string;
+      try {
+        appBundlePath = await resolveAppPathFromBuildSettings(
+          {
+            projectPath: params.projectPath,
+            workspacePath: params.workspacePath,
+            scheme: params.scheme,
+            configuration: resolved.configuration,
+            platform: resolved.detectedPlatform,
+            destination,
+            derivedDataPath: params.derivedDataPath,
+            extraArgs: params.extraArgs,
+          },
+          executor,
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to get app path to launch: ${errorMessage}`,
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+
+      log('info', `App bundle path for run: ${appBundlePath}`);
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'resolve-app-path',
+        status: 'succeeded',
       });
-    }
 
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'boot-simulator',
-      status: 'succeeded',
-    });
-
-    try {
-      const openResult = await executor(['open', '-a', 'Simulator'], 'Open Simulator App');
-      if (!openResult.success) {
-        throw new Error(openResult.error ?? 'Failed to open Simulator app');
-      }
-    } catch (error) {
-      log(
-        'warn',
-        `Warning: Could not open Simulator app: ${error instanceof Error ? error.message : String(error)}`,
+      const uuidResult = await determineSimulatorUuid(
+        { simulatorId: params.simulatorId, simulatorName: params.simulatorName },
+        executor,
       );
-    }
 
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'install-app',
-      status: 'started',
-    });
-    const installResult = await installAppOnSimulator(simulatorId, appBundlePath, executor);
-    if (!installResult.success) {
-      const errorMessage = installResult.error ?? 'Failed to install app';
+      if (uuidResult.error || !uuidResult.uuid) {
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            uuidResult.error ?? 'Failed to resolve simulator: no simulator identifier provided',
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+
+      if (uuidResult.warning) {
+        log('warn', uuidResult.warning);
+      }
+
+      const simulatorId = uuidResult.uuid;
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'boot-simulator',
+        status: 'started',
+      });
+
+      try {
+        const { simulator: targetSimulator, error: findError } = await findSimulatorById(
+          simulatorId,
+          executor,
+        );
+        if (!targetSimulator) {
+          throw new Error(findError ?? `Failed to find simulator with UUID: ${simulatorId}`);
+        }
+
+        if (targetSimulator.state !== 'Booted') {
+          const bootResult = await executor(
+            ['xcrun', 'simctl', 'boot', simulatorId],
+            'Boot Simulator',
+          );
+          if (!bootResult.success) {
+            throw new Error(bootResult.error ?? 'Failed to boot simulator');
+          }
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            simulatorId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to boot simulator: ${errorMessage}`,
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'boot-simulator',
+        status: 'succeeded',
+      });
+
+      try {
+        const openResult = await executor(['open', '-a', 'Simulator'], 'Open Simulator App');
+        if (!openResult.success) {
+          throw new Error(openResult.error ?? 'Failed to open Simulator app');
+        }
+      } catch (error) {
+        log(
+          'warn',
+          `Warning: Could not open Simulator app: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'install-app',
+        status: 'started',
+      });
+      const installResult = await installAppOnSimulator(simulatorId, appBundlePath, executor);
+      if (!installResult.success) {
+        const errorMessage = installResult.error ?? 'Failed to install app';
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            simulatorId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to install app on simulator: ${errorMessage}`,
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'install-app',
+        status: 'succeeded',
+      });
+
+      let bundleId: string;
+      try {
+        bundleId = (await extractBundleIdFromAppPath(appBundlePath, executor)).trim();
+        if (bundleId.length === 0) {
+          throw new Error('Empty bundle ID returned');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            simulatorId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to extract bundle ID: ${errorMessage}`,
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+
+      ctx.emitFragment({
+        kind: 'build-run-result',
+        fragment: 'phase',
+        phase: 'launch-app',
+        status: 'started',
+      });
+      const launchResult: LaunchWithLoggingResult = await launcher(simulatorId, bundleId, executor);
+      if (!launchResult.success) {
+        const errorMessage = launchResult.error ?? 'Failed to launch app';
+        return createBuildRunDomainResult({
+          started,
+          succeeded: false,
+          target: 'simulator',
+          artifacts: {
+            simulatorId,
+            buildLogPath: started.pipeline.logPath,
+          },
+          fallbackErrorMessages: collectFallbackErrorMessages(started, [
+            `Failed to launch app ${appBundlePath}: ${errorMessage}`,
+          ]),
+          request: resolved.invocationRequest,
+        });
+      }
+
+      const processId = launchResult.processId;
+      if (processId !== undefined) {
+        log('info', `Launched with PID: ${processId}`);
+      }
+
       return createBuildRunDomainResult({
         started,
-        succeeded: false,
+        succeeded: true,
         target: 'simulator',
         artifacts: {
+          appPath: appBundlePath,
+          bundleId,
+          ...(processId !== undefined ? { processId } : {}),
           simulatorId,
           buildLogPath: started.pipeline.logPath,
+          ...(launchResult.logFilePath ? { runtimeLogPath: launchResult.logFilePath } : {}),
+          ...(launchResult.osLogPath ? { osLogPath: launchResult.osLogPath } : {}),
         },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to install app on simulator: ${errorMessage}`,
-        ]),
         request: resolved.invocationRequest,
       });
-    }
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'install-app',
-      status: 'succeeded',
-    });
-
-    let bundleId: string;
-    try {
-      bundleId = (await extractBundleIdFromAppPath(appBundlePath, executor)).trim();
-      if (bundleId.length === 0) {
-        throw new Error('Empty bundle ID returned');
-      }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       return createBuildRunDomainResult({
@@ -422,60 +484,14 @@ export function createBuildRunSimExecutor(
         succeeded: false,
         target: 'simulator',
         artifacts: {
-          simulatorId,
           buildLogPath: started.pipeline.logPath,
         },
         fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to extract bundle ID: ${errorMessage}`,
+          `Error during simulator build and run: ${errorMessage}`,
         ]),
         request: resolved.invocationRequest,
       });
     }
-
-    ctx.emitFragment({
-      kind: 'build-run-result',
-      fragment: 'phase',
-      phase: 'launch-app',
-      status: 'started',
-    });
-    const launchResult: LaunchWithLoggingResult = await launcher(simulatorId, bundleId, executor);
-    if (!launchResult.success) {
-      const errorMessage = launchResult.error ?? 'Failed to launch app';
-      return createBuildRunDomainResult({
-        started,
-        succeeded: false,
-        target: 'simulator',
-        artifacts: {
-          simulatorId,
-          buildLogPath: started.pipeline.logPath,
-        },
-        fallbackErrorMessages: collectFallbackErrorMessages(started, [
-          `Failed to launch app ${appBundlePath}: ${errorMessage}`,
-        ]),
-        request: resolved.invocationRequest,
-      });
-    }
-
-    const processId = launchResult.processId;
-    if (processId !== undefined) {
-      log('info', `Launched with PID: ${processId}`);
-    }
-
-    return createBuildRunDomainResult({
-      started,
-      succeeded: true,
-      target: 'simulator',
-      artifacts: {
-        appPath: appBundlePath,
-        bundleId,
-        ...(processId !== undefined ? { processId } : {}),
-        simulatorId,
-        buildLogPath: started.pipeline.logPath,
-        ...(launchResult.logFilePath ? { runtimeLogPath: launchResult.logFilePath } : {}),
-        ...(launchResult.osLogPath ? { osLogPath: launchResult.osLogPath } : {}),
-      },
-      request: resolved.invocationRequest,
-    });
   };
 }
 
@@ -533,6 +549,7 @@ export async function build_run_simLogic(
   ctx.emit(createBuildInvocationFragment('build-run-result', 'BUILD', prepared.invocationRequest));
   const executionContext = createStreamingExecutionContext(ctx);
   const executeBuildRunSim = createBuildRunSimExecutor(executor, launcher, prepared);
+
   const result = await executeBuildRunSim(params, executionContext);
 
   setXcodebuildStructuredOutput(ctx, 'build-run-result', result);

--- a/src/mcp/tools/swift-package/__tests__/non_streaming_progress.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/non_streaming_progress.test.ts
@@ -50,13 +50,13 @@ describe('swift package non-streaming tools', () => {
           target: 'swift-package',
         },
       },
-      {
+      expect.objectContaining({
         kind: 'build-result',
         fragment: 'build-summary',
         operation: 'BUILD',
         status: 'SUCCEEDED',
-        durationMs: 0,
-      },
+        durationMs: expect.any(Number),
+      }),
     ]);
     expect(result.text()).toContain('Swift Package Run');
     expect(result.text()).toContain('Build & Run complete');

--- a/src/mcp/tools/swift-package/__tests__/non_streaming_progress.test.ts
+++ b/src/mcp/tools/swift-package/__tests__/non_streaming_progress.test.ts
@@ -32,13 +32,11 @@ describe('swift package non-streaming tools', () => {
   });
 
   it('carries invocation fragment for swift_package_run', async () => {
-    const { result } = await runToolLogic(
-      () =>
-        swift_package_runLogic(
-          { packagePath: '/test/package' },
-          createMockExecutor({ success: true, output: 'Hello, World!' }),
-        ),
-      { liveProgressEnabled: false },
+    const { result } = await runToolLogic(() =>
+      swift_package_runLogic(
+        { packagePath: '/test/package' },
+        createMockExecutor({ success: true, output: 'Hello, World!' }),
+      ),
     );
 
     expect(result.events).toEqual([
@@ -51,6 +49,13 @@ describe('swift package non-streaming tools', () => {
           executableName: 'package',
           target: 'swift-package',
         },
+      },
+      {
+        kind: 'build-result',
+        fragment: 'build-summary',
+        operation: 'BUILD',
+        status: 'SUCCEEDED',
+        durationMs: 0,
       },
     ]);
     expect(result.text()).toContain('Swift Package Run');

--- a/src/mcp/tools/xcode-ide/__tests__/bridge_tools.test.ts
+++ b/src/mcp/tools/xcode-ide/__tests__/bridge_tools.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../../../server/server-state.ts', () => ({
   getServer: vi.fn(),
@@ -41,9 +44,21 @@ import {
   getMcpBridgeAvailability,
 } from '../../../../integrations/xcode-tools-bridge/core.ts';
 import { allText, runToolLogic } from '../../../../test-utils/test-helpers.ts';
+import { setXcodeBuildMCPAppDirOverrideForTests } from '../../../../utils/log-paths.ts';
+import { setRuntimeInstanceForTests } from '../../../../utils/runtime-instance.ts';
 
 describe('xcode-ide bridge tools (standalone fallback)', () => {
+  let tempAppDir: string;
+
   beforeEach(async () => {
+    tempAppDir = mkdtempSync(join(tmpdir(), 'xcodebuildmcp-xcode-ide-test-'));
+    setXcodeBuildMCPAppDirOverrideForTests(tempAppDir);
+    setRuntimeInstanceForTests({
+      instanceId: 'test-instance',
+      pid: 1234,
+      workspaceKey: 'workspace-a',
+    });
+
     await shutdownXcodeToolsBridge();
 
     vi.mocked(getServer).mockReset();
@@ -62,7 +77,7 @@ describe('xcode-ide bridge tools (standalone fallback)', () => {
       lastError: null,
     });
     vi.mocked(buildXcodeToolsBridgeStatus).mockResolvedValue({
-      workflowEnabled: false,
+      workflowEnabled: true,
       bridgeAvailable: true,
       bridgePath: '/usr/bin/mcpbridge',
       xcodeRunning: true,
@@ -86,6 +101,12 @@ describe('xcode-ide bridge tools (standalone fallback)', () => {
     clientMocks.disconnect.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    setRuntimeInstanceForTests(null);
+    setXcodeBuildMCPAppDirOverrideForTests(null);
+    rmSync(tempAppDir, { recursive: true, force: true });
+  });
+
   it('status handler returns bridge status without MCP server instance', async () => {
     const result = await statusHandler({});
     const text = allText(result);
@@ -101,7 +122,7 @@ describe('xcode-ide bridge tools (standalone fallback)', () => {
     expect(text).toContain('"total": 2');
     expect(clientMocks.connectOnce).toHaveBeenCalledOnce();
     expect(clientMocks.listTools).toHaveBeenCalledOnce();
-    expect(clientMocks.disconnect).toHaveBeenCalledOnce();
+    expect(clientMocks.disconnect).not.toHaveBeenCalled();
   });
 
   it('disconnect handler succeeds without MCP server instance', async () => {
@@ -116,16 +137,93 @@ describe('xcode-ide bridge tools (standalone fallback)', () => {
     const result = await listHandler({ refresh: true });
     const text = allText(result);
     expect(text).toContain('Xcode IDE List Tools');
-    expect(text).toContain('"toolCount": 2');
+    expect(text).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(text).toContain('Raw Response JSON');
+    expect(text).not.toContain('toolA');
+    expect(text).not.toContain('toolB');
+    expect(text).not.toContain('"toolCount": 2');
     expect(clientMocks.listTools).toHaveBeenCalledOnce();
-    expect(clientMocks.disconnect).toHaveBeenCalledOnce();
+    expect(clientMocks.disconnect).not.toHaveBeenCalled();
   });
 
-  it('call handler forwards remote tool calls without MCP server instance', async () => {
+  it('list handler can return cached bridge tools without reconnecting', async () => {
+    const refreshed = await listHandler({ refresh: true });
+    const cached = await listHandler({ refresh: false });
+
+    expect(allText(refreshed)).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(allText(cached)).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(clientMocks.connectOnce).toHaveBeenCalledOnce();
+    expect(clientMocks.listTools).toHaveBeenCalledOnce();
+    expect(clientMocks.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('list handler defaults to refresh only when cache is empty', async () => {
+    const initial = await listHandler({});
+    const cached = await listHandler({});
+    const forced = await listHandler({ refresh: true });
+
+    expect(allText(initial)).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(allText(cached)).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(allText(forced)).toContain('Found 2 tool(s). Raw response saved to artifact.');
+    expect(clientMocks.connectOnce).toHaveBeenCalledTimes(2);
+    expect(clientMocks.listTools).toHaveBeenCalledTimes(2);
+    expect(clientMocks.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('call handler forwards remote tool calls and writes a raw response artifact', async () => {
     const result = await callHandler({ remoteTool: 'toolA', arguments: { foo: 'bar' } });
+    const text = allText(result);
+    const artifactDir = join(
+      tempAppDir,
+      'workspaces',
+      'workspace-a',
+      'state',
+      'xcode-ide',
+      'call-tool',
+      'ownerpid1234_test-instance',
+    );
+    const artifactPath = join(artifactDir, readdirSync(artifactDir)[0] ?? 'missing');
+
     expect(result.isError).toBeFalsy();
+    expect(text).toContain('Xcode IDE Call Tool');
+    expect(text).toContain('Raw Response JSON');
+    expect(text).toContain(artifactPath);
+    expect(text).not.toContain('Relayed Content');
+    expect(text).not.toContain('Structured Content');
+    expect(existsSync(artifactPath)).toBe(true);
+    expect(JSON.parse(readFileSync(artifactPath, 'utf8'))).toMatchObject({
+      remoteTool: 'toolA',
+      arguments: { foo: 'bar' },
+      response: {
+        content: [{ type: 'text', text: 'ok' }],
+        isError: false,
+      },
+    });
     expect(clientMocks.callTool).toHaveBeenCalledWith('toolA', { foo: 'bar' }, {});
-    expect(clientMocks.disconnect).toHaveBeenCalledOnce();
+    expect(clientMocks.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('call handler hard-fails when the raw response artifact cannot be written', async () => {
+    const blockingAppDir = join(tempAppDir, 'app-dir-file');
+    writeFileSync(blockingAppDir, 'not a directory');
+    setXcodeBuildMCPAppDirOverrideForTests(blockingAppDir);
+    clientMocks.callTool.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'large inline payload' }],
+      structuredContent: { raw: 'structured payload' },
+      isError: false,
+    });
+
+    const result = await callHandler({ remoteTool: 'toolA', arguments: { foo: 'bar' } });
+    const text = allText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain('Failed to write Xcode IDE bridge response artifact');
+    expect(text).not.toContain('Raw Response JSON');
+    expect(text).not.toContain('Relayed Content');
+    expect(text).not.toContain('Structured Content');
+    expect(text).not.toContain('large inline payload');
+    expect(text).not.toContain('structured payload');
+    expect(clientMocks.callTool).toHaveBeenCalledWith('toolA', { foo: 'bar' }, {});
   });
 
   it('logic functions do not emit progress events', async () => {

--- a/src/mcp/tools/xcode-ide/shared.ts
+++ b/src/mcp/tools/xcode-ide/shared.ts
@@ -16,8 +16,6 @@ import { getXcodeToolsBridgeToolHandler } from '../../../integrations/xcode-tool
 import type { ImageAttachment, ToolHandlerContext } from '../../../rendering/types.ts';
 
 export class BridgeToolExecutionContext {
-  readonly liveProgressEnabled = false;
-
   private nextStepParams?: NextStepParamsMap;
   private readonly bridgeImages: ImageAttachment[] = [];
 
@@ -75,11 +73,12 @@ export function finalizeBridgeToolExecution(
   executionContext: BridgeToolExecutionContext,
   result: ToolDomainResult,
   schema: string,
+  schemaVersion = '1',
 ): void {
   ctx.structuredOutput = {
     result,
     schema,
-    schemaVersion: '1',
+    schemaVersion,
   };
 
   for (const image of executionContext.getBridgeImages()) {
@@ -133,7 +132,7 @@ export function toBridgeToolListDomainResult(
       ? (bridgeResult.errorMessage ?? 'Failed to list bridge tools')
       : null,
     toolCount: payload?.toolCount ?? 0,
-    tools: payload?.tools ?? [],
+    ...(payload?.artifacts ? { artifacts: payload.artifacts } : {}),
   };
 }
 
@@ -152,9 +151,7 @@ export function toBridgeCallResultDomainResult(
       : null,
     succeeded: payload?.succeeded ?? !Boolean(bridgeResult.isError),
     content: payload?.content ?? [],
-    ...(payload?.structuredContent !== undefined
-      ? { structuredContent: payload.structuredContent }
-      : {}),
+    ...(payload?.artifacts ? { artifacts: payload.artifacts } : {}),
   };
 }
 

--- a/src/mcp/tools/xcode-ide/xcode_ide_call_tool.ts
+++ b/src/mcp/tools/xcode-ide/xcode_ide_call_tool.ts
@@ -56,6 +56,7 @@ export async function xcodeIdeCallToolLogic(params: Params): Promise<void> {
     executionContext,
     result,
     'xcodebuildmcp.output.xcode-bridge-call-result',
+    '2',
   );
 }
 

--- a/src/mcp/tools/xcode-ide/xcode_ide_list_tools.ts
+++ b/src/mcp/tools/xcode-ide/xcode_ide_list_tools.ts
@@ -16,7 +16,9 @@ const schemaObject = z.object({
   refresh: z
     .boolean()
     .optional()
-    .describe('When true (default), refreshes from Xcode bridge before returning tool list.'),
+    .describe(
+      'When true, forces a refresh from Xcode bridge. When omitted, uses cached tools if available and refreshes only when the cache is empty.',
+    ),
 });
 
 type Params = z.infer<typeof schemaObject>;
@@ -41,6 +43,7 @@ export async function xcodeIdeListToolsLogic(params: Params): Promise<void> {
     executionContext,
     result,
     'xcodebuildmcp.output.xcode-bridge-tool-list',
+    '2',
   );
 }
 

--- a/src/rendering/__tests__/text-render-parity.test.ts
+++ b/src/rendering/__tests__/text-render-parity.test.ts
@@ -49,7 +49,6 @@ describe('text render parity', () => {
     session.emit(fragment);
 
     expect(session.isError()).toBe(false);
-    expect(session.getFragments()).toEqual([fragment]);
   });
 
   it('marks explicit structured error output as a final render error', () => {
@@ -396,13 +395,6 @@ describe('text render parity', () => {
       },
     });
 
-    expect(session.getFragments()).toEqual([
-      invocation,
-      buildStage,
-      streamedWarning,
-      buildSummary,
-      transcriptLine,
-    ]);
     const rendered = session.finalize();
 
     expect(rendered).toContain('Scheme: MyApp');

--- a/src/rendering/__tests__/text-render-parity.test.ts
+++ b/src/rendering/__tests__/text-render-parity.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DomainFragment } from '../../types/domain-fragments.ts';
+import type { RuntimeStatusFragment } from '../../types/runtime-status.ts';
 import type { StructuredToolOutput } from '../types.ts';
-import { renderTranscript } from '../render.ts';
+import { createRenderSession, renderTranscript } from '../render.ts';
+import { createStructuredErrorOutput } from '../../utils/structured-error.ts';
 import { createCliTextRenderer } from '../../utils/renderers/cli-text-renderer.ts';
 import type { NextStep } from '../../types/common.ts';
 
@@ -33,6 +35,59 @@ function captureCliText(fixture: TranscriptFixture): string {
 describe('text render parity', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('does not mark emitted error fragments as final render errors', () => {
+    const session = createRenderSession('text');
+    const fragment: RuntimeStatusFragment = {
+      kind: 'infrastructure',
+      fragment: 'status',
+      level: 'error',
+      message: 'Transient progress error',
+    };
+
+    session.emit(fragment);
+
+    expect(session.isError()).toBe(false);
+    expect(session.getFragments()).toEqual([fragment]);
+  });
+
+  it('marks explicit structured error output as a final render error', () => {
+    const session = createRenderSession('text');
+
+    session.setStructuredOutput?.(
+      createStructuredErrorOutput({
+        category: 'runtime',
+        code: 'TEST_ERROR',
+        message: 'Final error',
+      }),
+    );
+
+    expect(session.isError()).toBe(true);
+  });
+
+  it('renders structured-only error output text', () => {
+    const fixture: TranscriptFixture = {
+      progressEvents: [],
+      structuredOutput: createStructuredErrorOutput({
+        category: 'runtime',
+        code: 'TEST_ERROR',
+        message: 'Final error',
+      }),
+    };
+
+    const rendered = renderTranscript(
+      {
+        items: fixture.progressEvents,
+        structuredOutput: fixture.structuredOutput,
+      },
+      'text',
+    );
+
+    expect(rendered).toBe(captureCliText(fixture));
+    expect(rendered).toContain('Final error');
+    expect(rendered).toContain('Category: runtime');
+    expect(rendered).toContain('Code: TEST_ERROR');
   });
 
   it('matches non-interactive cli text for discovery and summary output', () => {
@@ -277,6 +332,86 @@ describe('text render parity', () => {
     expect(output).toBe(captureCliText(fixture));
     expect(output).toContain('get_mac_app_path({ scheme: "MCPTest" })');
     expect(output).not.toContain('xcodebuildmcp macos get-app-path');
+  });
+
+  it('does not capture streaming fragments for render session final text', () => {
+    const session = createRenderSession('text');
+    const request = {
+      scheme: 'MyApp',
+      projectPath: '/tmp/MyApp.xcodeproj',
+      configuration: 'Debug',
+      platform: 'iOS Simulator',
+    };
+    const invocation: DomainFragment = {
+      kind: 'build-result',
+      fragment: 'invocation',
+      operation: 'BUILD',
+      request,
+    };
+    const buildStage: DomainFragment = {
+      kind: 'build-result',
+      fragment: 'build-stage',
+      operation: 'BUILD',
+      stage: 'COMPILING',
+      message: 'Compiling App.swift',
+    };
+    const streamedWarning: DomainFragment = {
+      kind: 'build-result',
+      fragment: 'warning',
+      message: 'streamed warning should stay transient',
+    };
+    const buildSummary: DomainFragment = {
+      kind: 'build-result',
+      fragment: 'build-summary',
+      operation: 'BUILD',
+      status: 'SUCCEEDED',
+      durationMs: 3200,
+    };
+    const transcriptLine: DomainFragment = {
+      kind: 'transcript',
+      fragment: 'process-line',
+      stream: 'stderr',
+      line: 'raw xcodebuild line\n',
+    };
+
+    session.emit(invocation);
+    session.emit(buildStage);
+    session.emit(streamedWarning);
+    session.emit(buildSummary);
+    session.emit(transcriptLine);
+    session.setStructuredOutput?.({
+      schema: 'xcodebuildmcp.output.build-result',
+      schemaVersion: '1.0.0',
+      result: {
+        kind: 'build-result',
+        request,
+        didError: false,
+        error: null,
+        summary: { status: 'SUCCEEDED', durationMs: 3200 },
+        artifacts: { buildLogPath: '/tmp/build.log' },
+        diagnostics: {
+          warnings: [{ message: 'final warning from structured output' }],
+          errors: [],
+        },
+      },
+    });
+
+    expect(session.getFragments()).toEqual([
+      invocation,
+      buildStage,
+      streamedWarning,
+      buildSummary,
+      transcriptLine,
+    ]);
+    const rendered = session.finalize();
+
+    expect(rendered).toContain('Scheme: MyApp');
+    expect(rendered).toContain('Build succeeded');
+    expect(rendered).toContain('final warning from structured output');
+    expect(rendered).toContain('Build Logs: /tmp/build.log');
+    expect(rendered).not.toContain('Compiling App.swift');
+    expect(rendered).not.toContain('streamed warning should stay transient');
+    expect(rendered).not.toContain('raw xcodebuild line');
   });
 
   it('matches for structured-only build-result with request and no fragments', () => {

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -28,7 +28,6 @@ interface RenderSessionHooks {
 }
 
 function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
-  const fragments: AnyFragment[] = [];
   const attachments: ImageAttachment[] = [];
   let structuredOutput: StructuredToolOutput | undefined;
   let nextSteps: NextStep[] = [];
@@ -36,7 +35,6 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
 
   return {
     emit(fragment: AnyFragment): void {
-      fragments.push(fragment);
       hooks.onEmit?.(fragment);
     },
 
@@ -65,10 +63,6 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
 
     getNextStepsRuntime(): 'cli' | 'daemon' | 'mcp' | undefined {
       return nextStepsRuntime;
-    },
-
-    getFragments(): readonly AnyFragment[] {
-      return fragments;
     },
 
     getAttachments(): readonly ImageAttachment[] {

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -13,13 +13,6 @@ import type {
   StructuredToolOutput,
 } from './types.ts';
 
-function isErrorFragment(fragment: AnyFragment): boolean {
-  return (
-    (fragment.fragment === 'compiler-diagnostic' && fragment.severity === 'error') ||
-    (fragment.fragment === 'status' && fragment.level === 'error')
-  );
-}
-
 export interface RenderTranscriptInput {
   items?: readonly AnyFragment[];
   structuredOutput?: StructuredToolOutput;
@@ -40,12 +33,10 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
   let structuredOutput: StructuredToolOutput | undefined;
   let nextSteps: NextStep[] = [];
   let nextStepsRuntime: 'cli' | 'daemon' | 'mcp' | undefined;
-  let hasError = false;
 
   return {
     emit(fragment: AnyFragment): void {
       fragments.push(fragment);
-      if (isErrorFragment(fragment)) hasError = true;
       hooks.onEmit?.(fragment);
     },
 
@@ -55,9 +46,6 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
 
     setStructuredOutput(output: StructuredToolOutput): void {
       structuredOutput = output;
-      if (output.result.didError) {
-        hasError = true;
-      }
       hooks.onSetStructuredOutput?.(output);
     },
 
@@ -88,12 +76,12 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
     },
 
     isError(): boolean {
-      return hasError;
+      return structuredOutput?.result.didError === true;
     },
 
     finalize(): string {
       return hooks.finalize({
-        items: fragments,
+        items: [],
         structuredOutput,
         nextSteps,
         nextStepsRuntime,
@@ -102,72 +90,70 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
   };
 }
 
-function createTextRenderSession(): RenderSession {
+function createRenderHooks(
+  strategy: RenderStrategy,
+  options: { interactive: boolean },
+): RenderSessionHooks {
   const suppressWarnings = sessionStore.get('suppressWarnings');
   const showTestTiming = getConfig().showTestTiming;
 
-  return createBaseRenderSession({
-    finalize: (input) =>
-      renderCliTextTranscript({
-        ...input,
-        suppressWarnings: suppressWarnings ?? false,
-        showTestTiming,
-      }),
-  });
-}
-
-function createRawRenderSession(): RenderSession {
-  const suppressWarnings = sessionStore.get('suppressWarnings');
-  const showTestTiming = getConfig().showTestTiming;
-
-  return createBaseRenderSession({
-    onEmit: (fragment) => {
-      if (fragment.kind === 'transcript') {
-        if (fragment.fragment === 'process-command') {
-          const dim = process.stderr.isTTY ? '\x1B[2m' : '';
-          const reset = process.stderr.isTTY ? '\x1B[0m' : '';
-          process.stderr.write(`${dim}$ ${fragment.displayCommand}${reset}\n`);
-        } else if (fragment.fragment === 'process-line') {
-          process.stderr.write(fragment.line);
-        }
-      }
-    },
-    finalize: (input) => {
-      const nonTranscriptItems = (input.items ?? []).filter((f) => f.kind !== 'transcript');
-      const text = renderCliTextTranscript({
-        items: nonTranscriptItems,
-        structuredOutput: input.structuredOutput,
-        nextSteps: input.nextSteps,
-        nextStepsRuntime: input.nextStepsRuntime,
+  switch (strategy) {
+    case 'text':
+      return {
+        finalize: (input) =>
+          renderCliTextTranscript({
+            ...input,
+            suppressWarnings: suppressWarnings ?? false,
+            showTestTiming,
+          }),
+      };
+    case 'raw':
+      return {
+        onEmit: (fragment) => {
+          if (fragment.kind === 'transcript') {
+            if (fragment.fragment === 'process-command') {
+              const dim = process.stderr.isTTY ? '\x1B[2m' : '';
+              const reset = process.stderr.isTTY ? '\x1B[0m' : '';
+              process.stderr.write(`${dim}$ ${fragment.displayCommand}${reset}\n`);
+            } else if (fragment.fragment === 'process-line') {
+              process.stderr.write(fragment.line);
+            }
+          }
+        },
+        finalize: (input) => {
+          const nonTranscriptItems = (input.items ?? []).filter((f) => f.kind !== 'transcript');
+          const text = renderCliTextTranscript({
+            items: nonTranscriptItems,
+            structuredOutput: input.structuredOutput,
+            nextSteps: input.nextSteps,
+            nextStepsRuntime: input.nextStepsRuntime,
+            suppressWarnings: suppressWarnings ?? false,
+            showTestTiming,
+          });
+          if (text) {
+            process.stdout.write(text);
+          }
+          return '';
+        },
+      };
+    case 'cli-text': {
+      const renderer = createCliTextRenderer({
+        ...options,
         suppressWarnings: suppressWarnings ?? false,
         showTestTiming,
       });
-      if (text) {
-        process.stdout.write(text);
-      }
-      return '';
-    },
-  });
-}
 
-function createCliTextRenderSession(options: { interactive: boolean }): RenderSession {
-  const suppressWarnings = sessionStore.get('suppressWarnings');
-  const showTestTiming = getConfig().showTestTiming;
-  const renderer = createCliTextRenderer({
-    ...options,
-    suppressWarnings: suppressWarnings ?? false,
-    showTestTiming,
-  });
-
-  return createBaseRenderSession({
-    onEmit: (fragment) => renderer.onFragment(fragment),
-    onSetStructuredOutput: (output) => renderer.setStructuredOutput(output),
-    onSetNextSteps: (steps, runtime) => renderer.setNextSteps(steps, runtime),
-    finalize: () => {
-      renderer.finalize();
-      return '';
-    },
-  });
+      return {
+        onEmit: (fragment) => renderer.onFragment(fragment),
+        onSetStructuredOutput: (output) => renderer.setStructuredOutput(output),
+        onSetNextSteps: (steps, runtime) => renderer.setNextSteps(steps, runtime),
+        finalize: () => {
+          renderer.finalize();
+          return '';
+        },
+      };
+    }
+  }
 }
 
 export interface RenderSessionOptions {
@@ -178,28 +164,13 @@ export function createRenderSession(
   strategy: RenderStrategy,
   options?: RenderSessionOptions,
 ): RenderSession {
-  switch (strategy) {
-    case 'text':
-      return createTextRenderSession();
-    case 'cli-text':
-      return createCliTextRenderSession({ interactive: options?.interactive ?? false });
-    case 'raw':
-      return createRawRenderSession();
-  }
+  return createBaseRenderSession(
+    createRenderHooks(strategy, { interactive: options?.interactive ?? false }),
+  );
 }
 
 export function renderTranscript(input: RenderTranscriptInput, strategy: RenderStrategy): string {
-  const session = createRenderSession(strategy);
-  for (const item of input.items ?? []) {
-    session.emit(item);
-  }
-  if (input.structuredOutput) {
-    session.setStructuredOutput?.(input.structuredOutput);
-  }
-  if (input.nextSteps && input.nextSteps.length > 0) {
-    session.setNextSteps?.([...input.nextSteps], input.nextStepsRuntime ?? 'cli');
-  }
-  return session.finalize();
+  return createRenderHooks(strategy, { interactive: false }).finalize(input);
 }
 
 export function renderFragments(

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -17,7 +17,6 @@ export interface RenderSession {
   setNextSteps?(steps: NextStep[], runtime: 'cli' | 'daemon' | 'mcp'): void;
   getNextSteps?(): readonly NextStep[];
   getNextStepsRuntime?(): 'cli' | 'daemon' | 'mcp' | undefined;
-  getFragments(): readonly AnyFragment[];
   getAttachments(): readonly ImageAttachment[];
   isError(): boolean;
   finalize(): string;

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -37,8 +37,6 @@ export interface StructuredToolOutput {
 export interface ToolHandlerContext {
   emit: (fragment: AnyFragment) => void;
   attach: (image: ImageAttachment) => void;
-  liveProgressEnabled: boolean;
-  streamingFragmentsEnabled: boolean;
   nextStepParams?: NextStepParamsMap;
   nextSteps?: NextStep[];
   structuredOutput?: StructuredToolOutput;

--- a/src/runtime/__tests__/tool-invoker.test.ts
+++ b/src/runtime/__tests__/tool-invoker.test.ts
@@ -8,6 +8,8 @@ import type { ToolDefinition } from '../types.ts';
 import { createToolCatalog } from '../tool-catalog.ts';
 import { DefaultToolInvoker } from '../tool-invoker.ts';
 import { createRenderSession } from '../../rendering/render.ts';
+import type { StructuredToolOutput, ToolHandlerContext } from '../../rendering/types.ts';
+import { createStructuredErrorOutput } from '../../utils/structured-error.ts';
 import { DaemonVersionMismatchError } from '../../cli/daemon-client.ts';
 import { ensureDaemonRunning, forceStopDaemon } from '../../cli/daemon-control.ts';
 
@@ -54,31 +56,40 @@ function statusFragment(
 
 function daemonResult(text: string, opts?: Partial<DaemonToolResult>): DaemonToolResult {
   return {
-    fragments: [
-      {
-        kind: 'infrastructure',
-        fragment: 'status',
-        level: 'success',
-        message: text,
+    structuredOutput: {
+      schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+      schemaVersion: '2',
+      result: {
+        kind: 'xcode-bridge-call-result',
+        remoteTool: 'Alpha',
+        didError: false,
+        error: null,
+        succeeded: true,
+        content: [{ type: 'text', text }],
       },
-    ],
+    },
     isError: false,
     ...opts,
   };
 }
 
+function structuredTextOutput(text: string): StructuredToolOutput {
+  return {
+    schema: 'xcodebuildmcp.output.debug-command-result',
+    schemaVersion: '1',
+    result: {
+      kind: 'debug-command-result',
+      didError: false,
+      error: null,
+      command: 'test',
+      outputLines: [text],
+    },
+  };
+}
+
 function streamedToolResult(opts: Partial<ToolInvokeResult> = {}): ToolInvokeResult {
   return {
-    structuredOutput: {
-      schema: 'xcodebuildmcp.output.simulator-list',
-      schemaVersion: '1',
-      result: {
-        kind: 'simulator-list',
-        didError: false,
-        error: null,
-        simulators: [],
-      },
-    },
+    structuredOutput: structuredTextOutput('daemon-result'),
     ...opts,
   };
 }
@@ -118,7 +129,7 @@ function invokeAndFinalize(
     workspaceRoot?: string;
     cliExposedWorkflowIds?: string[];
   },
-): Promise<ToolResponse> {
+): Promise<ToolResponse & { structuredOutput?: StructuredToolOutput }> {
   const session = createRenderSession('text');
   const promise = invoker.invoke(toolName, args, { ...opts, renderSession: session });
   return promise.then(() => {
@@ -127,6 +138,7 @@ function invokeAndFinalize(
       content: text ? [{ type: 'text', text }] : [],
       isError: session.isError() || undefined,
       nextSteps: undefined,
+      structuredOutput: session.getStructuredOutput?.(),
     };
     return response;
   });
@@ -134,7 +146,7 @@ function invokeAndFinalize(
 
 function emitHandler(text: string): ToolDefinition['handler'] {
   return vi.fn(async (_params, ctx) => {
-    ctx.emit(statusFragment('success', text));
+    ctx.structuredOutput = structuredTextOutput(text);
   });
 }
 
@@ -150,7 +162,7 @@ function emitNextStepsHandler(
   nextStepParams?: ToolResponse['nextStepParams'],
 ): ToolDefinition['handler'] {
   return vi.fn(async (_params, ctx) => {
-    ctx.emit(statusFragment('success', text));
+    ctx.structuredOutput = structuredTextOutput(text);
     if (nextSteps) ctx.nextSteps = nextSteps;
     if (nextStepParams) ctx.nextStepParams = nextStepParams;
   });
@@ -215,6 +227,31 @@ describe('DefaultToolInvoker CLI routing', () => {
     expect(response.content[0].text).toContain('direct-result');
   });
 
+  it('sets explicit structured error output for unresolved tool names', async () => {
+    const catalog = createToolCatalog([
+      makeTool({
+        cliName: 'list-sims',
+        workflow: 'simulator',
+        stateful: false,
+        handler: emitHandler('direct-result'),
+      }),
+    ]);
+    const invoker = new DefaultToolInvoker(catalog);
+
+    const response = await invokeAndFinalize(invoker, 'missing-tool', {}, { runtime: 'cli' });
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredOutput?.schema).toBe('xcodebuildmcp.output.error');
+    expect(response.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        didError: true,
+        code: 'TOOL_NOT_FOUND',
+      }),
+    );
+    expect(response.content[0].text).toContain("Unknown tool 'missing-tool'");
+  });
+
   it('injects direct invocation progress and structured output hooks into the handler context', async () => {
     const progressEvents: Array<{ kind: string }> = [];
     const structuredOutputs: string[] = [];
@@ -265,6 +302,71 @@ describe('DefaultToolInvoker CLI routing', () => {
     );
     expect(progressEvents).toEqual([{ kind: 'infrastructure' }]);
     expect(structuredOutputs).toEqual(['xcodebuildmcp.output.simulator-list']);
+  });
+
+  it('sets explicit structured error output when direct handlers throw', async () => {
+    const catalog = createToolCatalog([
+      makeTool({
+        cliName: 'list-sims',
+        workflow: 'simulator',
+        stateful: false,
+        handler: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+      }),
+    ]);
+    const invoker = new DefaultToolInvoker(catalog);
+
+    const response = await invokeAndFinalize(invoker, 'list-sims', {}, { runtime: 'cli' });
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        didError: true,
+        code: 'DIRECT_HANDLER_FAILED',
+        error: 'Tool execution failed: boom',
+      }),
+    );
+  });
+
+  it('keeps daemon handler failures as terminal structured output instead of protocol errors', async () => {
+    const handlerContext: ToolHandlerContext = {
+      emit: () => {},
+      attach: () => {},
+    };
+    const catalog = createToolCatalog([
+      makeTool({
+        cliName: 'list-sims',
+        workflow: 'simulator',
+        stateful: false,
+        handler: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+      }),
+    ]);
+    const invoker = new DefaultToolInvoker(catalog);
+
+    await expect(
+      invoker.invokeDirect(
+        catalog.tools[0],
+        {},
+        {
+          runtime: 'daemon',
+          handlerContext,
+          renderSession: createRenderSession('text'),
+        },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(handlerContext.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        didError: true,
+        code: 'DIRECT_HANDLER_FAILED',
+        error: 'Tool execution failed: boom',
+      }),
+    );
   });
 
   it('routes stateful tools through daemon and auto-starts when needed', async () => {
@@ -345,7 +447,7 @@ describe('DefaultToolInvoker CLI routing', () => {
     expect(directHandler).not.toHaveBeenCalled();
   });
 
-  it('renders streamed daemon progress without relying on terminal event replay', async () => {
+  it('does not replay streamed daemon progress into the final response', async () => {
     daemonClientMock.invokeTool.mockImplementation(async (_name, _args, options) => {
       options?.onFragment?.({
         kind: 'infrastructure',
@@ -377,7 +479,8 @@ describe('DefaultToolInvoker CLI routing', () => {
       },
     );
 
-    expect(response.content[0].text).toContain('daemon-event-result');
+    expect(response.content[0].text).toContain('daemon-result');
+    expect(response.content[0].text).not.toContain('daemon-event-result');
   });
 });
 
@@ -425,7 +528,61 @@ describe('DefaultToolInvoker xcode-ide dynamic routing', () => {
     );
     expect(daemonClientMock.invokeXcodeIdeTool).toHaveBeenCalledWith('Alpha', { value: 'hello' });
     expect(directHandler).not.toHaveBeenCalled();
-    expect(response.content[0].text).toContain('daemon-result');
+    expect(response.content[0].text).toContain('Tool "Alpha" completed successfully');
+  });
+
+  it('maps dynamic xcode-ide daemon failures to explicit structured error output', async () => {
+    daemonClientMock.invokeXcodeIdeTool.mockResolvedValue(
+      daemonResult('Remote tool failed', {
+        isError: true,
+        structuredOutput: {
+          schema: 'xcodebuildmcp.output.xcode-bridge-call-result',
+          schemaVersion: '2',
+          result: {
+            kind: 'xcode-bridge-call-result',
+            remoteTool: 'Alpha',
+            didError: true,
+            error: 'Remote tool failed',
+            succeeded: false,
+            content: [{ type: 'text', text: 'Remote tool failed' }],
+          },
+        },
+      }),
+    );
+    const directHandler = emitHandler('direct-result');
+    const catalog = createToolCatalog([
+      makeTool({
+        cliName: 'xcode-ide-alpha',
+        workflow: 'xcode-ide',
+        stateful: false,
+        xcodeIdeRemoteToolName: 'Alpha',
+        handler: directHandler,
+      }),
+    ]);
+    const invoker = new DefaultToolInvoker(catalog);
+
+    const response = await invokeAndFinalize(
+      invoker,
+      'xcode-ide-alpha',
+      { value: 'hello' },
+      {
+        runtime: 'cli',
+        socketPath: '/tmp/xcodebuildmcp.sock',
+        workspaceRoot: '/repo',
+        cliExposedWorkflowIds: ['simulator', 'xcode-ide'],
+      },
+    );
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'xcode-bridge-call-result',
+        didError: true,
+        error: 'Remote tool failed',
+      }),
+    );
+    expect(response.content[0].text).toContain('Remote tool failed');
+    expect(directHandler).not.toHaveBeenCalled();
   });
 
   it('fails for dynamic xcode-ide tools when socket path is missing', async () => {
@@ -451,6 +608,13 @@ describe('DefaultToolInvoker xcode-ide dynamic routing', () => {
     );
 
     expect(response.isError).toBe(true);
+    expect(response.structuredOutput?.result).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        didError: true,
+        code: 'SOCKET_PATH_MISSING',
+      }),
+    );
     expect(response.content[0].text).toContain('No socket path configured');
     expect(directHandler).not.toHaveBeenCalled();
     expect(daemonClientMock.invokeXcodeIdeTool).not.toHaveBeenCalled();
@@ -790,7 +954,7 @@ describe('DefaultToolInvoker next steps post-processing', () => {
     expect(text).toContain('session-123');
   });
 
-  it('renders failure next steps for ordinary error responses with replayable events', async () => {
+  it('does not render failure next steps for emitted error fragments alone', async () => {
     const directHandler = emitErrorEventsHandler([
       {
         kind: 'infrastructure',
@@ -830,6 +994,51 @@ describe('DefaultToolInvoker next steps post-processing', () => {
     const response = await invokeAndFinalize(invoker, 'list', {}, { runtime: 'cli' });
 
     expect(response.nextSteps).toBeUndefined();
+    const text = response.content.map((item) => (item.type === 'text' ? item.text : '')).join('\n');
+    expect(response.isError).toBeUndefined();
+    expect(text).not.toContain('Try building for device');
+    expect(text).not.toContain('build-device');
+  });
+
+  it('renders failure next steps for explicit structured error output', async () => {
+    const directHandler: ToolDefinition['handler'] = vi.fn(async (_params, ctx) => {
+      ctx.structuredOutput = createStructuredErrorOutput({
+        category: 'runtime',
+        code: 'ORDINARY_FAILURE',
+        message: 'failed',
+      });
+    });
+
+    const catalog = createToolCatalog([
+      makeTool({
+        id: 'list_devices',
+        cliName: 'list',
+        mcpName: 'list_devices',
+        workflow: 'device',
+        stateful: false,
+        nextStepTemplates: [
+          {
+            label: 'Try building for device',
+            toolId: 'build_device',
+            when: 'failure',
+          },
+        ],
+        handler: directHandler,
+      }),
+      makeTool({
+        id: 'build_device',
+        cliName: 'build-device',
+        mcpName: 'build_device',
+        workflow: 'device',
+        stateful: false,
+        handler: emitHandler('build'),
+      }),
+    ]);
+
+    const invoker = new DefaultToolInvoker(catalog);
+    const response = await invokeAndFinalize(invoker, 'list', {}, { runtime: 'cli' });
+
+    expect(response.isError).toBe(true);
     const text = response.content.map((item) => (item.type === 'text' ? item.text : '')).join('\n');
     expect(text).toContain('Try building for device');
     expect(text).toContain('build-device');

--- a/src/runtime/tool-invoker.ts
+++ b/src/runtime/tool-invoker.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/sentry.ts';
 import type { RenderSession, ToolHandlerContext } from '../rendering/types.ts';
 import { createRenderSession } from '../rendering/render.ts';
+import { createStructuredErrorOutput } from '../utils/structured-error.ts';
 
 type BuiltTemplateNextStep = {
   step: NextStep;
@@ -35,6 +36,26 @@ function createStatusFragment(
     level,
     message,
   };
+}
+
+function emitExplicitRuntimeError(params: {
+  session: RenderSession;
+  handlerContext?: ToolHandlerContext;
+  onStructuredOutput?: InvokeOptions['onStructuredOutput'];
+  code: string;
+  message: string;
+}): void {
+  const output = createStructuredErrorOutput({
+    category: 'runtime',
+    code: params.code,
+    message: params.message,
+  });
+  params.session.setStructuredOutput?.(output);
+  if (params.handlerContext) {
+    params.handlerContext.structuredOutput = output;
+  }
+  params.onStructuredOutput?.(output);
+  params.session.emit(createStatusFragment('error', params.message));
 }
 
 function buildTemplateNextSteps(
@@ -269,22 +290,24 @@ export class DefaultToolInvoker implements ToolInvoker {
     const resolvedOpts = { ...opts, renderSession: session };
 
     if (resolved.ambiguous) {
-      session.emit(
-        createStatusFragment(
-          'error',
-          `Ambiguous tool name: Multiple tools match '${toolName}'. Use one of:\n- ${resolved.ambiguous.join('\n- ')}`,
-        ),
-      );
+      emitExplicitRuntimeError({
+        session,
+        handlerContext: opts.handlerContext,
+        onStructuredOutput: opts.onStructuredOutput,
+        code: 'AMBIGUOUS_TOOL',
+        message: `Ambiguous tool name: Multiple tools match '${toolName}'. Use one of:\n- ${resolved.ambiguous.join('\n- ')}`,
+      });
       return;
     }
 
     if (resolved.notFound || !resolved.tool) {
-      session.emit(
-        createStatusFragment(
-          'error',
-          `Tool not found: Unknown tool '${toolName}'. Run 'xcodebuildmcp tools' to see available tools.`,
-        ),
-      );
+      emitExplicitRuntimeError({
+        session,
+        handlerContext: opts.handlerContext,
+        onStructuredOutput: opts.onStructuredOutput,
+        code: 'TOOL_NOT_FOUND',
+        message: `Tool not found: Unknown tool '${toolName}'. Run 'xcodebuildmcp tools' to see available tools.`,
+      });
       return;
     }
 
@@ -322,16 +345,19 @@ export class DefaultToolInvoker implements ToolInvoker {
       const error = new Error('SocketPathMissing');
       context.captureInfraErrorMetric(error);
       context.captureInvocationMetric('infra_error');
-      session.emit(
-        createStatusFragment(
-          'error',
-          'Socket path required: No socket path configured for daemon communication.',
-        ),
-      );
+      emitExplicitRuntimeError({
+        session,
+        handlerContext: opts.handlerContext,
+        onStructuredOutput: opts.onStructuredOutput,
+        code: 'SOCKET_PATH_MISSING',
+        message: 'Socket path required: No socket path configured for daemon communication.',
+      });
       return;
     }
 
-    const client = new DaemonClient({ socketPath });
+    const daemonTimeout =
+      context.postProcessParams.tool.workflow === 'xcode-ide' ? 60_000 : undefined;
+    const client = new DaemonClient({ socketPath, timeout: daemonTimeout });
     const isRunning = await client.isRunning();
 
     if (!isRunning) {
@@ -350,12 +376,13 @@ export class DefaultToolInvoker implements ToolInvoker {
         );
         context.captureInfraErrorMetric(error);
         context.captureInvocationMetric('infra_error');
-        session.emit(
-          createStatusFragment(
-            'error',
-            `Daemon auto-start failed: ${error instanceof Error ? error.message : String(error)}\n\nYou can try starting the daemon manually:\n  xcodebuildmcp daemon start`,
-          ),
-        );
+        emitExplicitRuntimeError({
+          session,
+          handlerContext: opts.handlerContext,
+          onStructuredOutput: opts.onStructuredOutput,
+          code: 'DAEMON_AUTO_START_FAILED',
+          message: `Daemon auto-start failed: ${error instanceof Error ? error.message : String(error)}\n\nYou can try starting the daemon manually:\n  xcodebuildmcp daemon start`,
+        });
         return;
       }
     }
@@ -375,7 +402,7 @@ export class DefaultToolInvoker implements ToolInvoker {
             startupTimeoutMs: opts.daemonStartupTimeoutMs ?? DEFAULT_DAEMON_STARTUP_TIMEOUT_MS,
             env: buildDaemonEnvOverrides(opts),
           });
-          const retryClient = new DaemonClient({ socketPath });
+          const retryClient = new DaemonClient({ socketPath, timeout: daemonTimeout });
           const daemonResult = await invoke(retryClient);
           context.captureInvocationMetric('completed');
           context.consumeResult(daemonResult);
@@ -388,12 +415,13 @@ export class DefaultToolInvoker implements ToolInvoker {
           );
           context.captureInfraErrorMetric(retryError);
           context.captureInvocationMetric('infra_error');
-          session.emit(
-            createStatusFragment(
-              'error',
-              `Daemon restart failed after protocol mismatch: ${retryError instanceof Error ? retryError.message : String(retryError)}\n\nTry restarting manually:\n  xcodebuildmcp daemon stop && xcodebuildmcp daemon start`,
-            ),
-          );
+          emitExplicitRuntimeError({
+            session,
+            handlerContext: opts.handlerContext,
+            onStructuredOutput: opts.onStructuredOutput,
+            code: 'DAEMON_RESTART_FAILED',
+            message: `Daemon restart failed after protocol mismatch: ${retryError instanceof Error ? retryError.message : String(retryError)}\n\nTry restarting manually:\n  xcodebuildmcp daemon stop && xcodebuildmcp daemon start`,
+          });
           return;
         }
       }
@@ -405,12 +433,13 @@ export class DefaultToolInvoker implements ToolInvoker {
       );
       context.captureInfraErrorMetric(error);
       context.captureInvocationMetric('infra_error');
-      session.emit(
-        createStatusFragment(
-          'error',
-          `${context.errorTitle}: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
+      emitExplicitRuntimeError({
+        session,
+        handlerContext: opts.handlerContext,
+        onStructuredOutput: opts.onStructuredOutput,
+        code: 'DAEMON_TRANSPORT_FAILED',
+        message: `${context.errorTitle}: ${error instanceof Error ? error.message : String(error)}`,
+      });
     }
   }
 
@@ -457,19 +486,20 @@ export class DefaultToolInvoker implements ToolInvoker {
           captureInfraErrorMetric,
           captureInvocationMetric,
           consumeResult: (daemonResult: DaemonToolResult) => {
-            for (const fragment of daemonResult.fragments ?? []) {
-              opts.renderSession!.emit(fragment);
+            const structuredOutput = daemonResult.structuredOutput ?? undefined;
+            if (structuredOutput) {
+              opts.renderSession!.setStructuredOutput?.(structuredOutput);
+              opts.onStructuredOutput?.(structuredOutput);
             }
 
             const ctx: ToolHandlerContext = {
-              liveProgressEnabled: opts.handlerContext?.liveProgressEnabled ?? false,
-              streamingFragmentsEnabled: opts.handlerContext?.liveProgressEnabled ?? false,
               emit: (fragment) => {
                 opts.renderSession!.emit(fragment);
               },
               attach: (image) => opts.renderSession!.attach(image),
               nextStepParams: daemonResult.nextStepParams,
               nextSteps: daemonResult.nextSteps,
+              structuredOutput,
             };
 
             postProcessSession({
@@ -508,8 +538,6 @@ export class DefaultToolInvoker implements ToolInvoker {
             }
 
             const ctx: ToolHandlerContext = {
-              liveProgressEnabled: opts.handlerContext?.liveProgressEnabled ?? false,
-              streamingFragmentsEnabled: opts.handlerContext?.liveProgressEnabled ?? false,
               emit: (fragment) => {
                 session.emit(fragment);
               },
@@ -532,10 +560,9 @@ export class DefaultToolInvoker implements ToolInvoker {
 
     // Direct invocation (CLI stateless or daemon internal)
     const session = opts.renderSession!;
+    let ctx: ToolHandlerContext | undefined;
     try {
-      const ctx: ToolHandlerContext = opts.handlerContext ?? {
-        liveProgressEnabled: false,
-        streamingFragmentsEnabled: false,
+      ctx = opts.handlerContext ?? {
         emit: (fragment): void => {
           session.emit(fragment);
           opts.onProgress?.(fragment);
@@ -569,11 +596,14 @@ export class DefaultToolInvoker implements ToolInvoker {
       );
       captureInfraErrorMetric(error);
       captureInvocationMetric('infra_error');
-      if (opts.runtime === 'daemon') {
-        throw error instanceof Error ? error : new Error(String(error));
-      }
       const message = error instanceof Error ? error.message : String(error);
-      session.emit(createStatusFragment('error', `Tool execution failed: ${message}`));
+      emitExplicitRuntimeError({
+        session,
+        handlerContext: ctx ?? opts.handlerContext,
+        onStructuredOutput: opts.onStructuredOutput,
+        code: 'DIRECT_HANDLER_FAILED',
+        message: `Tool execution failed: ${message}`,
+      });
     }
   }
 }

--- a/src/runtime/tool-invoker.ts
+++ b/src/runtime/tool-invoker.ts
@@ -1,7 +1,6 @@
 import type { ToolCatalog, ToolDefinition, ToolInvoker, InvokeOptions } from './types.ts';
 import type { NextStep, NextStepParams, NextStepParamsMap } from '../types/common.ts';
 import type { DaemonToolResult, ToolInvokeResult } from '../daemon/protocol.ts';
-import type { RuntimeStatusFragment } from '../types/runtime-status.ts';
 
 import { DaemonClient, DaemonVersionMismatchError } from '../cli/daemon-client.ts';
 import {
@@ -26,18 +25,6 @@ type BuiltTemplateNextStep = {
   templateToolId?: string;
 };
 
-function createStatusFragment(
-  level: RuntimeStatusFragment['level'],
-  message: string,
-): RuntimeStatusFragment {
-  return {
-    kind: 'infrastructure',
-    fragment: 'status',
-    level,
-    message,
-  };
-}
-
 function emitExplicitRuntimeError(params: {
   session: RenderSession;
   handlerContext?: ToolHandlerContext;
@@ -55,7 +42,6 @@ function emitExplicitRuntimeError(params: {
     params.handlerContext.structuredOutput = output;
   }
   params.onStructuredOutput?.(output);
-  params.session.emit(createStatusFragment('error', params.message));
 }
 
 function buildTemplateNextSteps(

--- a/src/smoke-tests/__tests__/e2e-mcp-discovery.test.ts
+++ b/src/smoke-tests/__tests__/e2e-mcp-discovery.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { z } from 'zod';
 import { createMcpTestHarness, type McpTestHarness } from '../mcp-test-harness.ts';
 import { loadManifest } from '../../core/manifest/load-manifest.ts';
-import { getMcpOutputSchema } from '../../core/structured-output-schema.ts';
+import { getMcpOutputSchemaForRegistration } from '../../core/structured-output-schema.ts';
 
 let harness: McpTestHarness;
 
@@ -11,6 +12,26 @@ const COMMON_DEFS_REF =
 function expectSelfContainedOutputSchema(outputSchema: unknown): void {
   expect(outputSchema).toBeDefined();
   expect(JSON.stringify(outputSchema)).not.toContain(COMMON_DEFS_REF);
+}
+
+function expectedRegistrationSchema(schema: string, version = '1'): unknown {
+  return z.toJSONSchema(getMcpOutputSchemaForRegistration({ schema, version }));
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => {
+        const record = value as Record<string, unknown>;
+        return `${JSON.stringify(key)}:${stableStringify(record[key])}`;
+      })
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
 }
 
 beforeAll(async () => {
@@ -69,11 +90,14 @@ describe('MCP Discovery (e2e)', () => {
       const tool = result.tools.find((candidate) => candidate.name === toolName);
       expect(tool).toBeDefined();
       expectSelfContainedOutputSchema(tool!.outputSchema);
-      expect(tool!.outputSchema).toEqual(getMcpOutputSchema({ schema: schemaName, version: '1' }));
+      expect(tool!.outputSchema).toEqual(expectedRegistrationSchema(schemaName));
     }
 
     const listSims = result.tools.find((tool) => tool.name === 'list_sims');
-    expect(listSims?.outputSchema?.$defs).toBeDefined();
+    const listSimsOutputSchema = listSims?.outputSchema as
+      | { oneOf?: Array<{ $defs?: unknown }> }
+      | undefined;
+    expect(listSimsOutputSchema?.oneOf?.[0]?.$defs).toBeDefined();
   });
 
   it('every registered manifest tool with output metadata advertises an output schema', async () => {
@@ -98,10 +122,12 @@ describe('MCP Discovery (e2e)', () => {
         failures.push(`${tool.names.mcp}: outputSchema contains external common refs`);
       }
       if (
-        registeredTool.outputSchema.$id !==
-        `https://xcodebuildmcp.com/schemas/structured-output/${tool.outputSchema.schema}/${tool.outputSchema.version}.schema.json`
+        stableStringify(registeredTool.outputSchema) !==
+        stableStringify(
+          expectedRegistrationSchema(tool.outputSchema.schema, tool.outputSchema.version),
+        )
       ) {
-        failures.push(`${tool.names.mcp}: outputSchema $id mismatch`);
+        failures.push(`${tool.names.mcp}: outputSchema mismatch`);
       }
     }
 

--- a/src/snapshot-tests/__fixtures__/cli/xcode-ide/documentation-search--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/xcode-ide/documentation-search--success.txt
@@ -1,0 +1,7 @@
+
+🔧 Xcode IDE Call Tool
+
+   Remote Tool: DocumentationSearch
+
+✅ Tool "DocumentationSearch" completed successfully. Raw response saved to artifact.
+  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
@@ -1,5 +1,5 @@
 
 🔧 Xcode IDE List Tools
 
-✅ Found 20 tool(s). Raw response saved to artifact.
+✅ Found <XCODE_IDE_TOOL_COUNT> tool(s). Raw response saved to artifact.
   └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
@@ -1,0 +1,5 @@
+
+🔧 Xcode IDE List Tools
+
+✅ Found 20 tool(s). Raw response saved to artifact.
+  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__fixtures__/json/xcode-ide/documentation-search--success.json
+++ b/src/snapshot-tests/__fixtures__/json/xcode-ide/documentation-search--success.json
@@ -1,0 +1,14 @@
+{
+  "schema": "xcodebuildmcp.output.xcode-bridge-call-result",
+  "schemaVersion": "2",
+  "didError": false,
+  "error": null,
+  "data": {
+    "remoteTool": "DocumentationSearch",
+    "succeeded": true,
+    "content": [],
+    "artifacts": {
+      "rawResponseJsonPath": "<RAW_RESPONSE_JSON_PATH>"
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/xcode-ide/list-tools--success.json
+++ b/src/snapshot-tests/__fixtures__/json/xcode-ide/list-tools--success.json
@@ -1,0 +1,12 @@
+{
+  "schema": "xcodebuildmcp.output.xcode-bridge-tool-list",
+  "schemaVersion": "2",
+  "didError": false,
+  "error": null,
+  "data": {
+    "toolCount": 20,
+    "artifacts": {
+      "rawResponseJsonPath": "<RAW_RESPONSE_JSON_PATH>"
+    }
+  }
+}

--- a/src/snapshot-tests/__fixtures__/json/xcode-ide/list-tools--success.json
+++ b/src/snapshot-tests/__fixtures__/json/xcode-ide/list-tools--success.json
@@ -4,7 +4,7 @@
   "didError": false,
   "error": null,
   "data": {
-    "toolCount": 20,
+    "toolCount": 99999,
     "artifacts": {
       "rawResponseJsonPath": "<RAW_RESPONSE_JSON_PATH>"
     }

--- a/src/snapshot-tests/__fixtures__/mcp/xcode-ide/documentation-search--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/xcode-ide/documentation-search--success.txt
@@ -1,0 +1,7 @@
+
+🔧 Xcode IDE Call Tool
+
+   Remote Tool: DocumentationSearch
+
+✅ Tool "DocumentationSearch" completed successfully. Raw response saved to artifact.
+  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
@@ -1,5 +1,5 @@
 
 🔧 Xcode IDE List Tools
 
-✅ Found 20 tool(s). Raw response saved to artifact.
+✅ Found <XCODE_IDE_TOOL_COUNT> tool(s). Raw response saved to artifact.
   └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
@@ -1,0 +1,5 @@
+
+🔧 Xcode IDE List Tools
+
+✅ Found 20 tool(s). Raw response saved to artifact.
+  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>

--- a/src/snapshot-tests/__tests__/xcode-ide.snapshot.test.ts
+++ b/src/snapshot-tests/__tests__/xcode-ide.snapshot.test.ts
@@ -1,0 +1,5 @@
+import { registerXcodeIdeSnapshotSuite } from '../suites/xcode-ide-suite.ts';
+
+registerXcodeIdeSnapshotSuite('cli');
+registerXcodeIdeSnapshotSuite('mcp');
+registerXcodeIdeSnapshotSuite('json');

--- a/src/snapshot-tests/harness.ts
+++ b/src/snapshot-tests/harness.ts
@@ -13,11 +13,19 @@ const SIMULATOR_STATE_POLL_INTERVAL_MS = 250;
 export type SnapshotHarness = WorkflowSnapshotHarness;
 export type { SnapshotResult };
 
-function getSnapshotHarnessEnv(): Record<string, string> {
+export interface CreateSnapshotHarnessOptions {
+  env?: Record<string, string>;
+  globalArgs?: string[];
+}
+
+export function getSnapshotHarnessEnv(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
   const { VITEST: _vitest, NODE_ENV: _nodeEnv, ...rest } = process.env;
-  return Object.fromEntries(
+  const env = Object.fromEntries(
     Object.entries(rest).filter((entry): entry is [string, string] => entry[1] !== undefined),
   );
+  return { ...env, ...overrides };
 }
 
 function runSnapshotCli(
@@ -25,8 +33,16 @@ function runSnapshotCli(
   cliToolName: string,
   args: Record<string, unknown>,
   output: 'text' | 'json' = 'text',
+  options: CreateSnapshotHarnessOptions = {},
 ): ReturnType<typeof spawnSync> {
-  const commandArgs = [CLI_PATH, workflow, cliToolName, '--json', JSON.stringify(args)];
+  const commandArgs = [
+    CLI_PATH,
+    ...(options.globalArgs ?? []),
+    workflow,
+    cliToolName,
+    '--json',
+    JSON.stringify(args),
+  ];
   if (output !== 'text') {
     commandArgs.push('--output', output);
   }
@@ -35,11 +51,13 @@ function runSnapshotCli(
     encoding: 'utf8',
     timeout: SNAPSHOT_COMMAND_TIMEOUT_MS,
     cwd: process.cwd(),
-    env: getSnapshotHarnessEnv(),
+    env: getSnapshotHarnessEnv(options.env),
   });
 }
 
-export async function createSnapshotHarness(): Promise<SnapshotHarness> {
+export async function createSnapshotHarness(
+  options: CreateSnapshotHarnessOptions = {},
+): Promise<SnapshotHarness> {
   async function invoke(
     workflow: string,
     cliToolName: string,
@@ -55,7 +73,7 @@ export async function createSnapshotHarness(): Promise<SnapshotHarness> {
       throw new Error(`Tool '${cliToolName}' in workflow '${workflow}' is not CLI-available`);
     }
 
-    const result = runSnapshotCli(workflow, cliToolName, args);
+    const result = runSnapshotCli(workflow, cliToolName, args, 'text', options);
     const stdout =
       typeof result.stdout === 'string' ? result.stdout : (result.stdout?.toString('utf8') ?? '');
 

--- a/src/snapshot-tests/json-harness.ts
+++ b/src/snapshot-tests/json-harness.ts
@@ -1,9 +1,11 @@
 import { formatStructuredEnvelopeFixture } from './json-normalize.ts';
 import type { SnapshotResult, WorkflowSnapshotHarness } from './contracts.ts';
-import { createMcpSnapshotHarness } from './mcp-harness.ts';
+import { createMcpSnapshotHarness, type CreateMcpSnapshotHarnessOptions } from './mcp-harness.ts';
 
-export async function createJsonSnapshotHarness(): Promise<WorkflowSnapshotHarness> {
-  const harness = await createMcpSnapshotHarness();
+export async function createJsonSnapshotHarness(
+  opts: CreateMcpSnapshotHarnessOptions = {},
+): Promise<WorkflowSnapshotHarness> {
+  const harness = await createMcpSnapshotHarness(opts);
 
   async function invoke(
     workflow: string,

--- a/src/snapshot-tests/json-normalize.ts
+++ b/src/snapshot-tests/json-normalize.ts
@@ -34,6 +34,9 @@ function normalizeString(value: string, key?: string, path: string[] = []): stri
 
 function normalizeNumber(path: string[], key: string | undefined, value: number): number {
   switch (key) {
+    case 'toolCount':
+      if (path.includes('data')) return 99999;
+      return value;
     case 'durationMs':
       if (path.at(-2) === 'summary') return 1234;
       if (path.includes('testCases')) return 0;

--- a/src/snapshot-tests/json-normalize.ts
+++ b/src/snapshot-tests/json-normalize.ts
@@ -9,6 +9,10 @@ function normalizeString(value: string, key?: string, path: string[] = []): stri
   const normalized = normalizeSnapshotOutput(value.replace(/\u00A0/g, ' '));
   let result = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized;
 
+  if (key === 'rawResponseJsonPath') {
+    return '<RAW_RESPONSE_JSON_PATH>';
+  }
+
   if (key === 'AXFrame') {
     // Round embedded floats to 1 decimal place for rounding-stable comparison with
     // the sibling `frame` object. e.g. 82.666664123535156 -> 82.7, 250.5 stays 250.5.
@@ -92,10 +96,34 @@ function normalizeValue(value: unknown, path: string[] = []): unknown {
   return value;
 }
 
+function normalizeXcodeBridgeCallEnvelope(
+  envelope: StructuredOutputEnvelope<unknown>,
+): StructuredOutputEnvelope<unknown> {
+  if (envelope.schema !== 'xcodebuildmcp.output.xcode-bridge-call-result') {
+    return envelope;
+  }
+
+  const data = (envelope as { data?: unknown }).data;
+  if (!isRecord(data)) {
+    return envelope;
+  }
+
+  return {
+    ...envelope,
+    data: {
+      ...data,
+      content: [],
+      ...(Object.hasOwn(data, 'structuredContent') ? { structuredContent: {} } : {}),
+    },
+  } as StructuredOutputEnvelope<unknown>;
+}
+
 export function normalizeStructuredEnvelope(
   envelope: StructuredOutputEnvelope<unknown>,
 ): StructuredOutputEnvelope<unknown> {
-  return normalizeValue(envelope) as StructuredOutputEnvelope<unknown>;
+  return normalizeValue(
+    normalizeXcodeBridgeCallEnvelope(envelope),
+  ) as StructuredOutputEnvelope<unknown>;
 }
 
 function compactFrameObjects(json: string): string {

--- a/src/snapshot-tests/mcp-harness.ts
+++ b/src/snapshot-tests/mcp-harness.ts
@@ -8,7 +8,7 @@ import { resolveSnapshotToolManifest } from './tool-manifest-resolver.ts';
 
 const CLI_PATH = path.resolve(process.cwd(), 'build/cli.js');
 const MCP_TOOL_TIMEOUT_MS = 120_000;
-const MCP_SNAPSHOT_PARITY_WORKFLOWS = [
+export const MCP_SNAPSHOT_PARITY_WORKFLOWS = [
   'coverage',
   'debugging',
   'device',

--- a/src/snapshot-tests/normalize.ts
+++ b/src/snapshot-tests/normalize.ts
@@ -140,6 +140,10 @@ export function normalizeSnapshotOutput(text: string): string {
     /(Build Logs: )(?:<TMPDIR>|<HOME>\/Library\/Developer\/XcodeBuildMCP)\/logs\//g,
     '$1<HOME>/Library/Developer/XcodeBuildMCP/logs/',
   );
+  normalized = normalized.replace(
+    /Raw Response JSON: .+\/xcode-ide\/call-tool\/.+\/[A-Za-z0-9._-]+\.json/g,
+    'Raw Response JSON: <RAW_RESPONSE_JSON_PATH>',
+  );
 
   normalized = normalized.replace(DERIVED_DATA_HASH_REGEX, '$1-<HASH>');
   normalized = normalized.replace(ISO_TIMESTAMP_REGEX, '<TIMESTAMP>');

--- a/src/snapshot-tests/normalize.ts
+++ b/src/snapshot-tests/normalize.ts
@@ -144,6 +144,10 @@ export function normalizeSnapshotOutput(text: string): string {
     /Raw Response JSON: .+\/xcode-ide\/call-tool\/.+\/[A-Za-z0-9._-]+\.json/g,
     'Raw Response JSON: <RAW_RESPONSE_JSON_PATH>',
   );
+  normalized = normalized.replace(
+    /Found \d+ tool\(s\)(?=\. Raw response saved to artifact\.|$)/g,
+    'Found <XCODE_IDE_TOOL_COUNT> tool(s)',
+  );
 
   normalized = normalized.replace(DERIVED_DATA_HASH_REGEX, '$1-<HASH>');
   normalized = normalized.replace(ISO_TIMESTAMP_REGEX, '<TIMESTAMP>');

--- a/src/snapshot-tests/suites/helpers.ts
+++ b/src/snapshot-tests/suites/helpers.ts
@@ -1,23 +1,28 @@
 import type { SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
 import { createFixtureMatcher, type FixtureMatchOptions } from '../fixture-io.ts';
-import { createSnapshotHarness } from '../harness.ts';
+import { createSnapshotHarness, type CreateSnapshotHarnessOptions } from '../harness.ts';
 import { createJsonSnapshotHarness } from '../json-harness.ts';
-import { createMcpSnapshotHarness } from '../mcp-harness.ts';
+import { createMcpSnapshotHarness, type CreateMcpSnapshotHarnessOptions } from '../mcp-harness.ts';
 
 const COMPILER_ERROR_EXTRA_ARGS = ['OTHER_SWIFT_FLAGS=$(inherited) -D SNAPSHOT_COMPILER_ERROR'];
 
+export interface CreateHarnessForRuntimeOptions
+  extends CreateMcpSnapshotHarnessOptions,
+    CreateSnapshotHarnessOptions {}
+
 export function createHarnessForRuntime(
   runtime: SnapshotRuntime,
+  options: CreateHarnessForRuntimeOptions = {},
 ): Promise<WorkflowSnapshotHarness> {
   if (runtime === 'mcp') {
-    return createMcpSnapshotHarness();
+    return createMcpSnapshotHarness(options);
   }
 
   if (runtime === 'json') {
-    return createJsonSnapshotHarness();
+    return createJsonSnapshotHarness(options);
   }
 
-  return createSnapshotHarness();
+  return createSnapshotHarness(options);
 }
 
 export interface WorkflowFixtureMatcherOptions extends FixtureMatchOptions {

--- a/src/snapshot-tests/suites/xcode-ide-suite.ts
+++ b/src/snapshot-tests/suites/xcode-ide-suite.ts
@@ -1,0 +1,181 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SnapshotResult, SnapshotRuntime, WorkflowSnapshotHarness } from '../contracts.ts';
+import { getSnapshotHarnessEnv } from '../harness.ts';
+import { isXcodeIdeBridgeAvailable } from '../xcode-ide-availability.ts';
+import { createHarnessForRuntime, createWorkflowFixtureMatcher } from './helpers.ts';
+
+const XCODE_IDE_BRIDGE_READY = isXcodeIdeBridgeAvailable();
+const DOCUMENTATION_SEARCH_TOOL = 'DocumentationSearch';
+const DOCUMENTATION_SEARCH_QUERY = 'AVCapturePhotoOutputMaxPhotoQualityPrioritization';
+const CLI_PATH = join(process.cwd(), 'build/cli.js');
+const XCODE_IDE_BRIDGE_SETTLE_MS = 2_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getArtifactPathFromEnvelope(result: SnapshotResult): string | null {
+  const data = result.structuredEnvelope?.data;
+  if (!isRecord(data) || !isRecord(data.artifacts)) {
+    return null;
+  }
+
+  return typeof data.artifacts.rawResponseJsonPath === 'string'
+    ? data.artifacts.rawResponseJsonPath
+    : null;
+}
+
+function getArtifactPathFromText(result: SnapshotResult): string | null {
+  const match = result.rawText.match(/Raw Response JSON:\s*(.+)$/m);
+  return match?.[1]?.trim() ?? null;
+}
+
+function resolveArtifactPath(artifactDisplayPath: string): string {
+  if (artifactDisplayPath === '~') {
+    return homedir();
+  }
+  if (artifactDisplayPath.startsWith('~/')) {
+    return join(homedir(), artifactDisplayPath.slice(2));
+  }
+  if (isAbsolute(artifactDisplayPath)) {
+    return artifactDisplayPath;
+  }
+  return join(process.cwd(), artifactDisplayPath);
+}
+
+function bridgeListContainsTool(result: SnapshotResult, toolName: string): boolean {
+  const artifactDisplayPath =
+    getArtifactPathFromEnvelope(result) ?? getArtifactPathFromText(result);
+  if (!artifactDisplayPath) {
+    throw new Error('xcode-ide list-tools warm-up did not expose a raw response artifact path.');
+  }
+
+  const artifactPath = resolveArtifactPath(artifactDisplayPath);
+  const artifact = JSON.parse(readFileSync(artifactPath, 'utf8')) as unknown;
+  if (
+    !isRecord(artifact) ||
+    !isRecord(artifact.response) ||
+    !Array.isArray(artifact.response.tools)
+  ) {
+    throw new Error(
+      `xcode-ide list-tools artifact did not contain response.tools: ${artifactPath}`,
+    );
+  }
+
+  return artifact.response.tools.some((tool) => isRecord(tool) && tool.name === toolName);
+}
+
+if (!XCODE_IDE_BRIDGE_READY) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[xcode-ide-suite] xcrun mcpbridge or a running Xcode instance is unavailable. Xcode IDE bridge snapshot tests will be skipped.',
+  );
+}
+
+export function registerXcodeIdeSnapshotSuite(runtime: SnapshotRuntime): void {
+  const expectFixture = createWorkflowFixtureMatcher(runtime, 'xcode-ide');
+
+  describe.runIf(XCODE_IDE_BRIDGE_READY)(`${runtime} xcode-ide workflow`, () => {
+    let harness: WorkflowSnapshotHarness;
+    let tempDir: string;
+    let socketPath: string;
+    let daemonEnv: Record<string, string>;
+    let bridgeListReady = false;
+    let documentationSearchReady = false;
+
+    beforeAll(async () => {
+      if (runtime === 'cli') {
+        tempDir = mkdtempSync(join(tmpdir(), 'xcodebuildmcp-xcode-ide-snapshot-'));
+        socketPath = join(tempDir, 'daemon.sock');
+        daemonEnv = {
+          XCODEBUILDMCP_ENABLED_WORKFLOWS: 'xcode-ide',
+          XCODEBUILDMCP_DISABLE_SESSION_DEFAULTS: 'true',
+          XCODEBUILDMCP_DISABLE_XCODE_AUTO_SYNC: '1',
+          XCODEBUILDMCP_XCODE_IDE_DISCOVERY_TIMEOUT_MS: '5000',
+        };
+        harness = await createHarnessForRuntime(runtime, {
+          env: daemonEnv,
+          globalArgs: ['--socket', socketPath],
+        });
+      } else {
+        harness = await createHarnessForRuntime(runtime, {
+          enabledWorkflows: ['xcode-ide'],
+        });
+      }
+
+      const warmup = await harness.invoke('xcode-ide', 'list-tools', { refresh: true });
+
+      bridgeListReady = warmup.isError === false;
+      documentationSearchReady =
+        bridgeListReady && bridgeListContainsTool(warmup, DOCUMENTATION_SEARCH_TOOL);
+
+      if (!bridgeListReady) {
+        // eslint-disable-next-line no-console
+        console.warn('[xcode-ide-suite] bridge warm-up failed; skipping xcode-ide snapshots.');
+      } else {
+        if (!documentationSearchReady) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[xcode-ide-suite] bridge warm-up did not expose ${DOCUMENTATION_SEARCH_TOOL}; skipping documentation-search snapshot only.`,
+          );
+        }
+        await delay(XCODE_IDE_BRIDGE_SETTLE_MS);
+      }
+    });
+
+    afterAll(async () => {
+      await harness.cleanup();
+      if (runtime === 'cli') {
+        try {
+          execFileSync('node', [CLI_PATH, '--socket', socketPath, 'daemon', 'stop'], {
+            env: getSnapshotHarnessEnv(daemonEnv),
+            stdio: ['ignore', 'ignore', 'ignore'],
+          });
+        } catch {
+          // best effort cleanup
+        }
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    describe('list-tools', () => {
+      it('success', async (context) => {
+        if (!bridgeListReady) {
+          context.skip();
+        }
+
+        const { text, isError } = await harness.invoke('xcode-ide', 'list-tools', {
+          refresh: false,
+        });
+
+        expect(isError).toBe(false);
+        expectFixture(text, 'list-tools--success');
+      }, 120_000);
+    });
+
+    describe('documentation-search', () => {
+      it('success', async (context) => {
+        if (!documentationSearchReady) {
+          context.skip();
+        }
+
+        const { text, isError } = await harness.invoke('xcode-ide', 'call-tool', {
+          remoteTool: DOCUMENTATION_SEARCH_TOOL,
+          arguments: { query: DOCUMENTATION_SEARCH_QUERY, frameworks: ['AVFoundation'] },
+          timeoutMs: 120_000,
+        });
+
+        expect(isError).toBe(false);
+        expectFixture(text, 'documentation-search--success');
+      }, 120_000);
+    });
+  });
+}

--- a/src/snapshot-tests/xcode-ide-availability.ts
+++ b/src/snapshot-tests/xcode-ide-availability.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+
+const BRIDGE_PROBE_TIMEOUT_MS = 8_000;
+
+export function isXcodeIdeBridgeAvailable(): boolean {
+  try {
+    execSync('xcrun --find mcpbridge', {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: BRIDGE_PROBE_TIMEOUT_MS,
+    });
+    execSync('pgrep -x Xcode', {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: BRIDGE_PROBE_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/test-utils/test-helpers.ts
+++ b/src/test-utils/test-helpers.ts
@@ -38,25 +38,22 @@ export interface MockToolHandlerResult {
   isError(): boolean;
 }
 
-export function createMockToolHandlerContext(
-  options: {
-    liveProgressEnabled?: boolean;
-  } = {},
-): {
+export function createMockToolHandlerContext(): {
   ctx: ToolHandlerContext;
   result: MockToolHandlerResult;
   run: <T>(fn: () => Promise<T>) => Promise<T>;
 } {
   const events: AnyFragment[] = [];
   const attachments: ImageAttachment[] = [];
+  const session = createRenderSession('text');
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: options.liveProgressEnabled ?? true,
-    streamingFragmentsEnabled: options.liveProgressEnabled ?? true,
     emit: (fragment: AnyFragment) => {
       events.push(fragment);
+      session.emit(fragment);
     },
     attach: (image) => {
       attachments.push(image);
+      session.attach(image);
     },
   };
   const resultObj: MockToolHandlerResult = {
@@ -67,20 +64,13 @@ export function createMockToolHandlerContext(
     },
     text() {
       return renderCliTextTranscript({
-        items: events,
+        items: [],
         structuredOutput: ctx.structuredOutput,
         nextSteps: ctx.nextSteps,
       });
     },
     isError() {
-      return (
-        events.some(
-          (e) =>
-            (e.fragment === 'compiler-diagnostic' && e.severity === 'error') ||
-            e.fragment === 'test-failure' ||
-            (e.fragment === 'status' && e.level === 'error'),
-        ) || ctx.structuredOutput?.result.didError === true
-      );
+      return ctx.structuredOutput?.result.didError === true;
     },
   };
   return {
@@ -92,16 +82,11 @@ export function createMockToolHandlerContext(
   };
 }
 
-export async function runToolLogic<T>(
-  logic: () => Promise<T>,
-  options: {
-    liveProgressEnabled?: boolean;
-  } = {},
-): Promise<{
+export async function runToolLogic<T>(logic: () => Promise<T>): Promise<{
   response: T;
   result: MockToolHandlerResult;
 }> {
-  const { result, run } = createMockToolHandlerContext(options);
+  const { result, run } = createMockToolHandlerContext();
   const response = await run(logic);
   return { response, result };
 }
@@ -164,12 +149,8 @@ export async function callHandler(
   args: Record<string, unknown>,
 ): Promise<CallHandlerResult> {
   const session = createRenderSession('text');
-  const items: AnyFragment[] = [];
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: true,
-    streamingFragmentsEnabled: true,
     emit: (fragment: AnyFragment) => {
-      items.push(fragment);
       session.emit(fragment);
     },
     attach: (image) => session.attach(image),
@@ -182,7 +163,7 @@ export async function callHandler(
     session.setNextSteps?.([...ctx.nextSteps], 'cli');
   }
   const text = renderCliTextTranscript({
-    items,
+    items: [],
     structuredOutput: ctx.structuredOutput,
     nextSteps: ctx.nextSteps,
   });

--- a/src/types/domain-results.ts
+++ b/src/types/domain-results.ts
@@ -1,4 +1,5 @@
 export type ToolDomainResultKind =
+  | 'error'
   | 'app-path'
   | 'build-result'
   | 'build-run-result'
@@ -36,6 +37,14 @@ export interface ToolDomainResultBase {
   didError: boolean;
   error: string | null;
   diagnostics?: BasicDiagnostics;
+}
+export type StructuredErrorCategory = 'runtime' | 'validation' | 'schema';
+export interface ErrorDomainResult extends ToolDomainResultBase {
+  kind: 'error';
+  didError: true;
+  error: string;
+  category: StructuredErrorCategory;
+  code: string;
 }
 export type AtLeastOne<T extends object> = {
   [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
@@ -294,18 +303,14 @@ export interface XcodeBridgeSyncStats {
   removed: number;
   total: number;
 }
-export interface XcodeBridgeToolDescriptor {
-  name: string;
-  title: string | null;
-  description: string | null;
-  inputSchema: Record<string, unknown> | boolean | null;
-  outputSchema: Record<string, unknown> | boolean | null;
-  annotations: Record<string, unknown> | null;
-}
 export interface XcodeBridgeRelayedContentItem {
   type: string;
   [key: string]: unknown;
 }
+export interface XcodeBridgeResponseArtifacts {
+  rawResponseJsonPath: string;
+}
+export type XcodeBridgeCallResultArtifacts = XcodeBridgeResponseArtifacts;
 export interface ProjectListSummary extends StatusSummary {
   maxDepth: number;
   projectCount?: number;
@@ -620,7 +625,7 @@ export type XcodeBridgeCallResultDomainResult = ToolDomainResultBase & {
   remoteTool: string;
   succeeded: boolean;
   content: XcodeBridgeRelayedContentItem[];
-  structuredContent?: Record<string, unknown> | null;
+  artifacts?: XcodeBridgeCallResultArtifacts;
 };
 export type XcodeBridgeStatusDomainResult = ToolDomainResultBase & {
   kind: 'xcode-bridge-status';
@@ -635,7 +640,7 @@ export type XcodeBridgeSyncDomainResult = ToolDomainResultBase & {
 export type XcodeBridgeToolListDomainResult = ToolDomainResultBase & {
   kind: 'xcode-bridge-tool-list';
   toolCount: number;
-  tools: XcodeBridgeToolDescriptor[];
+  artifacts?: XcodeBridgeResponseArtifacts;
 };
 export type WorkflowSelectionDomainResult = ToolDomainResultBase & {
   kind: 'workflow-selection';
@@ -643,6 +648,7 @@ export type WorkflowSelectionDomainResult = ToolDomainResultBase & {
   registeredToolCount: number;
 };
 export type ToolDomainResult =
+  | ErrorDomainResult
   | AppPathDomainResult
   | BuildResultDomainResult
   | BuildRunResultDomainResult

--- a/src/types/tool-execution.ts
+++ b/src/types/tool-execution.ts
@@ -11,7 +11,6 @@ export interface ToolAttachment {
  * Provides fragment emission for live progress streaming.
  */
 export interface StreamingExecutionContext {
-  liveProgressEnabled: boolean;
   attach?(image: ToolAttachment): void;
   emitFragment(fragment: AnyFragment): void;
 }

--- a/src/utils/__tests__/session-aware-tool-factory.test.ts
+++ b/src/utils/__tests__/session-aware-tool-factory.test.ts
@@ -38,22 +38,30 @@ function statusFragment(
 function invokeAndCollect(
   handler: ToolHandler,
   args: Record<string, unknown>,
-): Promise<{ text: string; isError: boolean }> {
+): Promise<{
+  text: string;
+  isError: boolean;
+  structuredOutput: ToolHandlerContext['structuredOutput'];
+}> {
   const session = createRenderSession('text');
   const items: AnyFragment[] = [];
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: false,
-    streamingFragmentsEnabled: false,
     emit: (event) => {
       items.push(event);
       session.emit(event);
     },
     attach: (image) => session.attach(image),
   };
-  return handler(args, ctx).then(() => ({
-    text: renderCliTextTranscript({ items }),
-    isError: session.isError(),
-  }));
+  return handler(args, ctx).then(() => {
+    if (ctx.structuredOutput) {
+      session.setStructuredOutput?.(ctx.structuredOutput);
+    }
+    return {
+      text: renderCliTextTranscript({ items, structuredOutput: ctx.structuredOutput }),
+      isError: session.isError(),
+      structuredOutput: ctx.structuredOutput,
+    };
+  });
 }
 
 describe('createSessionAwareTool', () => {
@@ -143,6 +151,8 @@ describe('createSessionAwareTool', () => {
       simulatorId: 'SIM-1',
     });
     expect(result.isError).toBe(true);
+    expect(result.structuredOutput?.schema).toBe('xcodebuildmcp.output.error');
+    expect(result.structuredOutput?.result.error).toContain('Missing required session defaults');
     expect(result.text).toContain('Missing required session defaults');
     expect(result.text).toContain('scheme is required');
   });

--- a/src/utils/__tests__/typed-tool-factory.test.ts
+++ b/src/utils/__tests__/typed-tool-factory.test.ts
@@ -36,22 +36,30 @@ async function testLogic(params: TestParams): Promise<void> {
 function invokeAndCollect(
   handler: ToolHandler,
   args: Record<string, unknown>,
-): Promise<{ text: string; isError: boolean }> {
+): Promise<{
+  text: string;
+  isError: boolean;
+  structuredOutput: ToolHandlerContext['structuredOutput'];
+}> {
   const session = createRenderSession('text');
   const items: AnyFragment[] = [];
   const ctx: ToolHandlerContext = {
-    liveProgressEnabled: false,
-    streamingFragmentsEnabled: false,
     emit: (event) => {
       items.push(event);
       session.emit(event);
     },
     attach: (image) => session.attach(image),
   };
-  return handler(args, ctx).then(() => ({
-    text: renderCliTextTranscript({ items }),
-    isError: session.isError(),
-  }));
+  return handler(args, ctx).then(() => {
+    if (ctx.structuredOutput) {
+      session.setStructuredOutput?.(ctx.structuredOutput);
+    }
+    return {
+      text: renderCliTextTranscript({ items, structuredOutput: ctx.structuredOutput }),
+      isError: session.isError(),
+      structuredOutput: ctx.structuredOutput,
+    };
+  });
 }
 
 describe('createTypedTool', () => {
@@ -78,6 +86,9 @@ describe('createTypedTool', () => {
       });
 
       expect(result.isError).toBe(true);
+      expect(result.structuredOutput?.schema).toBe('xcodebuildmcp.output.error');
+      expect(result.structuredOutput?.result.didError).toBe(true);
+      expect(result.structuredOutput?.result.error).toContain('Parameter validation failed');
       expect(result.text).toContain('Parameter validation failed');
       expect(result.text).toContain('requiredParam');
     });

--- a/src/utils/__tests__/workspace-filesystem-lifecycle.test.ts
+++ b/src/utils/__tests__/workspace-filesystem-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import {
+  cleanupOwnedWorkspaceFilesystemArtifacts,
   resetWorkspaceFilesystemLifecycleStateForTests,
   runWorkspaceFilesystemLifecycleSweep,
   scheduleWorkspaceFilesystemLifecycleSweep,
@@ -88,6 +89,44 @@ describe('workspace filesystem lifecycle', () => {
     expect(existsSync(derivedDataLog)).toBe(true);
   });
 
+  it('removes owned xcode-ide call-tool transient artifacts during shutdown cleanup', async () => {
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const currentArtifact = path.join(
+      layout.state,
+      'xcode-ide',
+      'call-tool',
+      `ownerpid${process.pid}_filesystem-lifecycle-test`,
+      'response.json',
+    );
+    const staleArtifact = path.join(
+      layout.state,
+      'xcode-ide',
+      'call-tool',
+      'ownerpid999999999_stale',
+      'response.json',
+    );
+    const liveArtifact = path.join(
+      layout.state,
+      'xcode-ide',
+      'call-tool',
+      `ownerpid${process.pid}_other-live-instance`,
+      'response.json',
+    );
+    writeFileWithMtime(currentArtifact, '{}', Date.now());
+    writeFileWithMtime(staleArtifact, '{}', Date.now());
+    writeFileWithMtime(liveArtifact, '{}', Date.now());
+
+    const result = await cleanupOwnedWorkspaceFilesystemArtifacts({
+      workspaceKey: 'workspace-a',
+      trigger: 'shutdown',
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(existsSync(currentArtifact)).toBe(false);
+    expect(existsSync(staleArtifact)).toBe(false);
+    expect(existsSync(liveArtifact)).toBe(true);
+  });
+
   it('protects active daemon logs through the existing daemon registry', async () => {
     const now = Date.UTC(2026, 4, 2, 12);
     const layout = getWorkspaceFilesystemLayout('workspace-a');
@@ -117,6 +156,38 @@ describe('workspace filesystem lifecycle', () => {
     expect(result).toMatchObject({ scanned: 2, deleted: 1 });
     expect(existsSync(daemonLog)).toBe(true);
     expect(existsSync(oldLog)).toBe(false);
+  });
+
+  it('removes stale xcode-ide call-tool transient artifacts at startup even when log retention is cooling down', async () => {
+    const now = Date.UTC(2026, 4, 2, 12);
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const staleArtifact = path.join(
+      layout.state,
+      'xcode-ide',
+      'call-tool',
+      'ownerpid999999999_stale',
+      'response.json',
+    );
+    const liveArtifact = path.join(
+      layout.state,
+      'xcode-ide',
+      'call-tool',
+      `ownerpid${process.pid}_other-live-instance`,
+      'response.json',
+    );
+    writeFileWithMtime(staleArtifact, '{}', now);
+    writeFileWithMtime(liveArtifact, '{}', now);
+    writeFileWithMtime(layout.filesystemLifecycle.markerPath, String(now), now);
+
+    const result = await runWorkspaceFilesystemLifecycleSweep({
+      workspaceKey: 'workspace-a',
+      trigger: 'startup',
+      now: now + 1000,
+    });
+
+    expect(result).toMatchObject({ skippedByCooldown: true, scanned: 0 });
+    expect(existsSync(staleArtifact)).toBe(false);
+    expect(existsSync(liveArtifact)).toBe(true);
   });
 
   it('runs startup OSLog reconciliation even when log retention is cooling down', async () => {

--- a/src/utils/execution/__tests__/tool-execution-context.test.ts
+++ b/src/utils/execution/__tests__/tool-execution-context.test.ts
@@ -54,14 +54,12 @@ describe('DefaultStreamingExecutionContext', () => {
 });
 
 describe('createStreamingExecutionContext', () => {
-  function makeHandlerContext(streamingFragmentsEnabled: boolean): {
+  function makeHandlerContext(): {
     ctx: ToolHandlerContext;
     emitted: AnyFragment[];
   } {
     const emitted: AnyFragment[] = [];
     const ctx: ToolHandlerContext = {
-      liveProgressEnabled: true,
-      streamingFragmentsEnabled,
       emit: (fragment) => emitted.push(fragment),
       attach: () => {},
     };
@@ -75,22 +73,13 @@ describe('createStreamingExecutionContext', () => {
     status: 'started',
   };
 
-  it('forwards fragments through ctx.emit when streamingFragmentsEnabled is true', () => {
-    const { ctx, emitted } = makeHandlerContext(true);
+  it('always forwards fragments through ctx.emit', () => {
+    const { ctx, emitted } = makeHandlerContext();
     const execCtx = createStreamingExecutionContext(ctx);
 
     execCtx.emitFragment(testFragment);
 
     expect(emitted).toHaveLength(1);
     expect(emitted[0]).toBe(testFragment);
-  });
-
-  it('silently drops fragments when streamingFragmentsEnabled is false', () => {
-    const { ctx, emitted } = makeHandlerContext(false);
-    const execCtx = createStreamingExecutionContext(ctx);
-
-    execCtx.emitFragment(testFragment);
-
-    expect(emitted).toHaveLength(0);
   });
 });

--- a/src/utils/execution/tool-execution-context.ts
+++ b/src/utils/execution/tool-execution-context.ts
@@ -2,17 +2,14 @@ import type { DomainFragment } from '../../types/domain-fragments.ts';
 import type { ToolAttachment, StreamingExecutionContext } from '../../types/tool-execution.ts';
 
 export interface StreamingExecutionContextOptions {
-  liveProgressEnabled?: boolean;
   onFragment?: (fragment: DomainFragment) => void;
 }
 
 export class DefaultStreamingExecutionContext implements StreamingExecutionContext {
-  readonly liveProgressEnabled: boolean;
   private readonly attachments: ToolAttachment[] = [];
   private readonly fragmentCallback?: (fragment: DomainFragment) => void;
 
   constructor(options: StreamingExecutionContextOptions = {}) {
-    this.liveProgressEnabled = options.liveProgressEnabled ?? true;
     this.fragmentCallback = options.onFragment;
   }
 

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -110,6 +110,8 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
   let structuredOutput: StructuredToolOutput | undefined;
   let sawIncomingHeaderEvent = false;
   let sawIncomingNonHeaderEvent = false;
+  let sawIncomingSummaryEvent = false;
+  let sawIncomingNonSummaryEvent = false;
   let nextSteps: readonly NextStep[] = [];
   let nextStepsRuntime: 'cli' | 'daemon' | 'mcp' | undefined;
   let sawProgressNextSteps = false;
@@ -392,6 +394,11 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       }
       if (item.type !== 'header') {
         sawIncomingNonHeaderEvent = true;
+        if (item.type === 'summary') {
+          sawIncomingSummaryEvent = true;
+        } else {
+          sawIncomingNonSummaryEvent = true;
+        }
       }
       processItem(item);
     },
@@ -420,6 +427,19 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
           for (const item of replayItems) {
             processItem(item);
           }
+        } else if (!sawIncomingNonSummaryEvent) {
+          const structuredItems = renderDomainResultTextItems(
+            structuredOutput.result,
+            structuredOutput.renderHints,
+          );
+          const replayItems = structuredItems.filter((item) => {
+            if (sawIncomingHeaderEvent && item.type === 'header') return false;
+            if (sawIncomingSummaryEvent && item.type === 'summary') return false;
+            return true;
+          });
+          for (const item of replayItems) {
+            processItem(item);
+          }
         } else {
           const tailItems = createStreamingTailItems(structuredOutput.result);
           for (const item of tailItems) {
@@ -445,6 +465,8 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       structuredOutput = undefined;
       sawIncomingHeaderEvent = false;
       sawIncomingNonHeaderEvent = false;
+      sawIncomingSummaryEvent = false;
+      sawIncomingNonSummaryEvent = false;
       nextSteps = [];
       nextStepsRuntime = undefined;
       parserStates.clear();

--- a/src/utils/renderers/domain-result-text.ts
+++ b/src/utils/renderers/domain-result-text.ts
@@ -1990,15 +1990,17 @@ export function createStreamingTailItems(result: ToolDomainResult): TextRenderab
   return items;
 }
 
-function renderBridgeCallContent(
-  content: Extract<ToolDomainResult, { kind: 'xcode-bridge-call-result' }>['content'],
-): string[] {
-  return content.map((item) => {
-    if (item.type === 'text' && typeof item.text === 'string') {
-      return item.text;
-    }
-    return JSON.stringify(item, null, 2);
-  });
+function createRawResponseArtifactItems(pathValue?: string): TextRenderableItem[] {
+  return pathValue
+    ? [
+        createDetailTree([
+          {
+            label: 'Raw Response JSON',
+            value: displayPath(pathValue),
+          },
+        ]),
+      ]
+    : [];
 }
 
 function createSpecialCaseItems(
@@ -2006,6 +2008,15 @@ function createSpecialCaseItems(
   hints?: RenderHints,
 ): TextRenderableItem[] | null {
   switch (result.kind) {
+    case 'error':
+      return [
+        createHeader('Error'),
+        createStatus('error', result.error),
+        createDetailTree([
+          { label: 'Category', value: result.category },
+          { label: 'Code', value: result.code },
+        ]),
+      ];
     case 'app-path':
       return createAppPathItems(result);
     case 'bundle-id':
@@ -2157,43 +2168,44 @@ function createSpecialCaseItems(
             ]),
             createStatus('success', 'Bridge sync completed'),
           ];
-    case 'xcode-bridge-tool-list':
-      return result.didError
-        ? [
-            createHeader('Xcode IDE List Tools'),
-            ...createFailureStatusWithDiagnostics(result, 'Failed to list bridge tools'),
-          ]
-        : [
-            createHeader('Xcode IDE List Tools'),
-            createSection('Tools', [
-              JSON.stringify({ toolCount: result.toolCount, tools: result.tools }, null, 2),
-            ]),
-            createStatus('success', `Found ${result.toolCount} tool(s)`),
-          ];
+    case 'xcode-bridge-tool-list': {
+      const items: TextRenderableItem[] = [createHeader('Xcode IDE List Tools')];
+      if (result.didError) {
+        items.push(...createFailureStatusWithDiagnostics(result, 'Failed to list bridge tools'));
+        items.push(...createRawResponseArtifactItems(result.artifacts?.rawResponseJsonPath));
+        return items;
+      }
+      items.push(
+        createStatus(
+          'success',
+          result.artifacts?.rawResponseJsonPath
+            ? `Found ${result.toolCount} tool(s). Raw response saved to artifact.`
+            : `Found ${result.toolCount} tool(s)`,
+        ),
+      );
+      items.push(...createRawResponseArtifactItems(result.artifacts?.rawResponseJsonPath));
+      return items;
+    }
     case 'xcode-bridge-call-result': {
       const items: TextRenderableItem[] = [
         createHeader('Xcode IDE Call Tool', [{ label: 'Remote Tool', value: result.remoteTool }]),
       ];
       if (result.didError) {
-        if (result.content.length > 0) {
-          items.push(createSection('Relayed Content', renderBridgeCallContent(result.content)));
-        }
         items.push(
           ...createFailureStatusWithDiagnostics(result, `Tool "${result.remoteTool}" failed`),
         );
+        items.push(...createRawResponseArtifactItems(result.artifacts?.rawResponseJsonPath));
         return items;
       }
-      if (result.content.length > 0) {
-        items.push(createSection('Relayed Content', renderBridgeCallContent(result.content)));
-      }
-      if (result.structuredContent) {
-        items.push(
-          createSection('Structured Content', [JSON.stringify(result.structuredContent, null, 2)]),
-        );
-      }
-      if (result.content.length === 0 && !result.structuredContent) {
-        items.push(createStatus('success', `Tool "${result.remoteTool}" completed successfully`));
-      }
+      items.push(
+        createStatus(
+          'success',
+          result.artifacts?.rawResponseJsonPath
+            ? `Tool "${result.remoteTool}" completed successfully. Raw response saved to artifact.`
+            : `Tool "${result.remoteTool}" completed successfully`,
+        ),
+      );
+      items.push(...createRawResponseArtifactItems(result.artifacts?.rawResponseJsonPath));
       return items;
     }
     default:

--- a/src/utils/structured-error.ts
+++ b/src/utils/structured-error.ts
@@ -1,0 +1,34 @@
+import type { StructuredToolOutput, ToolHandlerContext } from '../rendering/types.ts';
+import type { StructuredErrorCategory } from '../types/domain-results.ts';
+
+export const STRUCTURED_ERROR_SCHEMA = 'xcodebuildmcp.output.error';
+export const STRUCTURED_ERROR_SCHEMA_VERSION = '1';
+
+export interface StructuredErrorParams {
+  category: StructuredErrorCategory;
+  code: string;
+  message: string;
+}
+
+export function createStructuredErrorOutput(params: StructuredErrorParams): StructuredToolOutput {
+  return {
+    schema: STRUCTURED_ERROR_SCHEMA,
+    schemaVersion: STRUCTURED_ERROR_SCHEMA_VERSION,
+    result: {
+      kind: 'error',
+      didError: true,
+      error: params.message,
+      category: params.category,
+      code: params.code,
+    },
+  };
+}
+
+export function setStructuredErrorOutput(
+  ctx: Pick<ToolHandlerContext, 'structuredOutput'>,
+  params: StructuredErrorParams,
+): StructuredToolOutput {
+  const output = createStructuredErrorOutput(params);
+  ctx.structuredOutput = output;
+  return output;
+}

--- a/src/utils/tool-execution-compat.ts
+++ b/src/utils/tool-execution-compat.ts
@@ -4,10 +4,9 @@ import { DefaultStreamingExecutionContext } from './execution/index.ts';
 /**
  * Creates a streaming execution context bridged to a ToolHandlerContext.
  *
- * When `ctx.streamingFragmentsEnabled` is true, domain fragments are forwarded
- * through `ctx.emit(...)` to the render session's fragment handling. When
- * disabled (e.g. MCP, json/raw CLI modes), fragments are silently dropped —
- * the structured-output path captures results at finalization.
+ * Domain fragments are always forwarded through `ctx.emit(...)`; render sessions
+ * decide which fragments are transient live output and which are captured for
+ * final text.
  *
  * Only streaming tools (build/test/build-run) should use this adapter.
  * Non-streaming tools should not receive an execution context at all.
@@ -16,7 +15,6 @@ export function createStreamingExecutionContext(
   ctx: ToolHandlerContext,
 ): DefaultStreamingExecutionContext {
   return new DefaultStreamingExecutionContext({
-    liveProgressEnabled: ctx.liveProgressEnabled,
-    onFragment: ctx.streamingFragmentsEnabled ? (fragment) => ctx.emit(fragment) : undefined,
+    onFragment: (fragment) => ctx.emit(fragment),
   });
 }

--- a/src/utils/tool-registry.ts
+++ b/src/utils/tool-registry.ts
@@ -307,8 +307,6 @@ export async function applyWorkflowSelectionFromManifest(
             try {
               const session = createRenderSession('text');
               const ctx: ToolHandlerContext = {
-                liveProgressEnabled: false,
-                streamingFragmentsEnabled: false,
                 emit: (fragment) => {
                   session.emit(fragment);
                 },

--- a/src/utils/typed-tool-factory.ts
+++ b/src/utils/typed-tool-factory.ts
@@ -6,6 +6,7 @@ import { renderCliTextTranscript } from './renderers/cli-text-renderer.ts';
 import type { CommandExecutor } from './execution/index.ts';
 import type { AnyFragment, DomainFragment } from '../types/domain-fragments.ts';
 import { infrastructureStatus } from '../types/runtime-status.ts';
+import { setStructuredErrorOutput } from './structured-error.ts';
 
 import { sessionStore, type SessionDefaults } from './session-store.ts';
 import { isSessionDefaultsOptOutEnabled } from './environment.ts';
@@ -52,10 +53,19 @@ function isToolHandlerContext(value: unknown): value is ToolHandlerContext {
   );
 }
 
+function setValidationErrorOutput(ctx: ToolHandlerContext, message: string, code: string): void {
+  setStructuredErrorOutput(ctx, {
+    category: 'validation',
+    code,
+    message,
+  });
+  ctx.emit(infrastructureStatus('error', message));
+}
+
 function sessionToTestResult(session: ReturnType<typeof createRenderSession>): ToolTestResult {
   const fragments = [...session.getFragments()];
   const text = renderCliTextTranscript({
-    items: fragments,
+    items: [],
     structuredOutput: session.getStructuredOutput?.(),
     nextSteps: session.getNextSteps?.(),
     nextStepsRuntime: session.getNextStepsRuntime?.(),
@@ -93,8 +103,6 @@ function createValidatedHandler<TParams, TContext>(
           attach: (image) => {
             session!.attach(image);
           },
-          liveProgressEnabled: false,
-          streamingFragmentsEnabled: false,
         };
     const context =
       providedContext !== undefined && !hasProvidedHandlerContext ? providedContext : getContext();
@@ -114,8 +122,15 @@ function createValidatedHandler<TParams, TContext>(
     } catch (error) {
       if (error instanceof z.ZodError) {
         const details = `Invalid parameters:\n${formatZodIssues(error)}`;
-        ctx.emit(infrastructureStatus('error', `Parameter validation failed: ${details}`));
+        setValidationErrorOutput(
+          ctx,
+          `Parameter validation failed: ${details}`,
+          'PARAMETER_VALIDATION_FAILED',
+        );
         if (!hasProvidedHandlerContext) {
+          if (ctx.structuredOutput) {
+            session!.setStructuredOutput?.(ctx.structuredOutput);
+          }
           return sessionToTestResult(session!);
         }
         return;
@@ -239,8 +254,6 @@ function createSessionAwareHandler<TParams, TContext>(opts: {
           attach: (image) => {
             session!.attach(image);
           },
-          liveProgressEnabled: false,
-          streamingFragmentsEnabled: false,
         };
     const context =
       providedContext !== undefined && !hasProvidedHandlerContext ? providedContext : getContext();
@@ -268,11 +281,10 @@ function createSessionAwareHandler<TParams, TContext>(opts: {
       for (const pair of exclusivePairs) {
         const provided = pair.filter((k) => Object.prototype.hasOwnProperty.call(sanitizedArgs, k));
         if (provided.length >= 2) {
-          ctx.emit(
-            infrastructureStatus(
-              'error',
-              `Parameter validation failed: Invalid parameters:\nMutually exclusive parameters provided: ${provided.join(', ')}. Provide only one.`,
-            ),
+          setValidationErrorOutput(
+            ctx,
+            `Parameter validation failed: Invalid parameters:\nMutually exclusive parameters provided: ${provided.join(', ')}. Provide only one.`,
+            'MUTUALLY_EXCLUSIVE_PARAMETERS',
           );
           return finalize();
         }
@@ -297,7 +309,7 @@ function createSessionAwareHandler<TParams, TContext>(opts: {
               setHint,
               optOutEnabled: isSessionDefaultsOptOutEnabled(),
             });
-            ctx.emit(infrastructureStatus('error', `${title}: ${body}`));
+            setValidationErrorOutput(ctx, `${title}: ${body}`, 'MISSING_REQUIRED_PARAMETERS');
             return finalize();
           }
         } else if ('oneOf' in req) {
@@ -312,7 +324,7 @@ function createSessionAwareHandler<TParams, TContext>(opts: {
               setHint: `Set with: ${setHints}`,
               optOutEnabled: isSessionDefaultsOptOutEnabled(),
             });
-            ctx.emit(infrastructureStatus('error', `${title}: ${body}`));
+            setValidationErrorOutput(ctx, `${title}: ${body}`, 'MISSING_REQUIRED_PARAMETERS');
             return finalize();
           }
         }
@@ -324,7 +336,11 @@ function createSessionAwareHandler<TParams, TContext>(opts: {
     } catch (error) {
       if (error instanceof z.ZodError) {
         const details = `Invalid parameters:\n${formatZodIssues(error)}`;
-        ctx.emit(infrastructureStatus('error', `Parameter validation failed: ${details}`));
+        setValidationErrorOutput(
+          ctx,
+          `Parameter validation failed: ${details}`,
+          'PARAMETER_VALIDATION_FAILED',
+        );
         return finalize();
       }
       throw error;

--- a/src/utils/typed-tool-factory.ts
+++ b/src/utils/typed-tool-factory.ts
@@ -4,8 +4,7 @@ import type { ToolHandlerContext } from '../rendering/types.ts';
 import { createRenderSession } from '../rendering/render.ts';
 import { renderCliTextTranscript } from './renderers/cli-text-renderer.ts';
 import type { CommandExecutor } from './execution/index.ts';
-import type { AnyFragment, DomainFragment } from '../types/domain-fragments.ts';
-import { infrastructureStatus } from '../types/runtime-status.ts';
+import type { DomainFragment } from '../types/domain-fragments.ts';
 import { setStructuredErrorOutput } from './structured-error.ts';
 
 import { sessionStore, type SessionDefaults } from './session-store.ts';
@@ -19,7 +18,6 @@ import { mergeSessionDefaultArgs } from './session-default-args.ts';
 export interface ToolTestResult {
   content: Array<{ type: 'text'; text: string }>;
   isError?: boolean;
-  _fragments?: AnyFragment[];
 }
 
 /**
@@ -59,11 +57,9 @@ function setValidationErrorOutput(ctx: ToolHandlerContext, message: string, code
     code,
     message,
   });
-  ctx.emit(infrastructureStatus('error', message));
 }
 
 function sessionToTestResult(session: ReturnType<typeof createRenderSession>): ToolTestResult {
-  const fragments = [...session.getFragments()];
   const text = renderCliTextTranscript({
     items: [],
     structuredOutput: session.getStructuredOutput?.(),
@@ -79,7 +75,6 @@ function sessionToTestResult(session: ReturnType<typeof createRenderSession>): T
   return {
     content,
     isError: session.isError() || undefined,
-    ...(fragments.length > 0 ? { _fragments: fragments } : {}),
   };
 }
 

--- a/src/utils/workspace-filesystem-lifecycle.ts
+++ b/src/utils/workspace-filesystem-lifecycle.ts
@@ -1,4 +1,6 @@
+import type { Dirent } from 'node:fs';
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import { cleanupWorkspaceDaemonFiles, readDaemonRegistryEntry } from '../daemon/daemon-registry.ts';
 import { getWorkspaceFilesystemLayout } from './log-paths.ts';
@@ -35,6 +37,8 @@ const XCODEBUILD_LOG_NAME_PATTERN = new RegExp(
 const SIMULATOR_LOG_NAME_PATTERN = new RegExp(
   `^.+_${ISO_TIMESTAMP_PATTERN}_(?:helperpid\\d+_)?ownerpid\\d+_${SUFFIX_PATTERN}\\.log$`,
 );
+const XCODE_IDE_CALL_TOOL_TRANSIENT_DIR = path.join('xcode-ide', 'call-tool');
+const XCODE_IDE_CALL_TOOL_OWNER_DIR_PATTERN = /^ownerpid(\d+)_/u;
 
 export type WorkspaceFilesystemLifecycleTrigger =
   | 'startup'
@@ -336,12 +340,88 @@ function runDaemonCleanup(options: ResolvedWorkspaceFilesystemLifecycleOptions):
   cleanupWorkspaceDaemonFiles(options.workspaceKey, options.daemonCleanup);
 }
 
+function xcodeIdeCallToolTransientRoot(workspaceKey: string): string {
+  return path.join(
+    getWorkspaceFilesystemLayout(workspaceKey).state,
+    XCODE_IDE_CALL_TOOL_TRANSIENT_DIR,
+  );
+}
+
+async function cleanupXcodeIdeCallToolTransientArtifacts(
+  workspaceKey: string,
+  errors: string[],
+  options: { includeCurrentOwner: boolean },
+): Promise<void> {
+  const root = xcodeIdeCallToolTransientRoot(workspaceKey);
+  const runtimeInstance = getRuntimeInstanceIfConfigured();
+  const currentOwnerDir = runtimeInstance
+    ? `ownerpid${runtimeInstance.pid}_${runtimeInstance.instanceId}`
+    : null;
+
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    errors.push(error instanceof Error ? error.message : String(error));
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const ownerPid = Number(entry.name.match(XCODE_IDE_CALL_TOOL_OWNER_DIR_PATTERN)?.[1]);
+    const ownedByCurrentRuntime = options.includeCurrentOwner && currentOwnerDir === entry.name;
+    const ownedByDeadRuntime = Number.isInteger(ownerPid) && ownerPid > 0 && !isPidAlive(ownerPid);
+    if (!ownedByCurrentRuntime && !ownedByDeadRuntime) {
+      continue;
+    }
+    try {
+      await fs.rm(path.join(root, entry.name), { recursive: true, force: true });
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+}
+
+function cleanupXcodeIdeCallToolTransientArtifactsSync(): {
+  attemptedCount: number;
+  errors: string[];
+} {
+  const runtimeInstance = getRuntimeInstanceIfConfigured();
+  if (!runtimeInstance) {
+    return { attemptedCount: 0, errors: [] };
+  }
+  const ownerDir = `ownerpid${runtimeInstance.pid}_${runtimeInstance.instanceId}`;
+  const ownerPath = path.join(
+    xcodeIdeCallToolTransientRoot(runtimeInstance.workspaceKey),
+    ownerDir,
+  );
+  try {
+    fsSync.rmSync(ownerPath, { recursive: true, force: true });
+    return { attemptedCount: 1, errors: [] };
+  } catch (error) {
+    return {
+      attemptedCount: 1,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
 export async function runWorkspaceFilesystemLifecycleSweep(
   options: WorkspaceFilesystemLifecycleOptions,
 ): Promise<WorkspaceFilesystemLifecycleResult> {
   const resolved = resolveOptions(options);
   const errors: string[] = [];
   const stopped = await runStartupReconciliation(resolved, errors);
+  if (resolved.trigger === 'startup') {
+    await cleanupXcodeIdeCallToolTransientArtifacts(resolved.workspaceKey, errors, {
+      includeCurrentOwner: false,
+    });
+  }
 
   if (
     !resolved.force &&
@@ -483,6 +563,10 @@ export async function cleanupOwnedWorkspaceFilesystemArtifacts(
   if (options.daemonCleanup) {
     cleanupWorkspaceDaemonFiles(workspaceKey, options.daemonCleanup);
   }
+  const errors = [...stopResult.errors];
+  await cleanupXcodeIdeCallToolTransientArtifacts(workspaceKey, errors, {
+    includeCurrentOwner: true,
+  });
 
   return {
     workspaceKey,
@@ -493,7 +577,7 @@ export async function cleanupOwnedWorkspaceFilesystemArtifacts(
     stopped: stopResult.stoppedSessionCount,
     skippedByCooldown: false,
     skippedByLock: false,
-    errors: stopResult.errors,
+    errors,
   };
 }
 
@@ -502,7 +586,14 @@ export function terminateOwnedWorkspaceFilesystemArtifactsSync(): {
   errorCount: number;
   errors: string[];
 } {
-  return terminateLiveSimulatorLaunchOsLogSessionsSync();
+  const simulatorCleanup = terminateLiveSimulatorLaunchOsLogSessionsSync();
+  const transientArtifactCleanup = cleanupXcodeIdeCallToolTransientArtifactsSync();
+  const errors = [...simulatorCleanup.errors, ...transientArtifactCleanup.errors];
+  return {
+    attemptedCount: simulatorCleanup.attemptedCount + transientArtifactCleanup.attemptedCount,
+    errorCount: simulatorCleanup.errorCount + transientArtifactCleanup.errors.length,
+    errors,
+  };
 }
 
 export function resetWorkspaceFilesystemLifecycleStateForTests(): void {


### PR DESCRIPTION
Make final tool output come from explicit structured results instead of transient streaming fragments, then apply that path to Xcode IDE bridge calls.

Previously, some final CLI/daemon/MCP output depended on progress fragments that were meant only for live rendering. That made non-streaming output harder to reason about and risked leaking large relayed bridge payloads into final text. This change keeps streaming fragments transient and moves final status, errors, summaries, and artifact references into structured results.

For Xcode IDE bridge calls, raw remote responses are now saved as transient workspace-state JSON artifacts. The public output stays concise, while callers that need the full Xcode bridge response can follow the returned artifact path. The Xcode IDE CLI commands now use the same text, JSON, and JSONL rendering path as the rest of the tool catalog.

The branch is intentionally split into reviewable commits:

- shared rendering/runtime contract changes
- simulator/device/macOS build-and-run structured-result migration
- ownership-safe transient artifact cleanup
- Xcode IDE bridge artifact persistence and schema v2 output
- Xcode IDE snapshot coverage
- changelog and agent guidance updates

I considered preserving fragment-derived final state as a compatibility fallback, but that would keep two sources of truth. The structured result is now the canonical final output path, and fragments remain live progress only.

Validated locally with `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build`, and `npm test`.