### PR TITLE
feat(mcp): Add opt-in idle timeout shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in MCP server idle shutdown via `XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS`, allowing unused MCP server processes to gracefully exit after a configured idle period ([#394](https://github.com/getsentry/XcodeBuildMCP/issues/394)).
+
 ### Fixed
 
 - Fixed remaining `/bin/sh -c` shell-injection sites in bundle ID extraction and macOS launch flows by invoking `defaults` and `PlistBuddy` directly with argv arrays so user-supplied app paths are no longer interpreted by a shell ([#367](https://github.com/getsentry/XcodeBuildMCP/issues/367)).

--- a/src/daemon/idle-shutdown.ts
+++ b/src/daemon/idle-shutdown.ts
@@ -1,24 +1,19 @@
+import { DEFAULT_IDLE_CHECK_INTERVAL_MS, parseIdleTimeoutEnv } from '../utils/idle-timeout.ts';
 import type { DaemonActivitySnapshot } from './activity-registry.ts';
 
 export const DAEMON_IDLE_TIMEOUT_ENV_KEY = 'XCODEBUILDMCP_DAEMON_IDLE_TIMEOUT_MS';
 export const DEFAULT_DAEMON_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
-export const DEFAULT_DAEMON_IDLE_CHECK_INTERVAL_MS = 30 * 1000;
+export const DEFAULT_DAEMON_IDLE_CHECK_INTERVAL_MS = DEFAULT_IDLE_CHECK_INTERVAL_MS;
 
 export function resolveDaemonIdleTimeoutMs(
   env: NodeJS.ProcessEnv = process.env,
   fallbackMs: number = DEFAULT_DAEMON_IDLE_TIMEOUT_MS,
 ): number {
-  const raw = env[DAEMON_IDLE_TIMEOUT_ENV_KEY]?.trim();
-  if (!raw) {
-    return fallbackMs;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return fallbackMs;
-  }
-
-  return Math.floor(parsed);
+  return parseIdleTimeoutEnv({
+    env,
+    envKey: DAEMON_IDLE_TIMEOUT_ENV_KEY,
+    defaultTimeoutMs: fallbackMs,
+  }).timeoutMs;
 }
 
 export function hasActiveRuntimeSessions(snapshot: DaemonActivitySnapshot): boolean {

--- a/src/server/__tests__/mcp-idle-shutdown.test.ts
+++ b/src/server/__tests__/mcp-idle-shutdown.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  acquireDaemonActivity,
+  clearDaemonActivityRegistry,
+} from '../../daemon/activity-registry.ts';
+import {
+  DEFAULT_MCP_IDLE_TIMEOUT_MS,
+  MCP_IDLE_TIMEOUT_ENV_KEY,
+  createMcpIdleShutdownController,
+  resolveMcpIdleCheckIntervalMs,
+  resolveMcpIdleTimeoutConfig,
+  resolveMcpIdleTimeoutMs,
+} from '../mcp-idle-shutdown.ts';
+
+describe('MCP idle shutdown', () => {
+  beforeEach(() => {
+    clearDaemonActivityRegistry();
+  });
+
+  afterEach(() => {
+    clearDaemonActivityRegistry();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveMcpIdleTimeoutMs', () => {
+    it('defaults to disabled when env is not set', () => {
+      expect(resolveMcpIdleTimeoutMs({})).toBe(DEFAULT_MCP_IDLE_TIMEOUT_MS);
+    });
+
+    it('uses configured positive timeout', () => {
+      expect(resolveMcpIdleTimeoutMs({ [MCP_IDLE_TIMEOUT_ENV_KEY]: '15000' })).toBe(15000);
+    });
+
+    it('uses configured zero timeout', () => {
+      expect(resolveMcpIdleTimeoutMs({ [MCP_IDLE_TIMEOUT_ENV_KEY]: '0' })).toBe(0);
+    });
+
+    it('falls back to disabled for invalid timeout values', () => {
+      expect(resolveMcpIdleTimeoutMs({ [MCP_IDLE_TIMEOUT_ENV_KEY]: '-1' })).toBe(0);
+      expect(resolveMcpIdleTimeoutMs({ [MCP_IDLE_TIMEOUT_ENV_KEY]: 'NaN' })).toBe(0);
+    });
+
+    it('reports invalid raw values for startup logging', () => {
+      expect(resolveMcpIdleTimeoutConfig({ [MCP_IDLE_TIMEOUT_ENV_KEY]: '-1' })).toEqual({
+        timeoutMs: 0,
+        rawValue: '-1',
+        invalid: true,
+      });
+    });
+  });
+
+  describe('resolveMcpIdleCheckIntervalMs', () => {
+    it('keeps the check interval within the minimum and default bounds', () => {
+      expect(resolveMcpIdleCheckIntervalMs(1, 30_000)).toBe(100);
+      expect(resolveMcpIdleCheckIntervalMs(250, 30_000)).toBe(250);
+      expect(resolveMcpIdleCheckIntervalMs(60_000, 30_000)).toBe(30_000);
+      expect(resolveMcpIdleCheckIntervalMs(0, 30_000)).toBe(30_000);
+    });
+  });
+
+  it('does not start a timer when disabled', async () => {
+    vi.useFakeTimers();
+    const requestShutdown = vi.fn();
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 0,
+      intervalMs: 10,
+      requestShutdown,
+    });
+
+    controller.start();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(requestShutdown).not.toHaveBeenCalled();
+  });
+
+  it('starts an unref interval when enabled', () => {
+    const unref = vi.fn();
+    const timer = { unref } as unknown as NodeJS.Timeout;
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval').mockReturnValue(timer);
+    const clearIntervalSpy = vi
+      .spyOn(globalThis, 'clearInterval')
+      .mockImplementation(() => undefined);
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 50,
+      requestShutdown: vi.fn(),
+    });
+
+    controller.start();
+    controller.stop();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 50);
+    expect(unref).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(timer);
+  });
+
+  it('requests shutdown after the configured idle period', async () => {
+    vi.useFakeTimers();
+    let nowMs = 0;
+    const requestShutdown = vi.fn();
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      nowMs: () => nowMs,
+      requestShutdown,
+    });
+
+    controller.start();
+    nowMs = 1000;
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(requestShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request shutdown while a request is in flight', async () => {
+    vi.useFakeTimers();
+    let nowMs = 0;
+    const requestShutdown = vi.fn();
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      nowMs: () => nowMs,
+      requestShutdown,
+    });
+
+    controller.start();
+    controller.markRequestStarted();
+    nowMs = 2000;
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(requestShutdown).not.toHaveBeenCalled();
+    expect(controller.getInFlightRequestCount()).toBe(1);
+  });
+
+  it('does not request shutdown while daemon activity is active', async () => {
+    vi.useFakeTimers();
+    let nowMs = 0;
+    const requestShutdown = vi.fn();
+    const release = acquireDaemonActivity('video.capture');
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      nowMs: () => nowMs,
+      requestShutdown,
+    });
+
+    controller.start();
+    nowMs = 1000;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(requestShutdown).not.toHaveBeenCalled();
+
+    release();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(requestShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request shutdown after the controller is stopped', async () => {
+    vi.useFakeTimers();
+    let nowMs = 0;
+    const requestShutdown = vi.fn();
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      nowMs: () => nowMs,
+      requestShutdown,
+    });
+
+    controller.start();
+    controller.stop();
+    nowMs = 1000;
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(requestShutdown).not.toHaveBeenCalled();
+  });
+
+  it('resets the idle baseline when a request completes', async () => {
+    vi.useFakeTimers();
+    let nowMs = 0;
+    const requestShutdown = vi.fn();
+    const controller = createMcpIdleShutdownController({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      nowMs: () => nowMs,
+      requestShutdown,
+    });
+
+    controller.start();
+    controller.markRequestStarted();
+    nowMs = 800;
+    controller.markRequestCompleted();
+    expect(controller.getInFlightRequestCount()).toBe(0);
+
+    nowMs = 1700;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(requestShutdown).not.toHaveBeenCalled();
+
+    nowMs = 1800;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(requestShutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/__tests__/mcp-lifecycle.test.ts
+++ b/src/server/__tests__/mcp-lifecycle.test.ts
@@ -290,6 +290,7 @@ describe('mcp lifecycle snapshot', () => {
     expect(isTransportDisconnectReason('stdin-close')).toBe(true);
     expect(isTransportDisconnectReason('stdout-error')).toBe(true);
     expect(isTransportDisconnectReason('stderr-error')).toBe(true);
+    expect(isTransportDisconnectReason('idle-timeout')).toBe(false);
     expect(isTransportDisconnectReason('sigterm')).toBe(false);
   });
 });

--- a/src/server/__tests__/server.test.ts
+++ b/src/server/__tests__/server.test.ts
@@ -101,14 +101,20 @@ describe('MCP server transport request lifecycle instrumentation', () => {
     expect(onRequestCompleted).not.toHaveBeenCalled();
   });
 
-  it('completes duplicate responses only once', async () => {
+  it('ignores duplicate request IDs until the pending request completes', async () => {
+    const onRequestStarted = vi.fn();
     const onRequestCompleted = vi.fn();
-    const { transport } = await createStartedInstrumentedTransport({ onRequestCompleted });
+    const { transport } = await createStartedInstrumentedTransport({
+      onRequestStarted,
+      onRequestCompleted,
+    });
 
     transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'initialize' });
+    transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'tools/list' });
     await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
     await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
 
+    expect(onRequestStarted).toHaveBeenCalledTimes(1);
     expect(onRequestCompleted).toHaveBeenCalledTimes(1);
   });
 
@@ -122,6 +128,28 @@ describe('MCP server transport request lifecycle instrumentation', () => {
       'broken pipe',
     );
 
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks completion when downstream message handling throws synchronously', async () => {
+    const onRequestStarted = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const transport = new TestTransport();
+    const downstreamOnMessage = vi.fn(() => {
+      throw new Error('handler failed');
+    });
+    instrumentMcpRequestLifecycle(transport, { onRequestStarted, onRequestCompleted });
+
+    transport.onmessage = downstreamOnMessage;
+    await transport.start();
+
+    expect(() => {
+      transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'tools/list' });
+    }).toThrow('handler failed');
+
+    expect(onRequestStarted).toHaveBeenCalledTimes(1);
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+    await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
     expect(onRequestCompleted).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/__tests__/server.test.ts
+++ b/src/server/__tests__/server.test.ts
@@ -1,0 +1,127 @@
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  instrumentMcpRequestLifecycle,
+  type McpRequestLifecycleObserver,
+} from '../request-lifecycle.ts';
+
+class TestTransport implements Transport {
+  onmessage?: Transport['onmessage'];
+  sentMessages: JSONRPCMessage[] = [];
+  failNextSend = false;
+
+  async start(): Promise<void> {
+    return undefined;
+  }
+
+  async close(): Promise<void> {
+    return undefined;
+  }
+
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    if (this.failNextSend) {
+      this.failNextSend = false;
+      throw new Error('broken pipe');
+    }
+
+    this.sentMessages.push(message);
+  }
+}
+
+async function createStartedInstrumentedTransport(observer: McpRequestLifecycleObserver): Promise<{
+  transport: TestTransport;
+  downstreamOnMessage: ReturnType<typeof vi.fn>;
+}> {
+  const transport = new TestTransport();
+  const downstreamOnMessage = vi.fn();
+  instrumentMcpRequestLifecycle(transport, observer);
+
+  transport.onmessage = downstreamOnMessage;
+  await transport.start();
+
+  return { transport, downstreamOnMessage };
+}
+
+describe('MCP server transport request lifecycle instrumentation', () => {
+  it('marks request start and matching result response completion', async () => {
+    const onRequestStarted = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const { transport, downstreamOnMessage } = await createStartedInstrumentedTransport({
+      onRequestStarted,
+      onRequestCompleted,
+    });
+
+    transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'tools/list' });
+    await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
+
+    expect(onRequestStarted).toHaveBeenCalledTimes(1);
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+    expect(downstreamOnMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks matching error response completion', async () => {
+    const onRequestCompleted = vi.fn();
+    const { transport } = await createStartedInstrumentedTransport({ onRequestCompleted });
+
+    transport.onmessage?.({ jsonrpc: '2.0', id: 2, method: 'tools/call' });
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 2,
+      error: { code: -32603, message: 'failed' },
+    });
+
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores notifications', async () => {
+    const onRequestStarted = vi.fn();
+    const onRequestCompleted = vi.fn();
+    const { transport } = await createStartedInstrumentedTransport({
+      onRequestStarted,
+      onRequestCompleted,
+    });
+
+    transport.onmessage?.({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
+
+    expect(onRequestStarted).not.toHaveBeenCalled();
+    expect(onRequestCompleted).not.toHaveBeenCalled();
+  });
+
+  it('ignores unmatched responses', async () => {
+    const onRequestCompleted = vi.fn();
+    const { transport } = await createStartedInstrumentedTransport({ onRequestCompleted });
+
+    await transport.send({ jsonrpc: '2.0', id: 'missing', result: {} });
+
+    expect(onRequestCompleted).not.toHaveBeenCalled();
+  });
+
+  it('completes duplicate responses only once', async () => {
+    const onRequestCompleted = vi.fn();
+    const { transport } = await createStartedInstrumentedTransport({ onRequestCompleted });
+
+    transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'initialize' });
+    await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
+    await transport.send({ jsonrpc: '2.0', id: '1', result: {} });
+
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks completion after a matching response send rejects', async () => {
+    const onRequestCompleted = vi.fn();
+    const { transport } = await createStartedInstrumentedTransport({ onRequestCompleted });
+    transport.failNextSend = true;
+
+    transport.onmessage?.({ jsonrpc: '2.0', id: '1', method: 'initialize' });
+    await expect(transport.send({ jsonrpc: '2.0', id: '1', result: {} })).rejects.toThrow(
+      'broken pipe',
+    );
+
+    expect(onRequestCompleted).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/mcp-idle-shutdown.ts
+++ b/src/server/mcp-idle-shutdown.ts
@@ -1,0 +1,131 @@
+import {
+  getDaemonActivitySnapshot,
+  type DaemonActivitySnapshot,
+} from '../daemon/activity-registry.ts';
+import {
+  DEFAULT_IDLE_CHECK_INTERVAL_MS,
+  parseIdleTimeoutEnv,
+  type IdleTimeoutParseResult,
+} from '../utils/idle-timeout.ts';
+
+export const MCP_IDLE_TIMEOUT_ENV_KEY = 'XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS';
+export const DEFAULT_MCP_IDLE_TIMEOUT_MS = 0;
+export const DEFAULT_MCP_IDLE_CHECK_INTERVAL_MS = DEFAULT_IDLE_CHECK_INTERVAL_MS;
+export const MIN_MCP_IDLE_CHECK_INTERVAL_MS = 100;
+
+export interface McpIdleShutdownController {
+  start(): void;
+  stop(): void;
+  markRequestStarted(): void;
+  markRequestCompleted(): void;
+  getInFlightRequestCount(): number;
+}
+
+export function resolveMcpIdleTimeoutConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  fallbackMs: number = DEFAULT_MCP_IDLE_TIMEOUT_MS,
+): IdleTimeoutParseResult {
+  return parseIdleTimeoutEnv({
+    env,
+    envKey: MCP_IDLE_TIMEOUT_ENV_KEY,
+    defaultTimeoutMs: fallbackMs,
+  });
+}
+
+export function resolveMcpIdleTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+  fallbackMs: number = DEFAULT_MCP_IDLE_TIMEOUT_MS,
+): number {
+  return resolveMcpIdleTimeoutConfig(env, fallbackMs).timeoutMs;
+}
+
+export function resolveMcpIdleCheckIntervalMs(
+  timeoutMs: number,
+  defaultIntervalMs: number = DEFAULT_MCP_IDLE_CHECK_INTERVAL_MS,
+): number {
+  if (timeoutMs <= 0) {
+    return defaultIntervalMs;
+  }
+
+  return Math.min(Math.max(timeoutMs, MIN_MCP_IDLE_CHECK_INTERVAL_MS), defaultIntervalMs);
+}
+
+export function createMcpIdleShutdownController(options: {
+  timeoutMs: number;
+  intervalMs?: number;
+  getActivitySnapshot?: () => DaemonActivitySnapshot;
+  nowMs?: () => number;
+  requestShutdown: () => void | Promise<void>;
+  isShutdownRequested?: () => boolean;
+  logIdleMessage?: (message: string) => void;
+}): McpIdleShutdownController {
+  const timeoutMs = options.timeoutMs;
+  const intervalMs = options.intervalMs ?? DEFAULT_MCP_IDLE_CHECK_INTERVAL_MS;
+  const getActivitySnapshot = options.getActivitySnapshot ?? getDaemonActivitySnapshot;
+  const nowMs = options.nowMs ?? Date.now;
+  let lastRequestCompletedAtMs = nowMs();
+  let inFlightRequestCount = 0;
+  let timer: NodeJS.Timeout | null = null;
+  let shutdownTriggered = false;
+
+  const checkIdle = (): void => {
+    if (shutdownTriggered || options.isShutdownRequested?.()) {
+      return;
+    }
+
+    const idleForMs = nowMs() - lastRequestCompletedAtMs;
+    if (idleForMs < timeoutMs) {
+      return;
+    }
+
+    if (inFlightRequestCount > 0) {
+      return;
+    }
+
+    if (getActivitySnapshot().activeOperationCount > 0) {
+      return;
+    }
+
+    shutdownTriggered = true;
+    options.logIdleMessage?.(
+      `MCP idle timeout reached (${idleForMs}ms >= ${timeoutMs}ms); shutting down`,
+    );
+    void Promise.resolve(options.requestShutdown()).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      options.logIdleMessage?.(`MCP idle shutdown request failed: ${message}`);
+    });
+  };
+
+  return {
+    start(): void {
+      if (timeoutMs <= 0 || timer) {
+        return;
+      }
+
+      lastRequestCompletedAtMs = nowMs();
+      timer = setInterval(checkIdle, intervalMs);
+      timer.unref?.();
+    },
+
+    stop(): void {
+      if (!timer) {
+        return;
+      }
+      clearInterval(timer);
+      timer = null;
+    },
+
+    markRequestStarted(): void {
+      inFlightRequestCount += 1;
+    },
+
+    markRequestCompleted(): void {
+      inFlightRequestCount = Math.max(0, inFlightRequestCount - 1);
+      lastRequestCompletedAtMs = nowMs();
+    },
+
+    getInFlightRequestCount(): number {
+      return inFlightRequestCount;
+    },
+  };
+}

--- a/src/server/mcp-lifecycle.ts
+++ b/src/server/mcp-lifecycle.ts
@@ -31,6 +31,7 @@ export type McpShutdownReason =
   | 'sigint'
   | 'sigterm'
   | 'startup-failure'
+  | 'idle-timeout'
   | 'uncaught-exception'
   | 'unhandled-rejection';
 

--- a/src/server/request-lifecycle.ts
+++ b/src/server/request-lifecycle.ts
@@ -47,12 +47,25 @@ export function instrumentMcpRequestLifecycle(
     onMessageWrapped = true;
     const downstreamOnMessage = transport.onmessage;
     transport.onmessage = (message, extra) => {
+      let startedRequestId: string | null = null;
+
       if (isJSONRPCRequest(message)) {
-        pendingRequestIds.add(requestIdKey(message.id));
-        observer.onRequestStarted?.();
+        const requestId = requestIdKey(message.id);
+        if (!pendingRequestIds.has(requestId)) {
+          pendingRequestIds.add(requestId);
+          startedRequestId = requestId;
+          observer.onRequestStarted?.();
+        }
       }
 
-      downstreamOnMessage(message, extra);
+      try {
+        downstreamOnMessage(message, extra);
+      } catch (error) {
+        if (startedRequestId !== null && pendingRequestIds.delete(startedRequestId)) {
+          observer.onRequestCompleted?.();
+        }
+        throw error;
+      }
     };
   };
 

--- a/src/server/request-lifecycle.ts
+++ b/src/server/request-lifecycle.ts
@@ -1,0 +1,80 @@
+import type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  isJSONRPCErrorResponse,
+  isJSONRPCRequest,
+  isJSONRPCResultResponse,
+  type JSONRPCMessage,
+} from '@modelcontextprotocol/sdk/types.js';
+
+export interface McpRequestLifecycleObserver {
+  onRequestStarted?: () => void;
+  onRequestCompleted?: () => void;
+}
+
+function requestIdKey(id: string | number): string {
+  return String(id);
+}
+
+function completedRequestIdKey(message: JSONRPCMessage): string | null {
+  if (isJSONRPCResultResponse(message)) {
+    return requestIdKey(message.id);
+  }
+
+  if (isJSONRPCErrorResponse(message) && message.id !== undefined) {
+    return requestIdKey(message.id);
+  }
+
+  return null;
+}
+
+export function instrumentMcpRequestLifecycle(
+  transport: Transport,
+  observer: McpRequestLifecycleObserver,
+): void {
+  const pendingRequestIds = new Set<string>();
+  const originalStart = transport.start.bind(transport);
+  const originalSend = transport.send.bind(transport);
+  let onMessageWrapped = false;
+
+  const wrapOnMessage = (): void => {
+    if (onMessageWrapped || !transport.onmessage) {
+      return;
+    }
+
+    onMessageWrapped = true;
+    const downstreamOnMessage = transport.onmessage;
+    transport.onmessage = (message, extra) => {
+      if (isJSONRPCRequest(message)) {
+        pendingRequestIds.add(requestIdKey(message.id));
+        observer.onRequestStarted?.();
+      }
+
+      downstreamOnMessage(message, extra);
+    };
+  };
+
+  transport.start = async (): Promise<void> => {
+    wrapOnMessage();
+    await originalStart();
+  };
+
+  transport.send = async (
+    message: JSONRPCMessage,
+    options?: TransportSendOptions,
+  ): Promise<void> => {
+    const completedRequestId = completedRequestIdKey(message);
+    const completesPendingRequest =
+      completedRequestId !== null && pendingRequestIds.delete(completedRequestId);
+
+    try {
+      await originalSend(message, options);
+    } finally {
+      if (completesPendingRequest) {
+        observer.onRequestCompleted?.();
+      }
+    }
+  };
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,6 +17,10 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import * as Sentry from '@sentry/node';
 import { log } from '../utils/logger.ts';
 import { version } from '../version.ts';
+import {
+  instrumentMcpRequestLifecycle,
+  type McpRequestLifecycleObserver,
+} from './request-lifecycle.ts';
 import { getServer, setServer } from './server-state.ts';
 
 function createBaseServerInstance(): McpServer {
@@ -85,12 +89,22 @@ export function createServer(): McpServer {
   return server;
 }
 
+export interface StartServerOptions {
+  requestLifecycle?: McpRequestLifecycleObserver;
+}
+
 /**
  * Start the MCP server with stdio transport
  * @param server The MCP server instance to start
  */
-export async function startServer(server: McpServer): Promise<void> {
+export async function startServer(
+  server: McpServer,
+  options: StartServerOptions = {},
+): Promise<void> {
   const transport = new StdioServerTransport();
+  if (options.requestLifecycle) {
+    instrumentMcpRequestLifecycle(transport, options.requestLifecycle);
+  }
   await server.connect(transport);
   log('info', 'XcodeBuildMCP Server running on stdio');
 }

--- a/src/server/start-mcp-server.ts
+++ b/src/server/start-mcp-server.ts
@@ -24,6 +24,12 @@ import { getConfig } from '../utils/config-store.ts';
 import { getRegisteredWorkflows } from '../utils/tool-registry.ts';
 import { hydrateSentryDisabledEnvFromProjectConfig } from '../utils/sentry-config.ts';
 import { createMcpLifecycleCoordinator, isTransportDisconnectReason } from './mcp-lifecycle.ts';
+import {
+  createMcpIdleShutdownController,
+  resolveMcpIdleCheckIntervalMs,
+  resolveMcpIdleTimeoutConfig,
+  type McpIdleShutdownController,
+} from './mcp-idle-shutdown.ts';
 import { runMcpShutdown } from './mcp-shutdown.ts';
 
 /**
@@ -32,8 +38,12 @@ import { runMcpShutdown } from './mcp-shutdown.ts';
  * sets up signal handlers for graceful shutdown, and starts the server.
  */
 export async function startMcpServer(): Promise<void> {
+  let idleShutdown: McpIdleShutdownController | null = null;
+
   const lifecycle = createMcpLifecycleCoordinator({
     onShutdown: async ({ reason, error, snapshot, server }) => {
+      idleShutdown?.stop();
+
       const isCrash = reason === 'uncaught-exception' || reason === 'unhandled-rejection';
       const event = isCrash ? 'crash' : 'shutdown';
 
@@ -42,6 +52,7 @@ export async function startMcpServer(): Promise<void> {
         'stdin-close': 'MCP stdin closed; shutting down MCP server',
         'stdout-error': 'MCP stdout pipe broke; shutting down MCP server',
         'stderr-error': 'MCP stderr pipe broke; shutting down MCP server',
+        'idle-timeout': 'MCP idle timeout reached; shutting down MCP server',
       };
       log('info', transportMessages[reason] ?? `MCP shutdown requested: ${reason}`);
 
@@ -106,9 +117,41 @@ export async function startMcpServer(): Promise<void> {
     const bootstrap = await bootstrapServer(server);
     profiler.mark('bootstrapServer', stageStartMs);
 
+    const idleTimeoutConfig = resolveMcpIdleTimeoutConfig();
+    if (idleTimeoutConfig.invalid && idleTimeoutConfig.rawValue) {
+      log(
+        'warn',
+        `Invalid XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS=${idleTimeoutConfig.rawValue}; using default ${idleTimeoutConfig.timeoutMs}ms`,
+      );
+    }
+
+    const idleCheckIntervalMs = resolveMcpIdleCheckIntervalMs(idleTimeoutConfig.timeoutMs);
+
+    if (idleTimeoutConfig.timeoutMs === 0) {
+      log('info', 'MCP idle shutdown disabled');
+    } else {
+      log(
+        'info',
+        `MCP idle shutdown enabled: timeout=${idleTimeoutConfig.timeoutMs}ms interval=${idleCheckIntervalMs}ms`,
+      );
+    }
+
+    idleShutdown = createMcpIdleShutdownController({
+      timeoutMs: idleTimeoutConfig.timeoutMs,
+      intervalMs: idleCheckIntervalMs,
+      requestShutdown: () => lifecycle.shutdown('idle-timeout'),
+      isShutdownRequested: () => lifecycle.isShutdownRequested(),
+      logIdleMessage: (message) => log('info', message),
+    });
+
     stageStartMs = getStartupProfileNowMs();
     lifecycle.markPhase('starting-stdio-transport');
-    await startServer(server);
+    await startServer(server, {
+      requestLifecycle: {
+        onRequestStarted: () => idleShutdown?.markRequestStarted(),
+        onRequestCompleted: () => idleShutdown?.markRequestCompleted(),
+      },
+    });
     profiler.mark('startServer', stageStartMs);
 
     const config = getConfig();
@@ -125,6 +168,7 @@ export async function startMcpServer(): Promise<void> {
     });
 
     lifecycle.markPhase('running');
+    idleShutdown.start();
     const startupSnapshot = await lifecycle.getSnapshot();
     log('info', `[mcp-lifecycle] start ${JSON.stringify(startupSnapshot)}`);
     recordMcpLifecycleMetric({

--- a/src/smoke-tests/__tests__/e2e-mcp-idle-timeout.test.ts
+++ b/src/smoke-tests/__tests__/e2e-mcp-idle-timeout.test.ts
@@ -5,8 +5,6 @@ import type { Readable } from 'node:stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { afterEach, describe, expect, it } from 'vitest';
-import { getSnapshotHarnessEnv } from '../harness.ts';
-
 const CLI_PATH = join(process.cwd(), 'build/cli.js');
 const MCP_IDLE_TIMEOUT_MS = 1_000;
 const MCP_CONNECT_TIMEOUT_MS = 10_000;
@@ -17,6 +15,14 @@ type ChildExit = {
   code: number | null;
   signal: NodeJS.Signals | null;
 };
+
+function getSmokeTestEnv(overrides: Record<string, string> = {}): Record<string, string> {
+  const { VITEST: _vitest, NODE_ENV: _nodeEnv, ...rest } = process.env;
+  const env = Object.fromEntries(
+    Object.entries(rest).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  return { ...env, ...overrides };
+}
 
 let activeClient: Client | null = null;
 let activeChild: ChildProcess | null = null;
@@ -108,7 +114,7 @@ describe('MCP server idle timeout e2e', () => {
         command: 'node',
         args: [CLI_PATH, 'mcp'],
         cwd: process.cwd(),
-        env: getSnapshotHarnessEnv({
+        env: getSmokeTestEnv({
           SENTRY_DISABLED: 'true',
           XCODEBUILDMCP_ENABLED_WORKFLOWS: 'simulator',
           XCODEBUILDMCP_DISABLE_SESSION_DEFAULTS: 'true',

--- a/src/smoke-tests/__tests__/e2e-mcp-idle-timeout.test.ts
+++ b/src/smoke-tests/__tests__/e2e-mcp-idle-timeout.test.ts
@@ -7,6 +7,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { afterEach, describe, expect, it } from 'vitest';
 const CLI_PATH = join(process.cwd(), 'build/cli.js');
 const MCP_IDLE_TIMEOUT_MS = 1_000;
+const MCP_BASELINE_WAIT_MS = 2_000;
 const MCP_CONNECT_TIMEOUT_MS = 10_000;
 const MCP_EXIT_WAIT_MS = 8_000;
 const MCP_TEST_TIMEOUT_MS = 30_000;
@@ -81,6 +82,31 @@ function waitForExit(
   });
 }
 
+function waitForUnexpectedExit(child: ChildProcess, timeoutMs: number): Promise<ChildExit | null> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.removeListener('close', onClose);
+    };
+
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
+      resolve({ code, signal });
+    };
+
+    child.once('close', onClose);
+  });
+}
+
 async function cleanupActiveProcess(): Promise<void> {
   const client = activeClient;
   const child = activeChild;
@@ -101,6 +127,58 @@ afterEach(async () => {
 });
 
 describe('MCP server idle timeout e2e', () => {
+  it(
+    'stays running when the idle timeout is not configured',
+    async () => {
+      if (!existsSync(CLI_PATH)) {
+        throw new Error(
+          'MCP idle timeout e2e test requires build/cli.js. Run npm run build first.',
+        );
+      }
+
+      const transport = new StdioClientTransport({
+        command: 'node',
+        args: [CLI_PATH, 'mcp'],
+        cwd: process.cwd(),
+        env: getSmokeTestEnv({
+          SENTRY_DISABLED: 'true',
+          XCODEBUILDMCP_ENABLED_WORKFLOWS: 'simulator',
+          XCODEBUILDMCP_DISABLE_SESSION_DEFAULTS: 'true',
+          XCODEBUILDMCP_DISABLE_XCODE_AUTO_SYNC: '1',
+        }),
+        stderr: 'pipe',
+      });
+      const getStderr = collectOutput(transport.stderr as Readable | null);
+      const client = new Client({ name: 'mcp-idle-timeout-baseline-client', version: '1.0.0' });
+
+      activeClient = client;
+      try {
+        await client.connect(transport, { timeout: MCP_CONNECT_TIMEOUT_MS });
+      } catch (error) {
+        activeChild = getTransportChildIfSpawned(transport);
+        throw error;
+      }
+      const child = getTransportChild(transport);
+      activeChild = child;
+
+      const tools = await client.listTools(undefined, { timeout: 10_000 });
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      const unexpectedExit = await waitForUnexpectedExit(child, MCP_BASELINE_WAIT_MS);
+      expect(unexpectedExit).toBeNull();
+      expect(child.exitCode).toBeNull();
+      expect(child.signalCode).toBeNull();
+      expect(getStderr()).toContain('MCP idle shutdown disabled');
+
+      await client.close();
+      activeClient = null;
+      const exit = await waitForExit(child, 2_000, getStderr);
+      activeChild = null;
+      expect(exit).toEqual({ code: 0, signal: null });
+    },
+    MCP_TEST_TIMEOUT_MS,
+  );
+
   it(
     'exits gracefully after the opt-in idle timeout',
     async () => {

--- a/src/snapshot-tests/__tests__/mcp-idle-timeout.e2e.test.ts
+++ b/src/snapshot-tests/__tests__/mcp-idle-timeout.e2e.test.ts
@@ -1,0 +1,145 @@
+import type { ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Readable } from 'node:stream';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getSnapshotHarnessEnv } from '../harness.ts';
+
+const CLI_PATH = join(process.cwd(), 'build/cli.js');
+const MCP_IDLE_TIMEOUT_MS = 1_000;
+const MCP_CONNECT_TIMEOUT_MS = 10_000;
+const MCP_EXIT_WAIT_MS = 8_000;
+const MCP_TEST_TIMEOUT_MS = 30_000;
+
+type ChildExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+let activeClient: Client | null = null;
+let activeChild: ChildProcess | null = null;
+
+function collectOutput(stream: Readable | null): () => string {
+  let output = '';
+  stream?.setEncoding('utf8');
+  stream?.on('data', (chunk: string | Buffer) => {
+    output += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+  });
+  return () => output;
+}
+
+function getTransportChildIfSpawned(transport: StdioClientTransport): ChildProcess | null {
+  return (transport as unknown as { _process?: ChildProcess })._process ?? null;
+}
+
+function getTransportChild(transport: StdioClientTransport): ChildProcess {
+  const child = getTransportChildIfSpawned(transport);
+  if (!child) {
+    throw new Error('MCP stdio transport did not expose a spawned child process.');
+  }
+  return child;
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+  getDiagnostics: () => string,
+): Promise<ChildExit> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `MCP server process did not exit within ${timeoutMs}ms. stderr:\n${getDiagnostics()}`,
+        ),
+      );
+    }, timeoutMs);
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.removeListener('close', onClose);
+    };
+
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
+      resolve({ code, signal });
+    };
+
+    child.once('close', onClose);
+  });
+}
+
+async function cleanupActiveProcess(): Promise<void> {
+  const client = activeClient;
+  const child = activeChild;
+  activeClient = null;
+  activeChild = null;
+
+  if (child && child.exitCode === null && child.signalCode === null) {
+    await client?.close().catch(() => undefined);
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM');
+      await waitForExit(child, 2_000, () => '').catch(() => undefined);
+    }
+  }
+}
+
+afterEach(async () => {
+  await cleanupActiveProcess();
+});
+
+describe('MCP server idle timeout e2e', () => {
+  it(
+    'exits gracefully after the opt-in idle timeout',
+    async () => {
+      if (!existsSync(CLI_PATH)) {
+        throw new Error(
+          'MCP idle timeout e2e test requires build/cli.js. Run npm run build first.',
+        );
+      }
+
+      const transport = new StdioClientTransport({
+        command: 'node',
+        args: [CLI_PATH, 'mcp'],
+        cwd: process.cwd(),
+        env: getSnapshotHarnessEnv({
+          SENTRY_DISABLED: 'true',
+          XCODEBUILDMCP_ENABLED_WORKFLOWS: 'simulator',
+          XCODEBUILDMCP_DISABLE_SESSION_DEFAULTS: 'true',
+          XCODEBUILDMCP_DISABLE_XCODE_AUTO_SYNC: '1',
+          XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS: String(MCP_IDLE_TIMEOUT_MS),
+        }),
+        stderr: 'pipe',
+      });
+      const getStderr = collectOutput(transport.stderr as Readable | null);
+      const client = new Client({ name: 'mcp-idle-timeout-e2e-client', version: '1.0.0' });
+
+      activeClient = client;
+      try {
+        await client.connect(transport, { timeout: MCP_CONNECT_TIMEOUT_MS });
+      } catch (error) {
+        activeChild = getTransportChildIfSpawned(transport);
+        throw error;
+      }
+      const child = getTransportChild(transport);
+      activeChild = child;
+
+      const tools = await client.listTools(undefined, { timeout: 10_000 });
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      const exit = await waitForExit(child, MCP_EXIT_WAIT_MS, getStderr);
+      activeClient = null;
+      activeChild = null;
+
+      expect(exit).toEqual({ code: 0, signal: null });
+      expect(getStderr()).toContain('MCP idle timeout reached');
+    },
+    MCP_TEST_TIMEOUT_MS,
+  );
+});

--- a/src/utils/idle-timeout.ts
+++ b/src/utils/idle-timeout.ts
@@ -1,0 +1,37 @@
+export const DEFAULT_IDLE_CHECK_INTERVAL_MS = 30 * 1000;
+
+export interface IdleTimeoutParseResult {
+  timeoutMs: number;
+  rawValue: string | null;
+  invalid: boolean;
+}
+
+export function parseIdleTimeoutEnv(options: {
+  env: NodeJS.ProcessEnv;
+  envKey: string;
+  defaultTimeoutMs: number;
+}): IdleTimeoutParseResult {
+  const rawValue = options.env[options.envKey]?.trim() ?? null;
+  if (!rawValue) {
+    return {
+      timeoutMs: options.defaultTimeoutMs,
+      rawValue: null,
+      invalid: false,
+    };
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return {
+      timeoutMs: options.defaultTimeoutMs,
+      rawValue,
+      invalid: true,
+    };
+  }
+
+  return {
+    timeoutMs: Math.floor(parsed),
+    rawValue,
+    invalid: false,
+  };
+}


### PR DESCRIPTION
Add an opt-in MCP server idle shutdown path controlled by `XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS`.

MCP mode previously stayed alive until the client disconnected or the process was otherwise terminated. This adds a default-disabled idle timeout that exits through the existing graceful lifecycle shutdown path once the configured idle period has elapsed, no MCP request is in flight, and no registered runtime operation is active.

The implementation tracks JSON-RPC request lifecycles at the stdio transport boundary so regular MCP requests, not just tool handlers, keep the server alive. It also adds unit coverage for parsing, timer behavior, lifecycle request tracking, and a process-level MCP e2e test that starts the built CLI and asserts the server exits cleanly after the configured timeout.

Fixes #394
