### PR TITLE
feat(testing): Add default xcresult bundles for test tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added workspace-scoped default xcresult bundles for simulator, device, and macOS test tools so test artifacts are available in structured and text output even when callers do not pass `-resultBundlePath`.
 - Added opt-in MCP server idle shutdown via `XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS`, allowing unused MCP server processes to gracefully exit after a configured idle period ([#394](https://github.com/getsentry/XcodeBuildMCP/issues/394)).
 
 ### Fixed

--- a/src/mcp/tools/device/__tests__/test_device.test.ts
+++ b/src/mcp/tools/device/__tests__/test_device.test.ts
@@ -167,6 +167,8 @@ describe('test_device plugin', () => {
         'never',
         '-derivedDataPath',
         computeScopedDerivedDataPath('/path/to/project.xcodeproj'),
+        '-resultBundlePath',
+        expect.stringContaining('/result-bundles/test_device_'),
         'test',
       ]);
     });

--- a/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
@@ -19,4 +19,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
@@ -51,4 +51,5 @@ IntentionalFailureTests
         example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
@@ -14,5 +14,6 @@ Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 Running tests (1 completed, 0 failures, 0 skipped)
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
@@ -20,4 +20,5 @@ Compiler Errors (1):
     example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
@@ -12,4 +12,5 @@ Errors (1):
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
@@ -28,4 +28,5 @@ MCPTestTests
         example_projects/macOS/MCPTestTests/MCPTestTests.swift:11
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
@@ -16,5 +16,6 @@ Discovered 2 test(s):
 Running tests (1 completed, 0 failures, 0 skipped)
 Running tests (2 completed, 0 failures, 0 skipped)
 
-✅ 2 tests passed, 0 skipped (⏱️ <DURATION>)
+✅ 2 tests passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
@@ -36,4 +36,5 @@ IntentionalFailureTests
         example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
@@ -14,5 +14,6 @@ Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 Running tests (1 completed, 0 failures, 0 skipped)
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/test--success.txt
@@ -8,5 +8,5 @@
 Running tests (0 completed, 0 failures, 0 skipped)
 Running tests (1 completed, 0 failures, 0 skipped)
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
@@ -20,11 +20,17 @@
     "summary": {
       "status": "FAILED",
       "durationMs": 1234,
+      "counts": {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0
+      },
       "target": "device"
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/device/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--failure.json
@@ -27,7 +27,8 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/device/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--success.json
@@ -29,7 +29,8 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
@@ -19,10 +19,16 @@
     "summary": {
       "status": "FAILED",
       "durationMs": 1234,
+      "counts": {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0
+      },
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
@@ -16,10 +16,16 @@
     "summary": {
       "status": "FAILED",
       "durationMs": 1234,
+      "counts": {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0
+      },
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
@@ -24,7 +24,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/macos/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--success.json
@@ -27,7 +27,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
@@ -25,7 +25,8 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
@@ -27,7 +27,8 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
@@ -19,4 +19,5 @@ Errors (1):
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
@@ -26,4 +26,5 @@ Test Failures (2):
     <ROOT>/example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
@@ -13,5 +13,6 @@
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
@@ -20,4 +20,5 @@ Errors (1):
     <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
@@ -12,4 +12,5 @@ Errors (1):
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Test failed. (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
@@ -22,4 +22,5 @@ Test Failures (2):
     MCPTestTests.swift:11
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
@@ -14,5 +14,6 @@ Discovered 2 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
    MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
 
-✅ 2 tests passed, 0 skipped (⏱️ <DURATION>)
+✅ 2 tests passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
@@ -31,4 +31,5 @@ Test Failures (3):
     <ROOT>/example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
@@ -13,5 +13,6 @@
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
+  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/test--success.txt
@@ -6,5 +6,5 @@
    Platform: Swift Package
    Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
 
-✅ 1 test passed, 0 skipped (⏱️ <DURATION>)
+✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
   └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/normalize.ts
+++ b/src/snapshot-tests/normalize.ts
@@ -10,6 +10,7 @@ const UUID_REGEX = /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-
 const DURATION_REGEX = /\d+\.\d+s\b/g;
 const PID_NUMBER_REGEX = /(pid:\s*)\d+/gi;
 const PID_FILENAME_SUFFIX_REGEX = /_pid\d+(?:_[0-9a-f]{8})?\.log/g;
+const XCRESULT_FILENAME_PID_SUFFIX_REGEX = /_pid\d+_[0-9a-f]{8}\.xcresult/g;
 const HELPER_PID_FILENAME_SUFFIX_REGEX =
   /_(?:helperpid\d+_ownerpid\d+|ownerpid\d+)_[0-9a-f]{8}\.log/g;
 const PID_JSON_REGEX = /"pid"\s*:\s*\d+/g;
@@ -129,7 +130,7 @@ export function normalizeSnapshotOutput(text: string): string {
     '<TMPDIR>',
   );
   normalized = normalized.replace(
-    /(<HOME>\/Library\/Developer\/XcodeBuildMCP\/workspaces\/[^/]+)-[0-9a-f]{12}(?=\/logs\/)/g,
+    /(<HOME>\/Library\/Developer\/XcodeBuildMCP\/workspaces\/[^/]+)-[0-9a-f]{12}(?=\/(?:logs|result-bundles)\/)/g,
     '$1-<HASH>',
   );
   normalized = normalized.replace(
@@ -160,6 +161,7 @@ export function normalizeSnapshotOutput(text: string): string {
   normalized = normalized.replace(PID_NUMBER_REGEX, '$1<PID>');
   normalized = normalized.replace(HELPER_PID_FILENAME_SUFFIX_REGEX, '_pid<PID>.log');
   normalized = normalized.replace(PID_FILENAME_SUFFIX_REGEX, '_pid<PID>.log');
+  normalized = normalized.replace(XCRESULT_FILENAME_PID_SUFFIX_REGEX, '_pid<PID>.xcresult');
   normalized = normalized.replace(PID_JSON_REGEX, '"pid" : <PID>');
   normalized = normalized.replace(PROCESS_ID_REGEX, 'Process ID: <PID>');
   normalized = normalized.replace(PROCESS_INLINE_PID_REGEX, 'process <PID>');

--- a/src/utils/__tests__/log-paths.test.ts
+++ b/src/utils/__tests__/log-paths.test.ts
@@ -25,6 +25,7 @@ describe('log paths', () => {
       state: path.join(appDir, 'workspaces', 'workspace-a', 'state'),
       locks: path.join(appDir, 'workspaces', 'workspace-a', 'locks'),
       derivedData: path.join(appDir, 'workspaces', 'workspace-a', 'DerivedData'),
+      resultBundles: path.join(appDir, 'workspaces', 'workspace-a', 'result-bundles'),
       logRetention: {
         lockDir: path.join(appDir, 'workspaces', 'workspace-a', 'locks', 'log-retention.lock'),
         markerPath: path.join(

--- a/src/utils/__tests__/simulator-test-execution.test.ts
+++ b/src/utils/__tests__/simulator-test-execution.test.ts
@@ -84,7 +84,7 @@ describe('createSimulatorTwoPhaseExecutionPlan', () => {
     expect(plan.usesExactSelectors).toBe(true);
   });
 
-  it('keeps resultBundlePath out of build-for-testing args and includes it for test-without-building', () => {
+  it('includes resultBundlePath only in the simulator test execution phase', () => {
     const plan = createSimulatorTwoPhaseExecutionPlan({
       extraArgs: ['-resultBundlePath', '/tmp/UserProvided.xcresult'],
     });

--- a/src/utils/__tests__/snapshot-normalize.test.ts
+++ b/src/utils/__tests__/snapshot-normalize.test.ts
@@ -60,6 +60,19 @@ describe('normalizeSnapshotOutput tilde handling', () => {
     );
   });
 
+  it('normalizes workspace-scoped result bundle paths', () => {
+    const input =
+      'Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-abc123def456/result-bundles/test_macos_2026-05-07T09-58-46-123Z_pid1234_abcd1234.xcresult\n';
+
+    const result = normalizeSnapshotOutput(input);
+
+    expect(result).toContain(
+      '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult',
+    );
+    expect(result).not.toContain('Weather-abc123def456');
+    expect(result).not.toContain('abcd1234');
+  });
+
   it('normalizes workspace-scoped XcodeBuildMCP DerivedData hashes', () => {
     const input =
       'Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-abc123def456/DerivedData/CalculatorApp-22d700c6d603\n';

--- a/src/utils/__tests__/test-common.test.ts
+++ b/src/utils/__tests__/test-common.test.ts
@@ -1,11 +1,19 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createTestExecutor, resolveTestProgressEnabled } from '../test-common.ts';
 import type { CommandExecutor, CommandResponse } from '../command.ts';
 import { DefaultStreamingExecutionContext } from '../execution/index.ts';
 import type { AnyFragment } from '../../types/domain-fragments.ts';
 import type { TestPreflightResult } from '../test-preflight.ts';
 import { XcodePlatform } from '../xcode.ts';
+import {
+  getWorkspaceFilesystemLayout,
+  setXcodeBuildMCPAppDirOverrideForTests,
+} from '../log-paths.ts';
+import { setRuntimeInstanceForTests } from '../runtime-instance.ts';
 
 function createSuccessfulCommandResponse(): CommandResponse {
   return {
@@ -94,6 +102,36 @@ describe('resolveTestProgressEnabled', () => {
 });
 
 describe('createTestExecutor', () => {
+  let tempAppDir: string;
+
+  beforeEach(() => {
+    tempAppDir = mkdtempSync(join(tmpdir(), 'xcodebuildmcp-result-bundles-'));
+    setXcodeBuildMCPAppDirOverrideForTests(tempAppDir);
+    setRuntimeInstanceForTests({
+      instanceId: 'result-bundle-test',
+      pid: process.pid,
+      workspaceKey: 'workspace-a',
+    });
+  });
+
+  afterEach(() => {
+    setXcodeBuildMCPAppDirOverrideForTests(null);
+    setRuntimeInstanceForTests(null);
+    rmSync(tempAppDir, { recursive: true, force: true });
+  });
+
+  function expectDefaultResultBundlePath(command: readonly string[], toolName: string): string {
+    const resultBundleArgIndex = command.indexOf('-resultBundlePath');
+    expect(resultBundleArgIndex).toBeGreaterThan(-1);
+    const resultBundlePath = command[resultBundleArgIndex + 1];
+    expect(resultBundlePath).toEqual(
+      expect.stringContaining(getWorkspaceFilesystemLayout('workspace-a').resultBundles),
+    );
+    expect(resultBundlePath).toEqual(expect.stringContaining(`${toolName}_`));
+    expect(resultBundlePath).toEqual(expect.stringMatching(/\.xcresult$/u));
+    return resultBundlePath!;
+  }
+
   it('emits RUN_TESTS before test-without-building starts in two-phase simulator execution', async () => {
     const emitted: AnyFragment[] = [];
     const actions: string[] = [];
@@ -147,5 +185,229 @@ describe('createTestExecutor', () => {
 
     expect(runTestsIndex).toBeGreaterThan(-1);
     expect(finalSummaryIndex).toBeGreaterThan(runTestsIndex);
+  });
+
+  it('injects a workspace-scoped default result bundle path for macOS test commands', async () => {
+    const commands: string[][] = [];
+    const executor: CommandExecutor = async (command) => {
+      commands.push(command);
+      return createSuccessfulCommandResponse();
+    };
+
+    const executeTest = createTestExecutor(executor, {
+      toolName: 'test_macos',
+      target: 'macos',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(commands).toHaveLength(1);
+    const resultBundlePath = expectDefaultResultBundlePath(commands[0]!, 'test_macos');
+    expect(commands[0]!.at(-1)).toBe('test');
+    expect(result.artifacts.xcresultPath).toBe(resultBundlePath);
+  });
+
+  it('returns a structured test-result when default result bundle path resolution fails', async () => {
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    mkdirSync(layout.root, { recursive: true });
+    writeFileSync(layout.resultBundles, 'not a directory');
+    const executor = vi.fn<CommandExecutor>();
+
+    const executeTest = createTestExecutor(executor, {
+      toolName: 'test_macos',
+      target: 'macos',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(executor).not.toHaveBeenCalled();
+    expect(result.kind).toBe('test-result');
+    expect(result.didError).toBe(true);
+    expect(result.summary.status).toBe('FAILED');
+    expect(result.diagnostics.rawOutput?.join('\n')).toContain(
+      'Unable to create writable result bundle directory',
+    );
+  });
+
+  it('injects a workspace-scoped default result bundle path for device test commands', async () => {
+    const commands: string[][] = [];
+    const executor: CommandExecutor = async (command) => {
+      commands.push(command);
+      return createSuccessfulCommandResponse();
+    };
+
+    const executeTest = createTestExecutor(executor, {
+      toolName: 'test_device',
+      target: 'device',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.iOS,
+        deviceId: 'DEVICE-123',
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        platform: XcodePlatform.iOS,
+        deviceId: 'DEVICE-123',
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(commands).toHaveLength(1);
+    const resultBundlePath = expectDefaultResultBundlePath(commands[0]!, 'test_device');
+    expect(commands[0]!.at(-1)).toBe('test');
+    expect(result.artifacts.xcresultPath).toBe(resultBundlePath);
+  });
+
+  it('does not surface a result bundle when simulator build-for-testing fails before tests run', async () => {
+    const commands: string[][] = [];
+    const executor: CommandExecutor = async (command, _logPrefix, _useShell, opts) => {
+      commands.push(command);
+      opts?.onStderr?.(
+        'Writing error result bundle to /var/folders/test/ResultBundle_2026-05-07_09-38-0016.xcresult\n',
+      );
+      return {
+        success: false,
+        output: '',
+        process: { pid: 12345 } as ChildProcess,
+        exitCode: 65,
+      };
+    };
+
+    const executeTest = createTestExecutor(executor, {
+      preflight: createPreflight(),
+      toolName: 'test_sim',
+      target: 'simulator',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.iOSSimulator,
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        simulatorId: 'A2C64636-37E9-4B68-B872-E7F0A82A5670',
+        platform: XcodePlatform.iOSSimulator,
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).not.toContain('-resultBundlePath');
+    expect(result.artifacts.xcresultPath).toBeUndefined();
+  });
+
+  it('injects the default result bundle only into the simulator test execution phase', async () => {
+    const commands: string[][] = [];
+    const executor: CommandExecutor = async (command) => {
+      commands.push(command);
+      return createSuccessfulCommandResponse();
+    };
+
+    const executeTest = createTestExecutor(executor, {
+      preflight: createPreflight(),
+      toolName: 'test_sim',
+      target: 'simulator',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.iOSSimulator,
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        simulatorId: 'A2C64636-37E9-4B68-B872-E7F0A82A5670',
+        platform: XcodePlatform.iOSSimulator,
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).not.toContain('-resultBundlePath');
+    expect(commands[0]!.at(-1)).toBe('build-for-testing');
+    const testResultBundlePath = expectDefaultResultBundlePath(commands[1]!, 'test_sim');
+    expect(commands[1]!.at(-1)).toBe('test-without-building');
+    expect(result.artifacts.xcresultPath).toBe(testResultBundlePath);
+  });
+
+  it('preserves a user-supplied result bundle path instead of injecting a default', async () => {
+    const commands: string[][] = [];
+    const executor: CommandExecutor = async (command) => {
+      commands.push(command);
+      return createSuccessfulCommandResponse();
+    };
+
+    const executeTest = createTestExecutor(executor, {
+      toolName: 'test_macos',
+      target: 'macos',
+      request: {
+        scheme: 'Weather',
+        projectPath: 'Weather.xcodeproj',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+      },
+    });
+
+    const result = await executeTest(
+      {
+        projectPath: 'Weather.xcodeproj',
+        scheme: 'Weather',
+        configuration: 'Debug',
+        platform: XcodePlatform.macOS,
+        extraArgs: ['-quiet', '-resultBundlePath=/tmp/User Provided.xcresult'],
+      },
+      new DefaultStreamingExecutionContext(),
+    );
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain('-quiet');
+    expect(commands[0]).toContain('-resultBundlePath');
+    expect(commands[0]).toContain('/tmp/User Provided.xcresult');
+    expect(commands[0]).not.toContain(getWorkspaceFilesystemLayout('workspace-a').resultBundles);
+    expect(result.artifacts.xcresultPath).toBe('/tmp/User Provided.xcresult');
   });
 });

--- a/src/utils/__tests__/workspace-filesystem-lifecycle.test.ts
+++ b/src/utils/__tests__/workspace-filesystem-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   getWorkspaceFilesystemLayout,
   setXcodeBuildMCPAppDirOverrideForTests,
 } from '../log-paths.ts';
+import { getResultBundleCompletionMarkerPath } from '../result-bundle-path.ts';
 import { writeDaemonRegistryEntry } from '../../daemon/daemon-registry.ts';
 import { setRuntimeInstanceForTests } from '../runtime-instance.ts';
 import {
@@ -34,6 +35,17 @@ function writeFileWithMtime(filePath: string, content: string, mtimeMs: number):
 
 function managedXcodebuildLogName(name = 'build_sim'): string {
   return `${name}_2026-05-02T12-00-00-000Z_pid123_abcdef12.log`;
+}
+
+function managedResultBundleName(name = 'test', pid = 123): string {
+  return `${name}_2026-05-02T12-00-00-000Z_pid${pid}_abcdef12.xcresult`;
+}
+
+function writeResultBundleWithMtime(bundlePath: string, mtimeMs: number): void {
+  mkdirSync(bundlePath, { recursive: true });
+  writeFileSync(path.join(bundlePath, 'Info.plist'), 'stub');
+  const mtime = new Date(mtimeMs);
+  utimesSync(bundlePath, mtime, mtime);
 }
 
 function createTrackedChild(pid: number, onKill: () => void): ChildProcess {
@@ -249,6 +261,97 @@ describe('workspace filesystem lifecycle', () => {
     expect(result).toMatchObject({ scanned: 1, deleted: 1 });
     expect(existsSync(unknownLog)).toBe(true);
     expect(existsSync(knownLog)).toBe(false);
+  });
+
+  it('prunes only managed result bundles from workspace result-bundles', async () => {
+    const now = Date.UTC(2026, 4, 2, 12);
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const managedBundle = path.join(layout.resultBundles, managedResultBundleName('test'));
+    const unknownBundle = path.join(layout.resultBundles, 'manual-user-bundle.xcresult');
+    writeResultBundleWithMtime(managedBundle, now - 4 * 24 * 60 * 60 * 1000);
+    writeResultBundleWithMtime(unknownBundle, now - 4 * 24 * 60 * 60 * 1000);
+
+    const result = await runWorkspaceFilesystemLifecycleSweep({
+      workspaceKey: 'workspace-a',
+      trigger: 'manual',
+      now,
+      force: true,
+      minVisibleMs: 0,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, deleted: 1 });
+    expect(existsSync(managedBundle)).toBe(false);
+    expect(existsSync(unknownBundle)).toBe(true);
+  });
+
+  it('applies maxFiles overflow pruning to managed result bundles', async () => {
+    const now = Date.UTC(2026, 4, 2, 12);
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const oldBundle = path.join(layout.resultBundles, managedResultBundleName('test_old'));
+    const newBundle = path.join(layout.resultBundles, managedResultBundleName('test_new'));
+    writeResultBundleWithMtime(oldBundle, now - 2 * 24 * 60 * 60 * 1000);
+    writeResultBundleWithMtime(newBundle, now - 1 * 24 * 60 * 60 * 1000);
+
+    const result = await runWorkspaceFilesystemLifecycleSweep({
+      workspaceKey: 'workspace-a',
+      trigger: 'manual',
+      now,
+      force: true,
+      minVisibleMs: 0,
+      maxFiles: 1,
+    });
+
+    expect(result).toMatchObject({ scanned: 2, deleted: 1 });
+    expect(existsSync(oldBundle)).toBe(false);
+    expect(existsSync(newBundle)).toBe(true);
+  });
+
+  it('protects live managed result bundles until their completion marker exists', async () => {
+    const now = Date.UTC(2026, 4, 2, 12);
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const liveBundle = path.join(
+      layout.resultBundles,
+      managedResultBundleName('test_live', process.pid),
+    );
+    writeResultBundleWithMtime(liveBundle, now - 4 * 24 * 60 * 60 * 1000);
+
+    const result = await runWorkspaceFilesystemLifecycleSweep({
+      workspaceKey: 'workspace-a',
+      trigger: 'manual',
+      now,
+      force: true,
+      minVisibleMs: 0,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, deleted: 0 });
+    expect(existsSync(liveBundle)).toBe(true);
+  });
+
+  it('prunes completed managed result bundles even when the owner process is still alive', async () => {
+    const now = Date.UTC(2026, 4, 2, 12);
+    const layout = getWorkspaceFilesystemLayout('workspace-a');
+    const completedBundle = path.join(
+      layout.resultBundles,
+      managedResultBundleName('test_completed', process.pid),
+    );
+    writeResultBundleWithMtime(completedBundle, now - 4 * 24 * 60 * 60 * 1000);
+    writeFileWithMtime(
+      getResultBundleCompletionMarkerPath(completedBundle),
+      'completed',
+      now - 4 * 24 * 60 * 60 * 1000,
+    );
+
+    const result = await runWorkspaceFilesystemLifecycleSweep({
+      workspaceKey: 'workspace-a',
+      trigger: 'manual',
+      now,
+      force: true,
+      minVisibleMs: 0,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, deleted: 1 });
+    expect(existsSync(completedBundle)).toBe(false);
+    expect(existsSync(getResultBundleCompletionMarkerPath(completedBundle))).toBe(false);
   });
 
   it('cooldowns repeat schedule calls for the same workspace', () => {

--- a/src/utils/log-paths.ts
+++ b/src/utils/log-paths.ts
@@ -22,6 +22,7 @@ export interface WorkspaceFilesystemLayout {
   state: string;
   locks: string;
   derivedData: string;
+  resultBundles: string;
   logRetention: LogRetentionPaths;
   filesystemLifecycle: WorkspaceFilesystemLifecyclePaths;
   simulatorLaunchOsLogRegistryDir: string;
@@ -53,6 +54,7 @@ export function getWorkspaceFilesystemLayout(workspaceKey: string): WorkspaceFil
   const state = path.join(root, 'state');
   const locks = path.join(root, 'locks');
   const derivedData = path.join(root, 'DerivedData');
+  const resultBundles = path.join(root, 'result-bundles');
 
   return {
     workspaceKey: normalizedWorkspaceKey,
@@ -61,6 +63,7 @@ export function getWorkspaceFilesystemLayout(workspaceKey: string): WorkspaceFil
     state,
     locks,
     derivedData,
+    resultBundles,
     logRetention: {
       lockDir: path.join(locks, 'log-retention.lock'),
       markerPath: path.join(state, 'log-retention', 'last-cleanup'),

--- a/src/utils/result-bundle-path.ts
+++ b/src/utils/result-bundle-path.ts
@@ -1,0 +1,52 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { log } from './logger.ts';
+import { getWorkspaceFilesystemLayout } from './log-paths.ts';
+import { formatLogTimestamp, shortRandomSuffix } from './log-naming.ts';
+import { getRuntimeInstanceIfConfigured } from './runtime-instance.ts';
+import { workspaceKeyForRoot } from './workspace-identity.ts';
+
+const RESULT_BUNDLE_COMPLETION_MARKER_SUFFIX = '.xcodebuildmcp-completed';
+
+function resolveWorkspaceKey(): string {
+  return getRuntimeInstanceIfConfigured()?.workspaceKey ?? workspaceKeyForRoot(process.cwd());
+}
+
+export function getResultBundleCompletionMarkerPath(resultBundlePath: string): string {
+  return `${resultBundlePath}${RESULT_BUNDLE_COMPLETION_MARKER_SUFFIX}`;
+}
+
+export function createDefaultResultBundlePath(toolName: string): string {
+  const resultBundleDir = getWorkspaceFilesystemLayout(resolveWorkspaceKey()).resultBundles;
+
+  try {
+    fs.mkdirSync(resultBundleDir, { recursive: true, mode: 0o700 });
+    fs.accessSync(resultBundleDir, fs.constants.W_OK);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to create writable result bundle directory at ${resultBundleDir}: ${message}`,
+    );
+  }
+
+  return path.join(
+    resultBundleDir,
+    `${toolName}_${formatLogTimestamp()}_pid${process.pid}_${shortRandomSuffix()}.xcresult`,
+  );
+}
+
+export function markResultBundlePathCompleted(resultBundlePath: string | undefined): void {
+  if (!resultBundlePath) {
+    return;
+  }
+
+  try {
+    if (!fs.existsSync(resultBundlePath) || !fs.statSync(resultBundlePath).isDirectory()) {
+      return;
+    }
+    fs.writeFileSync(getResultBundleCompletionMarkerPath(resultBundlePath), `${Date.now()}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log('warn', `Unable to mark result bundle completed at ${resultBundlePath}: ${message}`);
+  }
+}

--- a/src/utils/simulator-test-execution.ts
+++ b/src/utils/simulator-test-execution.ts
@@ -63,14 +63,11 @@ export function createSimulatorTwoPhaseExecutionPlan(params: {
   const selectedTestArgs = parsedArgs.selectorArgs;
   const usesExactSelectors = selectedTestArgs.length > 0;
   const resultBundlePath = params.resultBundlePath ?? parsedArgs.resultBundlePath;
+  const resultBundleArgs = resultBundlePath ? ['-resultBundlePath', resultBundlePath] : [];
 
   return {
     buildArgs: [...parsedArgs.remainingArgs, ...selectedTestArgs],
-    testArgs: [
-      ...parsedArgs.remainingArgs,
-      ...selectedTestArgs,
-      ...(resultBundlePath ? ['-resultBundlePath', resultBundlePath] : []),
-    ],
+    testArgs: [...parsedArgs.remainingArgs, ...selectedTestArgs, ...resultBundleArgs],
     usesExactSelectors,
     ...(resultBundlePath ? { resultBundlePath } : {}),
   };

--- a/src/utils/test-common.ts
+++ b/src/utils/test-common.ts
@@ -16,7 +16,11 @@ import { getDefaultCommandExecutor } from './command.ts';
 import { type TestPreflightResult } from './test-preflight.ts';
 
 import { createSimulatorTwoPhaseExecutionPlan } from './simulator-test-execution.ts';
-import { findResultBundlePathArg } from './result-bundle-args.ts';
+import { parseResultBundlePathArgs } from './result-bundle-args.ts';
+import {
+  createDefaultResultBundlePath,
+  markResultBundlePathCompleted,
+} from './result-bundle-path.ts';
 
 import type {
   BuildTarget,
@@ -135,11 +139,16 @@ export function createTestExecutor(
     }
 
     try {
+      const parsedResultBundleArgs = parseResultBundlePathArgs(params.extraArgs);
+      const shouldUseDefaultResultBundlePath = !parsedResultBundleArgs.resultBundlePath;
+      const resultBundlePath =
+        parsedResultBundleArgs.resultBundlePath ?? createDefaultResultBundlePath(toolName);
+
       if (shouldUseTwoPhaseSimulatorExecution) {
         const executionPlan = createSimulatorTwoPhaseExecutionPlan({
           extraArgs: params.extraArgs,
           preflight: options.preflight,
-          resultBundlePath: undefined,
+          resultBundlePath,
         });
 
         const buildForTestingResult = await executeXcodeBuildCommand(
@@ -162,6 +171,7 @@ export function createTestExecutor(
               started.stderrLines,
               buildForTestingResult.content,
             ),
+            includeDetectedXcresult: false,
             preflight: options.preflight,
             request: options.request,
           });
@@ -185,6 +195,9 @@ export function createTestExecutor(
           started.pipeline,
         );
 
+        if (shouldUseDefaultResultBundlePath) {
+          markResultBundlePathCompleted(executionPlan.resultBundlePath);
+        }
         emitXcresultFailures(started.pipeline);
 
         return createTestDomainResult({
@@ -201,8 +214,13 @@ export function createTestExecutor(
         });
       }
 
+      const singlePhaseParams: SharedTestExecutorParams = {
+        ...params,
+        extraArgs: [...parsedResultBundleArgs.remainingArgs, '-resultBundlePath', resultBundlePath],
+      };
+
       const singlePhaseResult = await executeXcodeBuildCommand(
-        params,
+        singlePhaseParams,
         platformOptions,
         params.preferXcodebuild,
         'test',
@@ -211,17 +229,16 @@ export function createTestExecutor(
         started.pipeline,
       );
 
+      if (shouldUseDefaultResultBundlePath) {
+        markResultBundlePathCompleted(resultBundlePath);
+      }
       emitXcresultFailures(started.pipeline);
 
       return createTestDomainResult({
         started,
         succeeded: !singlePhaseResult.isError,
         target,
-        artifacts: createXcodebuildTestArtifacts(
-          params,
-          started,
-          findResultBundlePathArg(params.extraArgs),
-        ),
+        artifacts: createXcodebuildTestArtifacts(params, started, resultBundlePath),
         fallbackErrorMessages: getFallbackErrorMessages(
           started.stderrLines,
           singlePhaseResult.content,

--- a/src/utils/workspace-filesystem-lifecycle.ts
+++ b/src/utils/workspace-filesystem-lifecycle.ts
@@ -14,6 +14,7 @@ import { log } from './logging/index.ts';
 import { getRuntimeInstance, getRuntimeInstanceIfConfigured } from './runtime-instance.ts';
 import { tryAcquireFsLock } from './fs-lock.ts';
 import { isPidAlive } from './process-liveness.ts';
+import { getResultBundleCompletionMarkerPath } from './result-bundle-path.ts';
 
 export const WORKSPACE_FILESYSTEM_LIFECYCLE_LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
 export const WORKSPACE_FILESYSTEM_LIFECYCLE_LOG_MAX_FILES = 10_000;
@@ -37,6 +38,10 @@ const XCODEBUILD_LOG_NAME_PATTERN = new RegExp(
 const SIMULATOR_LOG_NAME_PATTERN = new RegExp(
   `^.+_${ISO_TIMESTAMP_PATTERN}_(?:helperpid\\d+_)?ownerpid\\d+_${SUFFIX_PATTERN}\\.log$`,
 );
+const RESULT_BUNDLE_NAME_PATTERN = new RegExp(
+  `^[A-Za-z0-9][A-Za-z0-9_-]*_${ISO_TIMESTAMP_PATTERN}_pid\\d+_${SUFFIX_PATTERN}\\.xcresult$`,
+);
+const RESULT_BUNDLE_OWNER_PID_PATTERN = /_pid(\d+)_/u;
 const XCODE_IDE_CALL_TOOL_TRANSIENT_DIR = path.join('xcode-ide', 'call-tool');
 const XCODE_IDE_CALL_TOOL_OWNER_DIR_PATTERN = /^ownerpid(\d+)_/u;
 
@@ -88,6 +93,7 @@ interface ResolvedWorkspaceFilesystemLifecycleOptions {
   logDir: string;
   markerPath: string;
   lockDir: string;
+  resultBundleDir: string | null;
   now: number;
   maxAgeMs: number;
   maxFiles: number;
@@ -142,6 +148,7 @@ function resolveOptions(
       options.lockDir ??
       layout?.filesystemLifecycle.lockDir ??
       path.join(logDir, FALLBACK_LOCK_DIR_NAME),
+    resultBundleDir: layout?.resultBundles ?? null,
     now: options.now ?? Date.now(),
     maxAgeMs: options.maxAgeMs ?? WORKSPACE_FILESYSTEM_LIFECYCLE_LOG_MAX_AGE_MS,
     maxFiles: options.maxFiles ?? WORKSPACE_FILESYSTEM_LIFECYCLE_LOG_MAX_FILES,
@@ -190,6 +197,15 @@ function isXcodeBuildMCPManagedLogName(fileName: string): boolean {
     return true;
   }
   return XCODEBUILD_LOG_NAME_PATTERN.test(fileName) || SIMULATOR_LOG_NAME_PATTERN.test(fileName);
+}
+
+function isXcodeBuildMCPManagedResultBundleName(fileName: string): boolean {
+  return RESULT_BUNDLE_NAME_PATTERN.test(fileName);
+}
+
+function getManagedResultBundleOwnerPid(fileName: string): number | null {
+  const pid = Number(fileName.match(RESULT_BUNDLE_OWNER_PID_PATTERN)?.[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
 }
 
 async function deleteFile(filePath: string): Promise<boolean> {
@@ -287,6 +303,98 @@ async function pruneKnownLogDirectory(
 
   const deletions = await Promise.all(
     [...expired, ...overflow].map((file) => deleteFile(file.path)),
+  );
+  const deleted = deletions.reduce((count, success) => count + (success ? 1 : 0), 0);
+
+  return { scanned, deleted };
+}
+
+async function hasResultBundleCompletionMarker(bundlePath: string): Promise<boolean> {
+  try {
+    const markerStat = await fs.stat(getResultBundleCompletionMarkerPath(bundlePath));
+    return markerStat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isProtectedResultBundleDirectory(
+  bundle: RetainedLogFile,
+  options: ResolvedWorkspaceFilesystemLifecycleOptions,
+): Promise<boolean> {
+  if (options.now - bundle.mtimeMs < options.minVisibleMs) {
+    return true;
+  }
+
+  const ownerPid = getManagedResultBundleOwnerPid(bundle.name);
+  if (ownerPid && isPidAlive(ownerPid) && !(await hasResultBundleCompletionMarker(bundle.path))) {
+    return true;
+  }
+
+  return false;
+}
+
+async function pruneKnownResultBundleDirectory(
+  options: ResolvedWorkspaceFilesystemLifecycleOptions,
+): Promise<{ scanned: number; deleted: number }> {
+  if (!options.resultBundleDir) {
+    return { scanned: 0, deleted: 0 };
+  }
+
+  const resultBundleDir = options.resultBundleDir;
+  await fs.mkdir(resultBundleDir, { recursive: true, mode: 0o700 });
+  const entries = await fs.readdir(resultBundleDir, { withFileTypes: true });
+  const candidates = entries
+    .filter((entry) => entry.isDirectory() && isXcodeBuildMCPManagedResultBundleName(entry.name))
+    .map((entry) => ({ name: entry.name, path: path.join(resultBundleDir, entry.name) }));
+
+  const stats = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        const stat = await fs.stat(candidate.path);
+        return { ...candidate, mtimeMs: stat.mtimeMs } satisfies RetainedLogFile;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const retainedDeletable: RetainedLogFile[] = [];
+  const expired: RetainedLogFile[] = [];
+  let scanned = 0;
+
+  for (const bundle of stats) {
+    if (!bundle) continue;
+    scanned += 1;
+    if (await isProtectedResultBundleDirectory(bundle, options)) {
+      continue;
+    }
+    if (options.now - bundle.mtimeMs > options.maxAgeMs) {
+      expired.push(bundle);
+      continue;
+    }
+    retainedDeletable.push(bundle);
+  }
+
+  const excessFileCount = retainedDeletable.length - options.maxFiles;
+  const overflow =
+    excessFileCount > 0
+      ? retainedDeletable
+          .slice()
+          .sort((left, right) => left.mtimeMs - right.mtimeMs)
+          .slice(0, excessFileCount)
+      : [];
+
+  const deletions = await Promise.all(
+    [...expired, ...overflow].map(async (bundle) => {
+      try {
+        await fs.rm(bundle.path, { recursive: true, force: true });
+        await deleteFile(getResultBundleCompletionMarkerPath(bundle.path));
+        return true;
+      } catch {
+        return false;
+      }
+    }),
   );
   const deleted = deletions.reduce((count, success) => count + (success ? 1 : 0), 0);
 
@@ -450,15 +558,16 @@ export async function runWorkspaceFilesystemLifecycleSweep(
 
     runDaemonCleanup(resolved);
     const protectedPaths = await collectProtectedLogPaths(resolved);
-    const { scanned, deleted } = await pruneKnownLogDirectory(resolved, protectedPaths);
+    const logPrune = await pruneKnownLogDirectory(resolved, protectedPaths);
+    const resultBundlePrune = await pruneKnownResultBundleDirectory(resolved);
     await touchCleanupMarker(resolved.markerPath, resolved.now);
 
     return {
       workspaceKey: resolved.workspaceKey,
       trigger: resolved.trigger,
       logDir: resolved.logDir,
-      scanned,
-      deleted,
+      scanned: logPrune.scanned + resultBundlePrune.scanned,
+      deleted: logPrune.deleted + resultBundlePrune.deleted,
       stopped,
       skippedByCooldown: false,
       skippedByLock: false,
@@ -520,10 +629,7 @@ export function scheduleWorkspaceFilesystemLifecycleSweep(
             lastScheduledAtByPreKey.set(preKey, completedAt);
           }
           if (result.deleted > 0) {
-            log(
-              'info',
-              `[FilesystemLifecycle] Deleted ${result.deleted} old log files from ${result.logDir}`,
-            );
+            log('info', `[FilesystemLifecycle] Deleted ${result.deleted} old filesystem artifacts`);
           }
         }
       })

--- a/src/utils/xcodebuild-domain-results.ts
+++ b/src/utils/xcodebuild-domain-results.ts
@@ -385,6 +385,7 @@ export function createTestDomainResult(options: {
   target: BuildTarget;
   artifacts: TestResultArtifacts;
   fallbackErrorMessages?: readonly string[];
+  includeDetectedXcresult?: boolean;
   preflight?: TestPreflightResult;
   request: BuildInvocationRequest;
 }): TestResultDomainResult {
@@ -398,10 +399,12 @@ export function createTestDomainResult(options: {
     ...(fragment.durationMs !== undefined ? { durationMs: fragment.durationMs } : {}),
   }));
   const detectedXcresultPath =
-    options.target === 'swift-package' ? null : options.started.pipeline.xcresultPath;
+    options.includeDetectedXcresult === false || options.target === 'swift-package'
+      ? null
+      : options.started.pipeline.xcresultPath;
   const providedXcresultPath =
     'xcresultPath' in options.artifacts ? options.artifacts.xcresultPath : undefined;
-  const xcresultPath = detectedXcresultPath ?? providedXcresultPath;
+  const xcresultPath = providedXcresultPath ?? detectedXcresultPath;
   const artifacts: TestResultArtifacts = {
     ...options.artifacts,
     ...(xcresultPath ? { xcresultPath } : {}),


### PR DESCRIPTION
Create workspace-scoped default xcresult bundles for simulator, device, and macOS test tools when callers do not pass `-resultBundlePath`.

Previously, test artifact paths were only surfaced when xcodebuild reported a bundle path or the caller provided one explicitly. This makes the artifact path deterministic for agents and scripts, and keeps user-provided bundle paths unchanged.

The workspace filesystem lifecycle now recognizes XcodeBuildMCP-managed result bundles and prunes them safely, while protecting live bundles until their completion marker is written and leaving user-created bundles alone.
