### PR TITLE
feat(rendering): Add configurable file path rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added configurable file artifact text rendering with CLI output defaulting to labeled `Files:` lists, MCP text preserving compact trees, and `filePathRenderStyle` / `XCODEBUILDMCP_FILE_PATH_RENDER_STYLE` / `--file-path-render-style` overrides.
 - Added workspace-scoped default xcresult bundles for simulator, device, and macOS test tools so test artifacts are available in structured and text output even when callers do not pass `-resultBundlePath`.
 - Added opt-in MCP server idle shutdown via `XCODEBUILDMCP_MCP_IDLE_TIMEOUT_MS`, allowing unused MCP server processes to gracefully exit after a configured idle period ([#394](https://github.com/getsentry/XcodeBuildMCP/issues/394)).
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,7 @@ disableSessionDefaults: false
 incrementalBuildsEnabled: false
 debug: false
 sentryDisabled: false
+filePathRenderStyle: 'list' # text output file artifacts: list or tree
 sessionDefaults:
   projectPath: './MyApp.xcodeproj' # xor workspacePath
   workspacePath: './MyApp.xcworkspace' # xor projectPath

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,12 @@ import { coerceLogLevel, setLogLevel, type LogLevel } from './utils/logger.ts';
 import { hydrateSentryDisabledEnvFromProjectConfig } from './utils/sentry-config.ts';
 
 function findTopLevelCommand(argv: string[]): string | undefined {
-  const flagsWithValue = new Set(['--socket', '--log-level', '--style']);
+  const flagsWithValue = new Set([
+    '--socket',
+    '--log-level',
+    '--style',
+    '--file-path-render-style',
+  ]);
   let skipNext = false;
 
   for (const token of argv) {
@@ -74,6 +79,11 @@ async function buildLightweightYargsApp(): Promise<ReturnType<typeof import('yar
       describe: 'Output verbosity (minimal hides next steps)',
       choices: ['normal', 'minimal'] as const,
       default: 'normal',
+    })
+    .option('file-path-render-style', {
+      type: 'string',
+      describe: 'Render file artifacts as a compact tree or labeled list in text output',
+      choices: ['tree', 'list'] as const,
     })
     .middleware((argv) => {
       const level = argv['log-level'] as LogLevel | undefined;

--- a/src/cli/__tests__/register-tool-commands.test.ts
+++ b/src/cli/__tests__/register-tool-commands.test.ts
@@ -374,6 +374,62 @@ describe('registerToolCommands', () => {
     stdoutWrite.mockRestore();
   });
 
+  it('applies --file-path-render-style to text output without forwarding it to tool args', async () => {
+    vi.spyOn(DefaultToolInvoker.prototype, 'invokeDirect').mockImplementation(
+      async (tool, args, opts) => {
+        const handlerContext: ToolHandlerContext = opts.handlerContext ?? {
+          emit: (fragment) => {
+            opts.renderSession?.emit(fragment);
+          },
+          attach: (image) => {
+            opts.renderSession?.attach(image);
+          },
+        };
+
+        await tool.handler(args, handlerContext);
+
+        if (handlerContext.structuredOutput) {
+          opts.renderSession?.setStructuredOutput?.(handlerContext.structuredOutput);
+          opts.onStructuredOutput?.(handlerContext.structuredOutput);
+        }
+      },
+    );
+    const stdoutChunks: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    const tool = createTool({
+      handler: vi.fn(async (_args, ctx) => {
+        if (ctx) {
+          ctx.structuredOutput = {
+            schema: 'xcodebuildmcp.output.app-path',
+            schemaVersion: '1',
+            result: {
+              kind: 'app-path',
+              didError: false,
+              error: null,
+              artifacts: { appPath: '/tmp/MyApp.app' },
+            },
+          };
+        }
+      }) as ToolDefinition['handler'],
+    });
+    const app = createApp(createCatalog([tool]));
+
+    await expect(
+      app.parseAsync(['simulator', 'run-tool', '--file-path-render-style', 'tree']),
+    ).resolves.toBeDefined();
+
+    expect(tool.handler).toHaveBeenCalledWith(
+      { workspacePath: 'Profile.xcworkspace' },
+      expect.any(Object),
+    );
+    expect(stdoutChunks.join('')).toContain('└── /tmp/MyApp.app — App Path');
+    expect(stdoutChunks.join('')).not.toContain('└ App Path: /tmp/MyApp.app');
+  });
+
   it('writes a structured envelope for tools that provide structured output', async () => {
     mockInvokeDirectThroughHandler();
     const stdoutChunks: string[] = [];

--- a/src/cli/register-tool-commands.ts
+++ b/src/cli/register-tool-commands.ts
@@ -9,6 +9,7 @@ import { groupToolsByWorkflow } from '../runtime/tool-catalog.ts';
 import { getWorkflowMetadataFromManifest } from '../core/manifest/load-manifest.ts';
 import type { ResolvedRuntimeConfig } from '../utils/config-store.ts';
 import type { ToolHandlerContext } from '../rendering/types.ts';
+import type { FilePathRenderStyle } from '../utils/runtime-config-types.ts';
 import type { AnyFragment } from '../types/domain-fragments.ts';
 import { transcriptEmitterStorage } from '../utils/transcript-context.ts';
 import {
@@ -138,7 +139,10 @@ export function registerToolCommands(
       workflowDescription,
       (yargs) => {
         // Hide root-level options from workflow help
-        yargs.option('log-level', { hidden: true }).option('style', { hidden: true });
+        yargs
+          .option('log-level', { hidden: true })
+          .option('style', { hidden: true })
+          .option('file-path-render-style', { hidden: true });
 
         // Register each tool as a subcommand under this workflow
         for (const tool of tools) {
@@ -201,7 +205,10 @@ function registerToolSubcommand(
     tool.description ?? `Run the ${tool.mcpName} tool`,
     (subYargs) => {
       // Hide root-level options from tool help
-      subYargs.option('log-level', { hidden: true }).option('style', { hidden: true });
+      subYargs
+        .option('log-level', { hidden: true })
+        .option('style', { hidden: true })
+        .option('file-path-render-style', { hidden: true });
 
       // Parse option-like values as arguments (e.g. --extra-args "-only-testing:...")
       subYargs.parserConfiguration({
@@ -270,6 +277,7 @@ function registerToolSubcommand(
       const outputFormat = (argv.output as OutputFormat) ?? 'text';
       const socketPath = argv.socket as string;
       const logLevel = argv['log-level'] as string | undefined;
+      const filePathRenderStyle = argv.filePathRenderStyle as FilePathRenderStyle | undefined;
 
       if (
         profileOverride &&
@@ -302,6 +310,8 @@ function registerToolSubcommand(
         'socket',
         'log-level',
         'logLevel',
+        'file-path-render-style',
+        'filePathRenderStyle',
         '_',
         '$0',
       ]);
@@ -340,14 +350,19 @@ function registerToolSubcommand(
       const restoreCliOutputFormat = setEnvScoped('XCODEBUILDMCP_CLI_OUTPUT_FORMAT', outputFormat);
 
       try {
-        const session =
-          outputFormat === 'text'
-            ? createRenderSession('cli-text', {
-                interactive: process.stdout.isTTY === true,
-              })
-            : outputFormat === 'raw'
-              ? createRenderSession('raw')
-              : createRenderSession('text');
+        let renderStrategy: 'cli-text' | 'raw' | 'text';
+        if (outputFormat === 'text') {
+          renderStrategy = 'cli-text';
+        } else if (outputFormat === 'raw') {
+          renderStrategy = 'raw';
+        } else {
+          renderStrategy = 'text';
+        }
+        const session = createRenderSession(renderStrategy, {
+          interactive: outputFormat === 'text' && process.stdout.isTTY === true,
+          runtime: 'cli',
+          filePathRenderStyle,
+        });
         const writeJsonlFragment =
           outputFormat === 'jsonl'
             ? (fragment: AnyFragment) => {

--- a/src/cli/yargs-app.ts
+++ b/src/cli/yargs-app.ts
@@ -55,6 +55,11 @@ export function buildYargsApp(opts: YargsAppOptions): ReturnType<typeof yargs> {
       choices: ['normal', 'minimal'] as const,
       default: 'normal',
     })
+    .option('file-path-render-style', {
+      type: 'string',
+      describe: 'Render file artifacts as a compact tree or labeled list in text output',
+      choices: ['tree', 'list'] as const,
+    })
     .middleware((argv) => {
       const level = argv['log-level'] as LogLevel | undefined;
       if (level) {

--- a/src/mcp/resources/devices.ts
+++ b/src/mcp/resources/devices.ts
@@ -11,8 +11,7 @@ import { getDefaultCommandExecutor } from '../../utils/execution/index.ts';
 import { list_devicesLogic } from '../tools/device/list_devices.ts';
 import { handlerContextStorage } from '../../utils/typed-tool-factory.ts';
 import type { ToolHandlerContext } from '../../rendering/types.ts';
-
-import { renderCliTextTranscript } from '../../utils/renderers/cli-text-renderer.ts';
+import { renderTranscript } from '../../rendering/render.ts';
 
 export async function devicesResourceLogic(
   executor: CommandExecutor = getDefaultCommandExecutor(),
@@ -25,10 +24,15 @@ export async function devicesResourceLogic(
   try {
     log('info', 'Processing devices resource request');
     await handlerContextStorage.run(ctx, () => list_devicesLogic({}, executor));
-    const text = renderCliTextTranscript({
-      structuredOutput: ctx.structuredOutput,
-      nextSteps: ctx.nextSteps,
-    });
+    const text = renderTranscript(
+      {
+        structuredOutput: ctx.structuredOutput,
+        nextSteps: ctx.nextSteps,
+        nextStepsRuntime: 'mcp',
+      },
+      'text',
+      { runtime: 'mcp' },
+    );
     const isError = ctx.structuredOutput?.result.didError === true;
     if (isError) {
       throw new Error(text || 'Failed to retrieve device data');

--- a/src/mcp/resources/simulators.ts
+++ b/src/mcp/resources/simulators.ts
@@ -11,8 +11,7 @@ import type { CommandExecutor } from '../../utils/execution/index.ts';
 import { list_simsLogic } from '../tools/simulator/list_sims.ts';
 import { handlerContextStorage } from '../../utils/typed-tool-factory.ts';
 import type { ToolHandlerContext } from '../../rendering/types.ts';
-
-import { renderCliTextTranscript } from '../../utils/renderers/cli-text-renderer.ts';
+import { renderTranscript } from '../../rendering/render.ts';
 
 export async function simulatorsResourceLogic(
   executor: CommandExecutor = getDefaultCommandExecutor(),
@@ -25,10 +24,15 @@ export async function simulatorsResourceLogic(
   try {
     log('info', 'Processing simulators resource request');
     await handlerContextStorage.run(ctx, () => list_simsLogic({ enabled: true }, executor));
-    const text = renderCliTextTranscript({
-      structuredOutput: ctx.structuredOutput,
-      nextSteps: ctx.nextSteps,
-    });
+    const text = renderTranscript(
+      {
+        structuredOutput: ctx.structuredOutput,
+        nextSteps: ctx.nextSteps,
+        nextStepsRuntime: 'mcp',
+      },
+      'text',
+      { runtime: 'mcp' },
+    );
     const structuredError = ctx.structuredOutput?.result.didError
       ? (ctx.structuredOutput.result.error ?? null)
       : null;

--- a/src/rendering/__tests__/text-render-parity.test.ts
+++ b/src/rendering/__tests__/text-render-parity.test.ts
@@ -285,7 +285,7 @@ describe('text render parity', () => {
 
     expect(output).toBe(captureCliText(fixture));
     expect(output.match(/Discovered 2 test\(s\):/g)).toHaveLength(1);
-    expect(output.match(/MCPTestTests\n  ✗ testTwo\(\):/g)).toHaveLength(1);
+    expect(output.match(/MCPTestTests\n {2}✗ testTwo\(\):/g)).toHaveLength(1);
     expect(output.match(/1 test failed, 1 passed, 0 skipped/g)).toHaveLength(1);
     expect(output).toContain('Result Bundle: /tmp/App Tests.xcresult');
     expect(output).toContain('Build Logs: /tmp/Test.log');
@@ -338,6 +338,40 @@ describe('text render parity', () => {
     expect(rendered).toBe(captureCliText(fixture));
     expect(rendered).toContain('✅ Build succeeded. (⏱️ 3.2s)');
     expect(rendered).not.toContain('❌ Build failed. (⏱️ 9.9s)');
+  });
+
+  it('omits header frontmatter for MCP runtime text transcripts', () => {
+    const output = renderTranscript(
+      {
+        items: [],
+        structuredOutput: {
+          schema: 'xcodebuildmcp.output.build-run-result',
+          schemaVersion: '1.0.0',
+          result: {
+            kind: 'build-run-result',
+            request: {
+              scheme: 'MyApp',
+              projectPath: '/tmp/MyApp.xcodeproj',
+              configuration: 'Debug',
+              platform: 'iOS Simulator',
+            },
+            didError: false,
+            error: null,
+            summary: { status: 'SUCCEEDED', durationMs: 5000 },
+            artifacts: { appPath: '/tmp/build/MyApp.app', buildLogPath: '/tmp/build.log' },
+            diagnostics: { warnings: [], errors: [] },
+          },
+        },
+      },
+      'text',
+      { runtime: 'mcp' },
+    );
+
+    expect(output).toContain('🚀 Build & Run');
+    expect(output).not.toContain('Scheme: MyApp');
+    expect(output).not.toContain('Project: /tmp/MyApp.xcodeproj');
+    expect(output).not.toContain('Configuration: Debug');
+    expect(output).toContain('✅ Build succeeded. (⏱️ 5.0s)');
   });
 
   it('renders next steps in MCP tool-call syntax for MCP runtime text transcripts', () => {

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -3,6 +3,12 @@ import type { NextStep } from '../types/common.ts';
 import { sessionStore } from '../utils/session-store.ts';
 import { getConfig } from '../utils/config-store.ts';
 import {
+  normalizeRenderRuntime,
+  resolveFilePathRenderStyle,
+  type FilePathRenderRuntime,
+} from '../utils/file-path-render-style.ts';
+import type { FilePathRenderStyle } from '../utils/runtime-config-types.ts';
+import {
   createCliTextRenderer,
   renderCliTextTranscript,
 } from '../utils/renderers/cli-text-renderer.ts';
@@ -86,10 +92,23 @@ function createBaseRenderSession(hooks: RenderSessionHooks): RenderSession {
 
 function createRenderHooks(
   strategy: RenderStrategy,
-  options: { interactive: boolean },
+  options: {
+    interactive: boolean;
+    runtime?: FilePathRenderRuntime;
+    filePathRenderStyle?: FilePathRenderStyle;
+    includeHeaderDetails?: boolean;
+  },
 ): RenderSessionHooks {
   const suppressWarnings = sessionStore.get('suppressWarnings');
-  const showTestTiming = getConfig().showTestTiming;
+  const config = getConfig();
+  const showTestTiming = config.showTestTiming;
+  const runtime = options.runtime ?? normalizeRenderRuntime(process.env.XCODEBUILDMCP_RUNTIME);
+  const filePathRenderStyle = resolveFilePathRenderStyle({
+    explicit: options.filePathRenderStyle,
+    configured: config.filePathRenderStyle,
+    runtime,
+  });
+  const includeHeaderDetails = options.includeHeaderDetails ?? runtime !== 'mcp';
 
   switch (strategy) {
     case 'text':
@@ -99,6 +118,8 @@ function createRenderHooks(
             ...input,
             suppressWarnings: suppressWarnings ?? false,
             showTestTiming,
+            filePathRenderStyle,
+            includeHeaderDetails,
           }),
       };
     case 'raw':
@@ -123,6 +144,8 @@ function createRenderHooks(
             nextStepsRuntime: input.nextStepsRuntime,
             suppressWarnings: suppressWarnings ?? false,
             showTestTiming,
+            filePathRenderStyle,
+            includeHeaderDetails,
           });
           if (text) {
             process.stdout.write(text);
@@ -135,6 +158,8 @@ function createRenderHooks(
         ...options,
         suppressWarnings: suppressWarnings ?? false,
         showTestTiming,
+        filePathRenderStyle,
+        includeHeaderDetails,
       });
 
       return {
@@ -152,6 +177,9 @@ function createRenderHooks(
 
 export interface RenderSessionOptions {
   interactive?: boolean;
+  runtime?: FilePathRenderRuntime;
+  filePathRenderStyle?: FilePathRenderStyle;
+  includeHeaderDetails?: boolean;
 }
 
 export function createRenderSession(
@@ -159,17 +187,14 @@ export function createRenderSession(
   options?: RenderSessionOptions,
 ): RenderSession {
   return createBaseRenderSession(
-    createRenderHooks(strategy, { interactive: options?.interactive ?? false }),
+    createRenderHooks(strategy, { ...options, interactive: options?.interactive ?? false }),
   );
 }
 
-export function renderTranscript(input: RenderTranscriptInput, strategy: RenderStrategy): string {
-  return createRenderHooks(strategy, { interactive: false }).finalize(input);
-}
-
-export function renderFragments(
-  fragments: readonly AnyFragment[],
+export function renderTranscript(
+  input: RenderTranscriptInput,
   strategy: RenderStrategy,
+  options?: Pick<RenderSessionOptions, 'runtime' | 'filePathRenderStyle' | 'includeHeaderDetails'>,
 ): string {
-  return renderTranscript({ items: fragments }, strategy);
+  return createRenderHooks(strategy, { ...options, interactive: false }).finalize(input);
 }

--- a/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--error-compiler.txt
@@ -5,7 +5,7 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Compiler Errors (1):
 
@@ -13,4 +13,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--error-wrong-scheme.txt
@@ -5,11 +5,12 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build--success.txt
@@ -5,10 +5,11 @@
    Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
    Configuration: Debug
    Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Get built device app path: xcodebuildmcp device get-app-path --scheme "CalculatorApp"

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-compiler.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Compiler Errors (1):
 
@@ -14,4 +14,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--error-wrong-scheme.txt
@@ -6,11 +6,12 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -16,10 +16,11 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Stop app on device: xcodebuildmcp device stop --device-id "<UUID>" --process-id "<PID>"

--- a/src/snapshot-tests/__fixtures__/cli/device/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/get-app-path--success.txt
@@ -7,9 +7,10 @@
    Platform: iOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
+  └ Files:
+     └ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
-2. Install app on device: xcodebuildmcp device install --device-id "DEVICE_UDID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
+1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
+2. Install app on device: xcodebuildmcp device install --device-id "DEVICE_UDID" --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
 3. Launch app on device: xcodebuildmcp device launch --device-id "DEVICE_UDID" --bundle-id "BUNDLE_ID"

--- a/src/snapshot-tests/__fixtures__/cli/device/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/install--success.txt
@@ -2,6 +2,6 @@
 📦 Install App
 
    Device: <DEVICE> (<UUID>)
-   App: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
+   App: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
 
 ✅ App installed successfully.

--- a/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--error-compiler.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -19,5 +19,6 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--failure.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Discovered 57 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear
@@ -51,5 +51,6 @@ IntentionalFailureTests
         example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/device/test--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS
    Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -15,5 +15,6 @@ Discovered 1 test(s):
 Running tests (1 completed, 0 failures, 0 skipped)
 
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--error-compiler.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Compiler Errors (1):
 
@@ -13,4 +13,5 @@ Compiler Errors (1):
     example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--error-wrong-scheme.txt
@@ -5,11 +5,12 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build--success.txt
@@ -5,11 +5,12 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
   ├ Bundle ID: io.sentry.MCPTest.macOS
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Get built macOS app path: xcodebuildmcp macos get-app-path --scheme "MCPTest"

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-compiler.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Compiler Errors (1):
 
@@ -13,4 +13,5 @@ Compiler Errors (1):
     example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--error-wrong-scheme.txt
@@ -5,11 +5,12 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/build-and-run--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -14,10 +14,11 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
   ├ Bundle ID: io.sentry.MCPTest.macOS
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Interact with the launched app in the foreground

--- a/src/snapshot-tests/__fixtures__/cli/macos/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/get-app-path--success.txt
@@ -7,8 +7,9 @@
    Platform: macOS
 
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
+  └ Files:
+     └ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp macos get-macos-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
-2. Launch app: xcodebuildmcp macos launch --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
+1. Get bundle ID: xcodebuildmcp macos get-macos-bundle-id --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
+2. Launch app: xcodebuildmcp macos launch --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"

--- a/src/snapshot-tests/__fixtures__/cli/macos/launch--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/launch--success.txt
@@ -1,7 +1,7 @@
 
 🚀 Launch macOS App
 
-   App: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
+   App: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
 
 ✅ App launched successfully
   ├ Bundle ID: io.sentry.MCPTest.macOS

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-compiler.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
    Selective Testing:
      MCPTestTests/MCPTestTests/appNameIsCorrect()
      MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
@@ -20,5 +20,6 @@ Compiler Errors (1):
     example_projects/macOS/MCPTest/MCPTestApp.swift:20:42
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--error-wrong-scheme.txt
@@ -5,12 +5,13 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--failure.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
 
 Discovered 4 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
@@ -28,5 +28,6 @@ MCPTestTests
         example_projects/macOS/MCPTestTests/MCPTestTests.swift:11
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/macos/test--success.txt
@@ -5,7 +5,7 @@
    Project: example_projects/macOS/MCPTest.xcodeproj
    Configuration: Debug
    Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
    Selective Testing:
      MCPTestTests/MCPTestTests/appNameIsCorrect()
      MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
@@ -17,5 +17,6 @@ Running tests (1 completed, 0 failures, 0 skipped)
 Running tests (2 completed, 0 failures, 0 skipped)
 
 ✅ 2 tests passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--error-compiler.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Compiler Errors (1):
 
@@ -14,4 +14,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--error-wrong-scheme.txt
@@ -6,11 +6,12 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build--success.txt
@@ -6,10 +6,11 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Get built app path in simulator derived data: xcodebuildmcp simulator get-app-path --simulator-name "iPhone 17" --scheme "CalculatorApp" --platform "iOS Simulator"

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-compiler.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Compiler Errors (1):
 
@@ -14,4 +14,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--error-wrong-scheme.txt
@@ -6,11 +6,12 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/build-and-run--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 ℹ️ Resolving app path
 ✅ Resolving app path
@@ -18,12 +18,13 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
-  ├ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
-  ├ Runtime Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
-  └ OSLog: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+     ├ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
+     ├ Runtime Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
+     └ OSLog: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Stop app in simulator: xcodebuildmcp simulator stop --simulator-id "<UUID>" --bundle-id "io.sentry.calculatorapp"

--- a/src/snapshot-tests/__fixtures__/cli/simulator/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/get-app-path--success.txt
@@ -8,10 +8,11 @@
    Simulator: iPhone 17
 
 ✅ Get app path successful (⏱️ <DURATION>)
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  └ Files:
+     └ App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 Next steps:
-1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+1. Get bundle ID: xcodebuildmcp device get-app-bundle-id --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
 2. Boot simulator: xcodebuildmcp simulator-management boot --simulator-id "SIMULATOR_UUID"
-3. Install app: xcodebuildmcp simulator install --simulator-id "SIMULATOR_UUID" --app-path "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+3. Install app: xcodebuildmcp simulator install --simulator-id "SIMULATOR_UUID" --app-path "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
 4. Launch app: xcodebuildmcp simulator launch-app --simulator-id "SIMULATOR_UUID" --bundle-id "BUNDLE_ID"

--- a/src/snapshot-tests/__fixtures__/cli/simulator/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/install--success.txt
@@ -2,7 +2,7 @@
 📦 Install App
 
    Simulator: <UUID>
-   App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+   App Path: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
 
 ✅ App installed successfully
 

--- a/src/snapshot-tests/__fixtures__/cli/simulator/launch-app--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/launch-app--success.txt
@@ -6,8 +6,9 @@
 
 ✅ App launched successfully
   ├ Process ID: <PID>
-  ├ Runtime Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
-  └ OSLog: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Runtime Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
+     └ OSLog: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
 
 Next steps:
 1. Open Simulator app to see it: xcodebuildmcp simulator-management open

--- a/src/snapshot-tests/__fixtures__/cli/simulator/screenshot--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/screenshot--success.txt
@@ -4,6 +4,7 @@
    Simulator: <UUID>
 
 ✅ Screenshot captured
-  ├ Screenshot: <TMPDIR>
   ├ Format: image/jpeg
-  └ Size: 368x800px
+  ├ Size: 368x800px
+  └ Files:
+     └ Screenshot: <TMPDIR>

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--error-compiler.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -19,4 +19,5 @@ Compiler Errors (1):
     example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33:42
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--error-wrong-scheme.txt
@@ -6,11 +6,12 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--failure.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
 
 Discovered 57 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear
@@ -36,5 +36,6 @@ IntentionalFailureTests
         example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/simulator/test--success.txt
@@ -6,7 +6,7 @@
    Configuration: Debug
    Platform: iOS Simulator
    Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
    Selective Testing:
      CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -15,5 +15,6 @@ Discovered 1 test(s):
 Running tests (1 completed, 0 failures, 0 skipped)
 
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ Result Bundle: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/build--error-bad-path.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/build--error-bad-path.txt
@@ -8,4 +8,5 @@ Errors (1):
   ✗ chdir error: No such file or directory (2): <ROOT>/example_projects/NONEXISTENT
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/build--success.txt
@@ -4,4 +4,5 @@
    Package: <ROOT>/example_projects/spm
 
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/run--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/run--success.txt
@@ -6,9 +6,10 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: example_projects/spm/.build/arm64-apple-macosx/debug/spm
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├ App Path: example_projects/spm/.build/arm64-apple-macosx/debug/spm
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log
 
 Output
   Hello, world!

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/test--error-bad-path.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/test--error-bad-path.txt
@@ -4,11 +4,12 @@
    Scheme: NONEXISTENT
    Configuration: debug
    Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
 
 Errors (1):
 
   ✗ chdir error: No such file or directory (2): <ROOT>/example_projects/NONEXISTENT
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/test--failure.txt
@@ -4,7 +4,7 @@
    Scheme: spm
    Configuration: debug
    Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
 Running tests (1 completed, 1 failure, 0 skipped)
 Running tests (2 completed, 1 failure, 0 skipped)
 Running tests (3 completed, 1 failure, 0 skipped)
@@ -25,4 +25,5 @@ Test failed
         SimpleTests.swift:57
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/swift-package/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/swift-package/test--success.txt
@@ -4,9 +4,10 @@
    Scheme: spm
    Configuration: debug
    Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
+   Derived Data: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
 Running tests (0 completed, 0 failures, 0 skipped)
 Running tests (1 completed, 0 failures, 0 skipped)
 
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └ Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log

--- a/src/snapshot-tests/__fixtures__/cli/xcode-ide/documentation-search--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/xcode-ide/documentation-search--success.txt
@@ -4,4 +4,5 @@
    Remote Tool: DocumentationSearch
 
 ✅ Tool "DocumentationSearch" completed successfully. Raw response saved to artifact.
-  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>
+  └ Files:
+     └ Raw Response JSON: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/state/xcode-ide/call-tool/ownerpid<PID>_<UUID>/<TIMESTAMP>-DocumentationSearch-<HASH>.json

--- a/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/cli/xcode-ide/list-tools--success.txt
@@ -2,4 +2,5 @@
 🔧 Xcode IDE List Tools
 
 ✅ Found <XCODE_IDE_TOOL_COUNT> tool(s). Raw response saved to artifact.
-  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>
+  └ Files:
+     └ Raw Response JSON: ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/state/xcode-ide/call-tool/ownerpid<PID>_<UUID>/<TIMESTAMP>-list-tools-<HASH>.json

--- a/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "target": "device"
@@ -18,7 +18,7 @@
       "target": "device"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "target": "device"
@@ -18,7 +18,7 @@
       "target": "device"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "target": "device"
@@ -18,7 +18,7 @@
       "target": "device"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -20,7 +20,7 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -20,7 +20,7 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/build-and-run--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -19,11 +19,11 @@
       "target": "device"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app",
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app",
       "bundleId": "io.sentry.calculatorapp",
       "processId": 99999,
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/get-app-path--success.json
@@ -15,7 +15,7 @@
       "target": "device"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/device/install--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/install--success.json
@@ -9,7 +9,7 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -29,8 +29,8 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/device/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--failure.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -27,8 +27,8 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/device/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/device/test--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS",
       "deviceId": "<UUID>",
@@ -29,8 +29,8 @@
     },
     "artifacts": {
       "deviceId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -18,7 +18,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -18,7 +18,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -19,7 +19,7 @@
     },
     "artifacts": {
       "bundleId": "io.sentry.MCPTest.macOS",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -18,7 +18,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -18,7 +18,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/build-and-run--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "target": "macos"
@@ -18,10 +18,10 @@
       "target": "macos"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
       "bundleId": "io.sentry.MCPTest.macOS",
       "processId": 99999,
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log"
     },
     "output": {
       "stdout": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/get-app-path--success.json
@@ -15,7 +15,7 @@
       "target": "macos"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/macos/launch--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/launch--success.json
@@ -8,7 +8,7 @@
       "status": "SUCCEEDED"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app",
       "bundleId": "io.sentry.MCPTest.macOS",
       "processId": 99999
     },

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [
@@ -27,8 +27,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [],
@@ -24,8 +24,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--failure.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [],
@@ -24,8 +24,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/macos/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/macos/test--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "MCPTest",
       "projectPath": "example_projects/macOS/MCPTest.xcodeproj",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>",
       "configuration": "Debug",
       "platform": "macOS",
       "onlyTesting": [
@@ -27,8 +27,8 @@
       "target": "macos"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,7 +18,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/build-and-run--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17"
@@ -18,13 +18,13 @@
       "target": "simulator"
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app",
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app",
       "bundleId": "io.sentry.calculatorapp",
       "processId": 99999,
       "simulatorId": "<UUID>",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log",
-      "runtimeLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log",
-      "osLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log",
+      "runtimeLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log",
+      "osLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/get-app-path--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/get-app-path--success.json
@@ -17,7 +17,7 @@
       "durationMs": 1234
     },
     "artifacts": {
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
     }
   }
 }

--- a/src/snapshot-tests/__fixtures__/json/simulator/install--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/install--success.json
@@ -9,7 +9,7 @@
     },
     "artifacts": {
       "simulatorId": "<UUID>",
-      "appPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
+      "appPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/launch-app--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/launch-app--success.json
@@ -11,8 +11,8 @@
       "simulatorId": "<UUID>",
       "bundleId": "io.sentry.calculatorapp",
       "processId": 99999,
-      "runtimeLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log",
-      "osLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log"
+      "runtimeLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log",
+      "osLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--error-compiler.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",
@@ -22,7 +22,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--error-wrong-scheme.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--error-wrong-scheme.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "NONEXISTENT",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",
@@ -20,7 +20,7 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--failure.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",
@@ -25,8 +25,8 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "discovered": {

--- a/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/simulator/test--success.json
@@ -7,7 +7,7 @@
     "request": {
       "scheme": "CalculatorApp",
       "workspacePath": "example_projects/iOS_Calculator/CalculatorApp.xcworkspace",
-      "derivedDataPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
+      "derivedDataPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>",
       "configuration": "Debug",
       "platform": "iOS Simulator",
       "simulatorName": "iPhone 17",
@@ -27,8 +27,8 @@
       "target": "simulator"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
-      "xcresultPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log",
+      "xcresultPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult"
     },
     "tests": {
       "selected": [

--- a/src/snapshot-tests/__fixtures__/json/swift-package/build--error-bad-path.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/build--error-bad-path.json
@@ -15,7 +15,7 @@
     },
     "artifacts": {
       "packagePath": "<ROOT>/example_projects/NONEXISTENT",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/swift-package/build--success.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/build--success.json
@@ -15,7 +15,7 @@
     },
     "artifacts": {
       "packagePath": "<ROOT>/example_projects/spm",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/swift-package/run--error-bad-executable.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/run--error-bad-executable.json
@@ -16,7 +16,7 @@
     },
     "artifacts": {
       "packagePath": "<ROOT>/example_projects/spm",
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/swift-package/run--success.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/run--success.json
@@ -18,7 +18,7 @@
       "packagePath": "<ROOT>/example_projects/spm",
       "executablePath": "<ROOT>/example_projects/spm/.build/arm64-apple-macosx/debug/spm",
       "processId": 99999,
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log"
     },
     "output": {
       "stdout": [
@@ -29,8 +29,8 @@
         "[0/6] Write sources",
         "[1/6] Write spm-entitlement.plist",
         "[2/6] Write swift-version--6988338F2F200930.txt",
-        "[4/8] Compiling spm main.swift",
-        "[5/8] Emitting module spm",
+        "[4/8] Emitting module spm",
+        "[5/8] Compiling spm main.swift",
         "[5/8] Write Objects.LinkFileList",
         "[6/8] Linking spm",
         "[7/8] Applying spm",

--- a/src/snapshot-tests/__fixtures__/json/swift-package/test--error-bad-path.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/test--error-bad-path.json
@@ -16,7 +16,7 @@
       "target": "swift-package"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log",
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log",
       "packagePath": "<ROOT>/example_projects/NONEXISTENT"
     },
     "diagnostics": {

--- a/src/snapshot-tests/__fixtures__/json/swift-package/test--failure.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/test--failure.json
@@ -21,7 +21,7 @@
       "target": "swift-package"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/json/swift-package/test--success.json
+++ b/src/snapshot-tests/__fixtures__/json/swift-package/test--success.json
@@ -21,7 +21,7 @@
       "target": "swift-package"
     },
     "artifacts": {
-      "buildLogPath": "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log"
+      "buildLogPath": "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log"
     },
     "diagnostics": {
       "warnings": [],

--- a/src/snapshot-tests/__fixtures__/mcp/coverage/get-coverage-report--error-invalid-bundle.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/coverage/get-coverage-report--error-invalid-bundle.txt
@@ -1,8 +1,6 @@
 
 📊 Coverage Report
 
-   xcresult: <TMPDIR>/invalid.xcresult
-
 Errors (1):
 
   ✗ Error Domain=XCCovErrorDomain Code=0 "Failed to load result bundle" UserInfo={NSLocalizedDescription=Failed to load result bundle, NSUnderlyingError=<ADDR> {Error Domain=XCResultStorage.ResultBundleFactory.Error Code=0 "Failed to create a new result bundle reader, underlying error: Info.plist at <TMPDIR>/invalid.xcresult/Info.plist does not exist, the result bundle might be corrupted or the provided path is not a result bundle"}}

--- a/src/snapshot-tests/__fixtures__/mcp/coverage/get-coverage-report--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/coverage/get-coverage-report--success.txt
@@ -1,9 +1,6 @@
 
 📊 Coverage Report
 
-   xcresult: <TMPDIR>/TestResults.xcresult
-   Target Filter: CalculatorAppTests
-
 ℹ️ Overall: 94.9% (371/391 lines)
 
 Targets

--- a/src/snapshot-tests/__fixtures__/mcp/coverage/get-file-coverage--error-invalid-bundle.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/coverage/get-file-coverage--error-invalid-bundle.txt
@@ -1,9 +1,6 @@
 
 📊 File Coverage
 
-   xcresult: <TMPDIR>/invalid.xcresult
-   File: SomeFile.swift
-
 Errors (1):
 
   ✗ Error Domain=XCCovErrorDomain Code=0 "Failed to load result bundle" UserInfo={NSLocalizedDescription=Failed to load result bundle, NSUnderlyingError=<ADDR> {Error Domain=XCResultStorage.ResultBundleFactory.Error Code=0 "Failed to create a new result bundle reader, underlying error: Info.plist at <TMPDIR>/invalid.xcresult/Info.plist does not exist, the result bundle might be corrupted or the provided path is not a result bundle"}}

--- a/src/snapshot-tests/__fixtures__/mcp/coverage/get-file-coverage--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/coverage/get-file-coverage--success.txt
@@ -1,9 +1,6 @@
 
 📊 File Coverage
 
-   xcresult: <TMPDIR>/TestResults.xcresult
-   File: CalculatorService.swift
-
 File: example_projects/iOS_Calculator/CalculatorAppPackage/Sources/CalculatorAppFeature/CalculatorService.swift
 
 ℹ️ Coverage: 83.1% (157/189 lines)

--- a/src/snapshot-tests/__fixtures__/mcp/debugging/lldb-command--error-no-session.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/debugging/lldb-command--error-no-session.txt
@@ -1,8 +1,6 @@
 
 🐛 LLDB Command
 
-   Command: bt
-
 Errors (1):
 
   ✗ No active debug session. Provide debugSessionId or attach first.

--- a/src/snapshot-tests/__fixtures__/mcp/debugging/lldb-command--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/debugging/lldb-command--success.txt
@@ -1,8 +1,6 @@
 
 🐛 LLDB Command
 
-   Command: breakpoint list
-
 ✅ Command executed
 
 Output:

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--error-compiler.txt
@@ -1,16 +1,11 @@
 
 🔨 Build
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--error-wrong-scheme.txt
@@ -1,15 +1,10 @@
 
 🔨 Build
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/device/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build--success.txt
@@ -1,14 +1,9 @@
 
 🔨 Build
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_device_<TIMESTAMP>_pid<PID>.log — Build Logs
 
 Next steps:
 1. Get built device app path: get_device_app_path({ scheme: "CalculatorApp" })

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-compiler.txt
@@ -1,17 +1,11 @@
 
 🚀 Build & Run
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--error-wrong-scheme.txt
@@ -1,16 +1,10 @@
 
 🚀 Build & Run
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/build-and-run--success.txt
@@ -1,13 +1,6 @@
 
 🚀 Build & Run
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 ℹ️ Resolving app path
 ✅ Resolving app path
 ℹ️ Installing app
@@ -16,10 +9,12 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app — App Path
+         └── logs/build_run_device_<TIMESTAMP>_pid<PID>.log — Build Logs
 
 Next steps:
 1. Stop app on device: stop_app_device({ deviceId: "<UUID>", processId: <PID> })

--- a/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--error-wrong-scheme.txt
@@ -1,11 +1,6 @@
 
 🔍 Get App Path
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.

--- a/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/get-app-path--success.txt
@@ -1,15 +1,11 @@
 
 🔍 Get App Path
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app — App Path
 
 Next steps:
-1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
-2. Install app on device: install_app_device({ deviceId: "DEVICE_UDID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
+1. Get bundle ID: get_app_bundle_id({ appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
+2. Install app on device: install_app_device({ deviceId: "DEVICE_UDID", appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app" })
 3. Launch app on device: launch_app_device({ deviceId: "DEVICE_UDID", bundleId: "BUNDLE_ID" })

--- a/src/snapshot-tests/__fixtures__/mcp/device/install--error-invalid-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/install--error-invalid-app.txt
@@ -1,9 +1,6 @@
 
 📦 Install App
 
-   Device: <UUID>
-   App: /tmp/nonexistent.app
-
 Errors (1):
 
   ✗ Failed to load provisioning paramter list due to error: Error Domain=com.apple.dt.CoreDeviceError Code=1002 "No provider was found." UserInfo={NSLocalizedDescription=No provider was found.}.

--- a/src/snapshot-tests/__fixtures__/mcp/device/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/install--success.txt
@@ -1,7 +1,4 @@
 
 📦 Install App
 
-   Device: <DEVICE> (<UUID>)
-   App: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphoneos/CalculatorApp.app
-
 ✅ App installed successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/device/launch--error-invalid-bundle.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/launch--error-invalid-bundle.txt
@@ -1,9 +1,6 @@
 
 🚀 Launch App
 
-   Device: <UUID>
-   Bundle ID: com.nonexistent.app
-
 Errors (1):
 
   ✗ Failed to load provisioning paramter list due to error: Error Domain=com.apple.dt.CoreDeviceError Code=1002 "No provider was found." UserInfo={NSLocalizedDescription=No provider was found.}.

--- a/src/snapshot-tests/__fixtures__/mcp/device/launch--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/launch--success.txt
@@ -1,9 +1,6 @@
 
 🚀 Launch App
 
-   Device: <DEVICE> (<UUID>)
-   Bundle ID: io.sentry.calculatorapp
-
 ✅ App launched successfully.
   └ Process ID: <PID>
 

--- a/src/snapshot-tests/__fixtures__/mcp/device/stop--error-no-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/stop--error-no-app.txt
@@ -1,9 +1,6 @@
 
 🛑 Stop App
 
-   Device: <UUID>
-   PID: <PID>
-
 Errors (1):
 
   ✗ Failed to load provisioning paramter list due to error: Error Domain=com.apple.dt.CoreDeviceError Code=1002 "No provider was found." UserInfo={NSLocalizedDescription=No provider was found.}.

--- a/src/snapshot-tests/__fixtures__/mcp/device/stop--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/stop--success.txt
@@ -1,7 +1,4 @@
 
 🛑 Stop App
 
-   Device: <DEVICE> (<UUID>)
-   PID: <PID>
-
 ✅ App stopped successfully

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--error-compiler.txt
@@ -1,15 +1,6 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-   Selective Testing:
-     CalculatorAppTests/CalculatorAppTests/testAddition
-
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -19,5 +10,7 @@ Errors (1):
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_device_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--failure.txt
@@ -1,13 +1,6 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Discovered 57 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear
    CalculatorAppFeatureTests/CalculatorBasicTests/testInitialState
@@ -26,5 +19,7 @@ Test Failures (2):
     <ROOT>/example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_device_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/device/test--success.txt
@@ -1,18 +1,11 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-   Device: <DEVICE> (<UUID>)
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-   Selective Testing:
-     CalculatorAppTests/CalculatorAppTests/testAddition
-
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_device_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_device_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_device_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--error-compiler.txt
@@ -1,16 +1,11 @@
 
 🔨 Build
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--error-wrong-scheme.txt
@@ -1,15 +1,10 @@
 
 🔨 Build
 
-   Scheme: NONEXISTENT
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build--success.txt
@@ -1,15 +1,10 @@
 
 🔨 Build
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 ✅ Build succeeded. (⏱️ <DURATION>)
   ├ Bundle ID: io.sentry.MCPTest.macOS
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
 
 Next steps:
 1. Get built macOS app path: get_mac_app_path({ scheme: "MCPTest" })

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-compiler.txt
@@ -1,16 +1,11 @@
 
 🚀 Build & Run
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--error-wrong-scheme.txt
@@ -1,15 +1,10 @@
 
 🚀 Build & Run
 
-   Scheme: NONEXISTENT
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/build-and-run--success.txt
@@ -1,12 +1,6 @@
 
 🚀 Build & Run
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 ℹ️ Resolving app path
 ✅ Resolving app path
 ℹ️ Launching app
@@ -14,10 +8,12 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
   ├ Bundle ID: io.sentry.MCPTest.macOS
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app — App Path
+         └── logs/build_run_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
 
 Next steps:
 1. Interact with the launched app in the foreground

--- a/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--error-wrong-scheme.txt
@@ -1,11 +1,6 @@
 
 🔍 Get App Path
 
-   Scheme: NONEXISTENT
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.

--- a/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/get-app-path--success.txt
@@ -1,14 +1,10 @@
 
 🔍 Get App Path
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-
 ✅ Success
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app — App Path
 
 Next steps:
-1. Get bundle ID: get_mac_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })
-2. Launch app: launch_mac_app({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })
+1. Get bundle ID: get_mac_bundle_id({ appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })
+2. Launch app: launch_mac_app({ appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app" })

--- a/src/snapshot-tests/__fixtures__/mcp/macos/get-macos-bundle-id--error-missing-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/get-macos-bundle-id--error-missing-app.txt
@@ -1,8 +1,6 @@
 
 🔍 Get macOS Bundle ID
 
-   App: /nonexistent/path/Fake.app
-
 Errors (1):
 
   ✗ File not found: '/nonexistent/path/Fake.app'. Please check the path and try again.

--- a/src/snapshot-tests/__fixtures__/mcp/macos/get-macos-bundle-id--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/get-macos-bundle-id--success.txt
@@ -1,8 +1,6 @@
 
 🔍 Get macOS Bundle ID
 
-   App: <TMPDIR>/BundleTest.app
-
 ✅ Bundle ID
   └ com.test.snapshot-macos
 

--- a/src/snapshot-tests/__fixtures__/mcp/macos/launch--error-invalid-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/launch--error-invalid-app.txt
@@ -1,8 +1,6 @@
 
 🚀 Launch macOS App
 
-   App: <TMPDIR>/NonExistent.app
-
 Errors (1):
 
   ✗ File not found: '<TMPDIR>/NonExistent.app'. Please check the path and try again.

--- a/src/snapshot-tests/__fixtures__/mcp/macos/launch--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/launch--success.txt
@@ -1,8 +1,6 @@
 
 🚀 Launch macOS App
 
-   App: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>/Build/Products/Debug/MCPTest.app
-
 ✅ App launched successfully
   ├ Bundle ID: io.sentry.MCPTest.macOS
   └ Process ID: <PID>

--- a/src/snapshot-tests/__fixtures__/mcp/macos/stop--error-no-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/stop--error-no-app.txt
@@ -1,8 +1,6 @@
 
 🛑 Stop macOS App
 
-   App: PID 999999
-
 Errors (1):
 
   ✗ kill: 999999: No such process

--- a/src/snapshot-tests/__fixtures__/mcp/macos/stop--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/stop--success.txt
@@ -1,6 +1,4 @@
 
 🛑 Stop macOS App
 
-   App: MCPTest
-
 ✅ App stopped successfully

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-compiler.txt
@@ -1,15 +1,6 @@
 
 🧪 Test
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-   Selective Testing:
-     MCPTestTests/MCPTestTests/appNameIsCorrect()
-     MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
-
 Discovered 2 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
    MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
@@ -20,5 +11,7 @@ Errors (1):
     <ROOT>/example_projects/macOS/MCPTest/MCPTestApp.swift:20
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--error-wrong-scheme.txt
@@ -1,16 +1,12 @@
 
 🧪 Test
 
-   Scheme: NONEXISTENT
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Errors (1):
 
   ✗ The project named "MCPTest" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the project.
 
 ❌ Test failed. (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--failure.txt
@@ -1,12 +1,6 @@
 
 🧪 Test
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-
 Discovered 4 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
    MCPTestTests/MCPTestTests/deliberateFailure
@@ -22,5 +16,7 @@ Test Failures (2):
     MCPTestTests.swift:11
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/macos/test--success.txt
@@ -1,19 +1,12 @@
 
 🧪 Test
 
-   Scheme: MCPTest
-   Project: example_projects/macOS/MCPTest.xcodeproj
-   Configuration: Debug
-   Platform: macOS
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/MCPTest-<HASH>
-   Selective Testing:
-     MCPTestTests/MCPTestTests/appNameIsCorrect()
-     MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
-
 Discovered 2 test(s):
    MCPTestTests/MCPTestTests/appNameIsCorrect
    MCPTestTests/MCPTestsXCTests/testAppNameIsCorrect
 
 ✅ 2 tests passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_macos_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_macos_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/discover-projs--error-invalid-root.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/discover-projs--error-invalid-root.txt
@@ -1,10 +1,6 @@
 
 🔍 Discover Projects
 
-   Workspace root: /nonexistent/path/Fake.app
-   Scan path: /nonexistent/path
-   Max depth: 3
-
 Errors (1):
 
   ✗ Failed to access scan path: /nonexistent/path. Error: ENOENT: no such file or directory, stat '/nonexistent/path'

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/discover-projs--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/discover-projs--success.txt
@@ -1,10 +1,6 @@
 
 🔍 Discover Projects
 
-   Workspace root: <PATH>
-   Scan path: <PATH>
-   Max depth: 3
-
 ✅ Found 1 project and 1 workspace
 
 Projects:

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-app-bundle-id--error-missing-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-app-bundle-id--error-missing-app.txt
@@ -1,8 +1,6 @@
 
 🔍 Get Bundle ID
 
-   App: /nonexistent/path/Fake.app
-
 Errors (1):
 
   ✗ File not found: '/nonexistent/path/Fake.app'. Please check the path and try again.

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-app-bundle-id--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-app-bundle-id--success.txt
@@ -1,8 +1,6 @@
 
 🔍 Get Bundle ID
 
-   App: <TMPDIR>/BundleTest.app
-
 ✅ Bundle ID
   └ com.test.snapshot
 

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-macos-bundle-id--error-missing-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-macos-bundle-id--error-missing-app.txt
@@ -1,8 +1,6 @@
 
 🔍 Get macOS Bundle ID
 
-   App: /nonexistent/path/Fake.app
-
 Errors (1):
 
   ✗ File not found: '/nonexistent/path/Fake.app'. Please check the path and try again.

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-macos-bundle-id--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/get-macos-bundle-id--success.txt
@@ -1,8 +1,6 @@
 
 🔍 Get macOS Bundle ID
 
-   App: <TMPDIR>/BundleTest.app
-
 ✅ Bundle ID
   └ com.test.snapshot
 

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/list-schemes--error-invalid-workspace.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/list-schemes--error-invalid-workspace.txt
@@ -1,8 +1,6 @@
 
 🔍 List Schemes
 
-   Workspace: /nonexistent/path/Fake.xcworkspace
-
 Errors (1):
 
   ✗ '/nonexistent/path/Fake.xcworkspace' does not exist.

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/list-schemes--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/list-schemes--success.txt
@@ -1,8 +1,6 @@
 
 🔍 List Schemes
 
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-
 ✅ Found 2 schemes
 
 Schemes:

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/show-build-settings--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/show-build-settings--error-wrong-scheme.txt
@@ -1,9 +1,6 @@
 
 🔍 Show Build Settings
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.

--- a/src/snapshot-tests/__fixtures__/mcp/project-discovery/show-build-settings--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-discovery/show-build-settings--success.txt
@@ -1,9 +1,6 @@
 
 🔍 Show Build Settings
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-
 ✅ Build settings retrieved
 
 Settings

--- a/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-ios--error-existing.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-ios--error-existing.txt
@@ -1,10 +1,6 @@
 
 📝 Scaffold iOS Project
 
-   Name: SnapshotTestApp
-   Path: <TMPDIR>/ios-existing
-   Platform: iOS
-
 Errors (1):
 
   ✗ Xcode project files already exist in <TMPDIR>/ios-existing

--- a/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-ios--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-ios--success.txt
@@ -1,10 +1,6 @@
 
 📝 Scaffold iOS Project
 
-   Name: SnapshotTestApp
-   Path: <TMPDIR>/ios
-   Platform: iOS
-
 ✅ Project scaffolded successfully
   └ <TMPDIR>/ios
 

--- a/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-macos--error-existing.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-macos--error-existing.txt
@@ -1,10 +1,6 @@
 
 📝 Scaffold macOS Project
 
-   Name: SnapshotTestMacApp
-   Path: <TMPDIR>/macos-existing
-   Platform: macOS
-
 Errors (1):
 
   ✗ Xcode project files already exist in <TMPDIR>/macos-existing

--- a/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-macos--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/project-scaffolding/scaffold-macos--success.txt
@@ -1,10 +1,6 @@
 
 📝 Scaffold macOS Project
 
-   Name: SnapshotTestMacApp
-   Path: <TMPDIR>/macos
-   Platform: macOS
-
 ✅ Project scaffolded successfully
   └ <TMPDIR>/macos
 

--- a/src/snapshot-tests/__fixtures__/mcp/resources/doctor--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/resources/doctor--success.txt
@@ -36,6 +36,7 @@ Process Tree
    <PID> (ppid <PID>): <PROCESS>
    <PID> (ppid <PID>): <PROCESS>
    <PID> (ppid <PID>): <PROCESS>
+   <PID> (ppid <PID>): <PROCESS>
 
 Xcode Information
   version: <XCODE_VERSION>

--- a/src/snapshot-tests/__fixtures__/mcp/session-management/session-clear-defaults--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/session-management/session-clear-defaults--success.txt
@@ -1,6 +1,4 @@
 
 ⚙️ Clear Defaults
 
-   Profile: (default)
-
 ✅ Session defaults cleared (default profile)

--- a/src/snapshot-tests/__fixtures__/mcp/session-management/session-set-defaults--scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/session-management/session-set-defaults--scheme.txt
@@ -1,9 +1,6 @@
 
 ⚙️ Set Defaults
 
-   Scheme: CalculatorApp
-   Profile: (default)
-
 ✅ Session defaults updated (default profile)
   ├ projectPath: (not set)
   ├ workspacePath: (not set)

--- a/src/snapshot-tests/__fixtures__/mcp/session-management/session-set-defaults--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/session-management/session-set-defaults--success.txt
@@ -1,10 +1,6 @@
 
 ⚙️ Set Defaults
 
-   Workspace Path: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Scheme: CalculatorApp
-   Profile: (default)
-
 ✅ Session defaults updated (default profile)
   ├ projectPath: (not set)
   ├ workspacePath: example_projects/iOS_Calculator/CalculatorApp.xcworkspace

--- a/src/snapshot-tests/__fixtures__/mcp/session-management/session-use-defaults-profile--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/session-management/session-use-defaults-profile--success.txt
@@ -1,6 +1,4 @@
 
 ⚙️ Use Defaults Profile
 
-   Current profile: (default)
-
 ✅ Activated profile (MyCustomProfile profile)

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/boot--error-invalid-id.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/boot--error-invalid-id.txt
@@ -1,8 +1,6 @@
 
 📱 Boot Simulator
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Invalid device or device pair: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/boot--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/boot--success.txt
@@ -1,8 +1,6 @@
 
 📱 Boot Simulator
 
-   Simulator: <UUID>
-
 ✅ Simulator booted successfully
 
 Next steps:

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/erase--error-invalid-id.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/erase--error-invalid-id.txt
@@ -1,8 +1,6 @@
 
 🗑 Erase Simulator
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/erase--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/erase--success.txt
@@ -1,6 +1,4 @@
 
 🗑 Erase Simulator
 
-   Simulator: <UUID>
-
 ✅ Simulators were erased successfully

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/reset-location--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/reset-location--error-invalid-simulator.txt
@@ -1,8 +1,6 @@
 
 📍 Reset Location
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/reset-location--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/reset-location--success.txt
@@ -1,6 +1,4 @@
 
 📍 Reset Location
 
-   Simulator: <UUID>
-
 ✅ Location successfully reset to default

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-appearance--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-appearance--error-invalid-simulator.txt
@@ -1,9 +1,6 @@
 
 🎨 Set Appearance
 
-   Simulator: <UUID>
-   Mode: dark
-
 Errors (1):
 
   ✗ Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-appearance--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-appearance--success.txt
@@ -1,7 +1,4 @@
 
 🎨 Set Appearance
 
-   Simulator: <UUID>
-   Mode: dark
-
 ✅ Appearance successfully set to dark mode

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-location--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-location--error-invalid-simulator.txt
@@ -1,9 +1,6 @@
 
 📍 Set Location
 
-   Simulator: <UUID>
-   Coordinates: 37.7749,-122.4194
-
 Errors (1):
 
   ✗ Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-location--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/set-location--success.txt
@@ -1,7 +1,4 @@
 
 📍 Set Location
 
-   Simulator: <UUID>
-   Coordinates: 37.7749,-122.4194
-
 ✅ Location set successfully

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/statusbar--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/statusbar--error-invalid-simulator.txt
@@ -1,9 +1,6 @@
 
 📱 Statusbar
 
-   Simulator: <UUID>
-   Data Network: wifi
-
 Errors (1):
 
   ✗ Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/statusbar--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/statusbar--success.txt
@@ -1,7 +1,4 @@
 
 📱 Statusbar
 
-   Simulator: <UUID>
-   Data Network: wifi
-
 ✅ Status bar data network set successfully

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-connect-hardware-keyboard--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-connect-hardware-keyboard--error-invalid-simulator.txt
@@ -1,8 +1,6 @@
 
 ⚙️ Toggle Connect Hardware Keyboard
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Simulator <UUID> not found. Use list_sims to see available simulators.

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-connect-hardware-keyboard--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-connect-hardware-keyboard--success.txt
@@ -1,6 +1,4 @@
 
 ⚙️ Toggle Connect Hardware Keyboard
 
-   Simulator: <UUID>
-
 ✅ Sent Connect Hardware Keyboard (Cmd+Shift+K)

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-software-keyboard--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-software-keyboard--error-invalid-simulator.txt
@@ -1,8 +1,6 @@
 
 ⚙️ Toggle Software Keyboard
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Simulator <UUID> not found. Use list_sims to see available simulators.

--- a/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-software-keyboard--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator-management/toggle-software-keyboard--success.txt
@@ -1,6 +1,4 @@
 
 ⚙️ Toggle Software Keyboard
 
-   Simulator: <UUID>
-
 ✅ Sent Toggle Software Keyboard (Cmd+K)

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-compiler.txt
@@ -1,17 +1,11 @@
 
 🔨 Build
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--error-wrong-scheme.txt
@@ -1,16 +1,10 @@
 
 🔨 Build
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build--success.txt
@@ -1,15 +1,9 @@
 
 🔨 Build
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log — Build Logs
 
 Next steps:
 1. Get built app path in simulator derived data: get_sim_app_path({ simulatorName: "iPhone 17", scheme: "CalculatorApp", platform: "iOS Simulator" })

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-compiler.txt
@@ -1,17 +1,11 @@
 
 🚀 Build & Run
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ cannot convert value of type 'String' to specified type 'Int'
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--error-wrong-scheme.txt
@@ -1,16 +1,10 @@
 
 🚀 Build & Run
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/build-and-run--success.txt
@@ -1,13 +1,6 @@
 
 🚀 Build & Run
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 ℹ️ Resolving app path
 ✅ Resolving app path
 ℹ️ Booting simulator
@@ -18,12 +11,15 @@
 
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
   ├ Bundle ID: io.sentry.calculatorapp
   ├ Process ID: <PID>
-  ├ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_sim_<TIMESTAMP>_pid<PID>.log
-  ├ Runtime Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
-  └ OSLog: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app — App Path
+         └── logs/
+             ├── build_run_sim_<TIMESTAMP>_pid<PID>.log — Build Logs
+             ├── io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log — Runtime Logs
+             └── io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log — OSLog
 
 Next steps:
 1. Stop app in simulator: stop_app_sim({ simulatorId: "<UUID>", bundleId: "io.sentry.calculatorapp" })

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--error-wrong-scheme.txt
@@ -1,12 +1,6 @@
 
 🔍 Get App Path
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/get-app-path--success.txt
@@ -1,17 +1,12 @@
 
 🔍 Get App Path
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-
 ✅ Get app path successful (⏱️ <DURATION>)
-  └ App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app — App Path
 
 Next steps:
-1. Get bundle ID: get_app_bundle_id({ appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
+1. Get bundle ID: get_app_bundle_id({ appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
 2. Boot simulator: boot_sim({ simulatorId: "SIMULATOR_UUID" })
-3. Install app: install_app_sim({ simulatorId: "SIMULATOR_UUID", appPath: "<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
+3. Install app: install_app_sim({ simulatorId: "SIMULATOR_UUID", appPath: "~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app" })
 4. Launch app: launch_app_sim({ simulatorId: "SIMULATOR_UUID", bundleId: "BUNDLE_ID" })

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/install--error-invalid-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/install--error-invalid-app.txt
@@ -1,9 +1,6 @@
 
 📦 Install App
 
-   Simulator: <UUID>
-   App Path: <TMPDIR>/NotAnApp.app
-
 Errors (1):
 
   ✗ An error was encountered processing the command (domain=IXErrorDomain, code=13):

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/install--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/install--success.txt
@@ -1,9 +1,6 @@
 
 📦 Install App
 
-   Simulator: <UUID>
-   App Path: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>/Build/Products/Debug-iphonesimulator/CalculatorApp.app
-
 ✅ App installed successfully
 
 Next steps:

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/launch-app--error-not-installed.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/launch-app--error-not-installed.txt
@@ -1,9 +1,6 @@
 
 🚀 Launch App
 
-   Simulator: <UUID>
-   Bundle ID: com.nonexistent.app
-
 Errors (1):
 
   ✗ App is not installed on the simulator. Please use install_app_sim before launching. Workflow: build -> install -> launch.

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/launch-app--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/launch-app--success.txt
@@ -1,13 +1,12 @@
 
 🚀 Launch App
 
-   Simulator: <UUID>
-   Bundle ID: io.sentry.calculatorapp
-
 ✅ App launched successfully
   ├ Process ID: <PID>
-  ├ Runtime Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log
-  └ OSLog: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/
+         ├── io.sentry.calculatorapp_<TIMESTAMP>_pid<PID>.log — Runtime Logs
+         └── io.sentry.calculatorapp_oslog_<TIMESTAMP>_pid<PID>.log — OSLog
 
 Next steps:
 1. Open Simulator app to see it: open_sim()

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/screenshot--error-invalid-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/screenshot--error-invalid-simulator.txt
@@ -1,8 +1,6 @@
 
 📷 Screenshot
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ Failed to capture screenshot: Invalid device: <UUID>

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/screenshot--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/screenshot--success.txt
@@ -1,9 +1,8 @@
 
 📷 Screenshot
 
-   Simulator: <UUID>
-
 ✅ Screenshot captured
-  ├ Screenshot: <TMPDIR>
   ├ Format: image/jpeg
-  └ Size: 368x800px
+  ├ Size: 368x800px
+  └ Files:
+     └── <TMPDIR> — Screenshot

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/stop--error-no-app.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/stop--error-no-app.txt
@@ -1,9 +1,6 @@
 
 🛑 Stop App
 
-   Simulator: <UUID>
-   Bundle ID: com.nonexistent.app
-
 Errors (1):
 
   ✗ An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=3):

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/stop--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/stop--success.txt
@@ -1,7 +1,4 @@
 
 🛑 Stop App
 
-   Simulator: <UUID>
-   Bundle ID: io.sentry.calculatorapp
-
 ✅ App stopped successfully

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-compiler.txt
@@ -1,15 +1,6 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-   Selective Testing:
-     CalculatorAppTests/CalculatorAppTests/testAddition
-
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
@@ -19,4 +10,5 @@ Errors (1):
     <ROOT>/example_projects/iOS_Calculator/CalculatorApp/CalculatorApp.swift:33
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--error-wrong-scheme.txt
@@ -1,16 +1,10 @@
 
 🧪 Test
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Errors (1):
 
   ✗ The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--failure.txt
@@ -1,13 +1,6 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-
 Discovered 57 test(s):
    CalculatorAppFeatureTests/CalculatorBasicTests/testClear
    CalculatorAppFeatureTests/CalculatorBasicTests/testInitialState
@@ -31,5 +24,7 @@ Test Failures (3):
     <ROOT>/example_projects/iOS_Calculator/CalculatorAppTests/CalculatorAppTests.swift:286
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_sim_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/simulator/test--success.txt
@@ -1,18 +1,11 @@
 
 🧪 Test
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS Simulator
-   Simulator: iPhone 17
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>
-   Selective Testing:
-     CalculatorAppTests/CalculatorAppTests/testAddition
-
 Discovered 1 test(s):
    CalculatorAppTests/CalculatorAppTests/testAddition
 
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  ├ Result Bundle: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/test_sim_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/
+         ├── logs/test_sim_<TIMESTAMP>_pid<PID>.log — Build Logs
+         └── result-bundles/test_sim_<TIMESTAMP>_pid<PID>.xcresult — Result Bundle

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/build--error-bad-path.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/build--error-bad-path.txt
@@ -1,11 +1,10 @@
 
 📦 Swift Package Build
 
-   Package: <ROOT>/example_projects/NONEXISTENT
-
 Errors (1):
 
   ✗ chdir error: No such file or directory (2): <ROOT>/example_projects/NONEXISTENT
 
 ❌ Build failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/build--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/build--success.txt
@@ -1,7 +1,6 @@
 
 📦 Swift Package Build
 
-   Package: <ROOT>/example_projects/spm
-
 ✅ Build succeeded. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_spm_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/clean--error-bad-path.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/clean--error-bad-path.txt
@@ -1,8 +1,6 @@
 
 🧹 Swift Package Clean
 
-   Package: <ROOT>/example_projects/NONEXISTENT
-
 Errors (1):
 
   ✗ chdir error: No such file or directory (2): <ROOT>/example_projects/NONEXISTENT

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/clean--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/clean--success.txt
@@ -1,6 +1,4 @@
 
 🧹 Swift Package Clean
 
-   Package: <ROOT>/example_projects/spm
-
 ✅ Swift package cleaned successfully

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/run--error-bad-executable.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/run--error-bad-executable.txt
@@ -1,9 +1,6 @@
 
 🚀 Swift Package Run
 
-   Package: <ROOT>/example_projects/spm
-   Executable: nonexistent-executable
-
 Errors (1):
 
   ✗ no executable product named 'nonexistent-executable'

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/run--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/run--success.txt
@@ -1,14 +1,12 @@
 
 🚀 Swift Package Run
 
-   Package: <ROOT>/example_projects/spm
-   Executable: spm
-
 ✅ Build succeeded. (⏱️ <DURATION>)
 ✅ Build & Run complete
-  ├ App Path: example_projects/spm/.build/arm64-apple-macosx/debug/spm
   ├ Process ID: <PID>
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     ├── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build_run_spm_<TIMESTAMP>_pid<PID>.log — Build Logs
+     └── example_projects/spm/.build/arm64-apple-macosx/debug/spm — App Path
 
 Output
   Hello, world!

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/stop--error-no-process.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/stop--error-no-process.txt
@@ -1,8 +1,6 @@
 
 🛑 Swift Package Stop
 
-   PID: <PID>
-
 Errors (1):
 
   ✗ No running process found with PID 999999. Use swift_package_list to check active processes.

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/test--error-bad-path.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/test--error-bad-path.txt
@@ -1,14 +1,10 @@
 
 🧪 Swift Package Test
 
-   Scheme: NONEXISTENT
-   Configuration: debug
-   Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
-
 Errors (1):
 
   ✗ chdir error: No such file or directory (2): <ROOT>/example_projects/NONEXISTENT
 
 ❌ Test failed. (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/test--failure.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/test--failure.txt
@@ -1,11 +1,6 @@
 
 🧪 Swift Package Test
 
-   Scheme: spm
-   Configuration: debug
-   Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
-
 Test Failures (2):
 
   ✗ CalculatorAppTests / testCalculatorServiceFailure: XCTAssertEqual failed: ("0") is not equal to ("999") - This test should fail - display should be 0, not 999
@@ -16,4 +11,5 @@ Test Failures (2):
     SimpleTests.swift:57
 
 ❌ <FAIL_COUNT> tests failed, <PASS_COUNT> passed, <SKIP_COUNT> skipped (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/swift-package/test--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/swift-package/test--success.txt
@@ -1,10 +1,6 @@
 
 🧪 Swift Package Test
 
-   Scheme: spm
-   Configuration: debug
-   Platform: Swift Package
-   Derived Data: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData
-
 ✅ 1 test passed, 0 failed, 0 skipped (⏱️ <DURATION>)
-  └ Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/swift_package_test_<TIMESTAMP>_pid<PID>.log — Build Logs

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/button--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/button--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Button
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/button--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/button--success.txt
@@ -1,6 +1,4 @@
 
 👆 Button
 
-   Simulator: <UUID>
-
 ✅ Hardware button 'home' pressed successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/gesture--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/gesture--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Gesture
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/gesture--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/gesture--success.txt
@@ -1,6 +1,4 @@
 
 👆 Gesture
 
-   Simulator: <UUID>
-
 ✅ Gesture 'scroll-down' executed successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-press--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-press--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 ⌨️ Key Press
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-press--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-press--success.txt
@@ -1,6 +1,4 @@
 
 ⌨️ Key Press
 
-   Simulator: <UUID>
-
 ✅ Key press (code: 4) simulated successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-sequence--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-sequence--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 ⌨️ Key Sequence
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-sequence--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/key-sequence--success.txt
@@ -1,6 +1,4 @@
 
 ⌨️ Key Sequence
 
-   Simulator: <UUID>
-
 ✅ Key sequence [4,5,6] executed successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/long-press--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/long-press--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Long Press
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/long-press--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/long-press--success.txt
@@ -1,8 +1,6 @@
 
 👆 Long Press
 
-   Simulator: <UUID>
-
 Warnings (1):
 
   ⚠ snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/snapshot-ui--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/snapshot-ui--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 📷 Snapshot UI
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/snapshot-ui--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/snapshot-ui--success.txt
@@ -1,8 +1,6 @@
 
 📷 Snapshot UI
 
-   Simulator: <UUID>
-
 Accessibility Hierarchy
   ```json
   [

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/swipe--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/swipe--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Swipe
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/swipe--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/swipe--success.txt
@@ -1,8 +1,6 @@
 
 👆 Swipe
 
-   Simulator: <UUID>
-
 Warnings (1):
 
   ⚠ snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/tap--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/tap--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Tap
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/tap--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/tap--success.txt
@@ -1,8 +1,6 @@
 
 👆 Tap
 
-   Simulator: <UUID>
-
 Warnings (1):
 
   ⚠ snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/touch--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/touch--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 👆 Touch
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/touch--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/touch--success.txt
@@ -1,8 +1,6 @@
 
 👆 Touch
 
-   Simulator: <UUID>
-
 Warnings (1):
 
   ⚠ snapshot_ui has not been called yet. Consider using snapshot_ui for precise coordinates instead of guessing from screenshots.

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/type-text--error-no-simulator.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/type-text--error-no-simulator.txt
@@ -1,8 +1,6 @@
 
 ⌨️ Type Text
 
-   Simulator: <UUID>
-
 Errors (1):
 
   ✗ CLIError(errorDescription: "Simulator with UDID <UUID> not found in set.")

--- a/src/snapshot-tests/__fixtures__/mcp/ui-automation/type-text--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/ui-automation/type-text--success.txt
@@ -1,6 +1,4 @@
 
 ⌨️ Type Text
 
-   Simulator: <UUID>
-
 ✅ Text typing simulated successfully.

--- a/src/snapshot-tests/__fixtures__/mcp/utilities/clean--error-wrong-scheme.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/utilities/clean--error-wrong-scheme.txt
@@ -1,11 +1,6 @@
 
 🧹 Clean
 
-   Scheme: NONEXISTENT
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-
 Errors (1):
 
   ✗ xcodebuild: error: The workspace named "CalculatorApp" does not contain a scheme named "NONEXISTENT". The "-list" option can be used to find the names of the schemes in the workspace.

--- a/src/snapshot-tests/__fixtures__/mcp/utilities/clean--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/utilities/clean--success.txt
@@ -1,9 +1,4 @@
 
 🧹 Clean
 
-   Scheme: CalculatorApp
-   Workspace: example_projects/iOS_Calculator/CalculatorApp.xcworkspace
-   Configuration: Debug
-   Platform: iOS
-
 ✅ Clean successful

--- a/src/snapshot-tests/__fixtures__/mcp/xcode-ide/documentation-search--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/xcode-ide/documentation-search--success.txt
@@ -1,7 +1,6 @@
 
 🔧 Xcode IDE Call Tool
 
-   Remote Tool: DocumentationSearch
-
 ✅ Tool "DocumentationSearch" completed successfully. Raw response saved to artifact.
-  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/state/xcode-ide/call-tool/ownerpid<PID>_<UUID>/<TIMESTAMP>-DocumentationSearch-<HASH>.json — Raw Response JSON

--- a/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
+++ b/src/snapshot-tests/__fixtures__/mcp/xcode-ide/list-tools--success.txt
@@ -2,4 +2,5 @@
 🔧 Xcode IDE List Tools
 
 ✅ Found <XCODE_IDE_TOOL_COUNT> tool(s). Raw response saved to artifact.
-  └ Raw Response JSON: <RAW_RESPONSE_JSON_PATH>
+  └ Files:
+     └── ~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/state/xcode-ide/call-tool/ownerpid<PID>_<UUID>/<TIMESTAMP>-list-tools-<HASH>.json — Raw Response JSON

--- a/src/snapshot-tests/__tests__/normalize.test.ts
+++ b/src/snapshot-tests/__tests__/normalize.test.ts
@@ -10,6 +10,50 @@ function progressBlock(total: number, failed: number): string {
 }
 
 describe('normalizeSnapshotOutput', () => {
+  it('preserves display-formatted home paths while normalizing workspace hashes', () => {
+    expect(
+      normalizeSnapshotOutput(
+        '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-c5da0cbe19a7/logs/build.log\n',
+      ),
+    ).toBe('~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build.log\n');
+  });
+
+  it('normalizes absolute home XcodeBuildMCP paths to ~/', () => {
+    expect(
+      normalizeSnapshotOutput(
+        '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-c5da0cbe19a7/logs/build.log\n',
+      ),
+    ).toBe('~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/logs/build.log\n');
+  });
+
+  it('normalizes workspace hash and derived data hash together', () => {
+    expect(
+      normalizeSnapshotOutput(
+        '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-c5da0cbe19a7/DerivedData/CalculatorApp-7834e7689e33\n',
+      ),
+    ).toBe(
+      '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData/CalculatorApp-<HASH>\n',
+    );
+  });
+
+  it('normalizes workspace root nodes with trailing slash', () => {
+    expect(
+      normalizeSnapshotOutput(
+        '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-c5da0cbe19a7/\n',
+      ),
+    ).toBe('~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/\n');
+  });
+
+  it('normalizes xcode-ide raw response artifact path volatility', () => {
+    expect(
+      normalizeSnapshotOutput(
+        '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-c5da0cbe19a7/state/xcode-ide/call-tool/ownerpid22817_6DDCB226-377E-4F3F-93D4-3CA386249E80/2026-05-07T17-21-14-001Z-list-tools-44fa9782.json — Raw Response JSON\n',
+      ),
+    ).toBe(
+      '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/state/xcode-ide/call-tool/ownerpid<PID>_<UUID>/<TIMESTAMP>-list-tools-<HASH>.json — Raw Response JSON\n',
+    );
+  });
+
   it('collapses long simulator failure progress streams while preserving final counts', () => {
     const normalized = normalizeSnapshotOutput(`${progressBlock(42, 3)}\n`);
 

--- a/src/snapshot-tests/normalize.ts
+++ b/src/snapshot-tests/normalize.ts
@@ -41,6 +41,12 @@ const TARGET_DEVICE_IDENTIFIER_REGEX = /(TARGET_DEVICE_IDENTIFIER = )([0-9A-Fa-f
 const CODEX_ARG0_PATH_REGEX = /<HOME>\/\.codex\/tmp\/arg0\/codex-arg0[A-Za-z0-9]+/g;
 const CODEX_WORKTREE_NODE_MODULES_REGEX =
   /<HOME>\/\.codex\/worktrees\/[^/:]+\/node_modules\/\.bin/g;
+const XCODEBUILDMCP_HOME_PREFIX_REGEX = /<HOME>(?=\/Library\/Developer\/XcodeBuildMCP(?:\/|$))/g;
+const XCODEBUILDMCP_WORKSPACE_KEY_REGEX =
+  /(~\/Library\/Developer\/XcodeBuildMCP\/workspaces\/[^/\n]+)-[0-9a-f]{12}(?=\/|$)/g;
+const XCODE_IDE_ARTIFACT_OWNER_PID_REGEX = /(\/state\/xcode-ide\/call-tool\/ownerpid)\d+_/g;
+const XCODE_IDE_ARTIFACT_HASH_REGEX =
+  /(\/state\/xcode-ide\/call-tool\/[^/\n]+\/[^/\n]+-)[0-9a-f]{8}(?=\.json)/g;
 const ACQUIRED_USAGE_ASSERTION_TIME_REGEX =
   /(^\s*)\d{2}:\d{2}:\d{2}( {2}Acquired usage assertion\.)$/gm;
 const BUILD_SETTINGS_PATH_REGEX = /^( {6}PATH = ).+$/gm;
@@ -111,8 +117,6 @@ export function normalizeSnapshotOutput(text: string): string {
 
   const home = os.homedir();
   normalized = normalized.replace(new RegExp(escapeRegex(home), 'g'), '<HOME>');
-  normalized = normalized.replace(/~\//g, '<HOME>/');
-  normalized = normalized.replace(/(?<=\s|:)~(?=\s|$)/gm, '<HOME>');
 
   const username = os.userInfo().username;
   normalized = normalized.replace(
@@ -129,17 +133,13 @@ export function normalizeSnapshotOutput(text: string): string {
     new RegExp(escapeRegex(tmpDir) + '/[A-Za-z0-9._-]+(?=/|[^A-Za-z0-9._/-]|$)', 'g'),
     '<TMPDIR>',
   );
+  normalized = normalized.replace(XCODEBUILDMCP_HOME_PREFIX_REGEX, '~');
+  normalized = normalized.replace(XCODEBUILDMCP_WORKSPACE_KEY_REGEX, '$1-<HASH>');
+  normalized = normalized.replace(XCODE_IDE_ARTIFACT_OWNER_PID_REGEX, '$1<PID>_');
+  normalized = normalized.replace(XCODE_IDE_ARTIFACT_HASH_REGEX, '$1<HASH>');
   normalized = normalized.replace(
-    /(<HOME>\/Library\/Developer\/XcodeBuildMCP\/workspaces\/[^/]+)-[0-9a-f]{12}(?=\/(?:logs|result-bundles)\/)/g,
-    '$1-<HASH>',
-  );
-  normalized = normalized.replace(
-    /(<HOME>\/Library\/Developer\/XcodeBuildMCP\/workspaces\/[^/]+)-[0-9a-f]{12}\/DerivedData(?=$|[^A-Za-z0-9])/g,
-    '$1-<HASH>/DerivedData',
-  );
-  normalized = normalized.replace(
-    /(Build Logs: )(?:<TMPDIR>|<HOME>\/Library\/Developer\/XcodeBuildMCP)\/logs\//g,
-    '$1<HOME>/Library/Developer/XcodeBuildMCP/logs/',
+    /(Build Logs: )(?:<TMPDIR>|~\/Library\/Developer\/XcodeBuildMCP)\/logs\//g,
+    '$1~/Library/Developer/XcodeBuildMCP/logs/',
   );
   normalized = normalized.replace(
     /Raw Response JSON: .+\/xcode-ide\/call-tool\/.+\/[A-Za-z0-9._-]+\.json/g,

--- a/src/snapshot-tests/suites/xcode-ide-suite.ts
+++ b/src/snapshot-tests/suites/xcode-ide-suite.ts
@@ -34,8 +34,13 @@ function getArtifactPathFromEnvelope(result: SnapshotResult): string | null {
 }
 
 function getArtifactPathFromText(result: SnapshotResult): string | null {
-  const match = result.rawText.match(/Raw Response JSON:\s*(.+)$/m);
-  return match?.[1]?.trim() ?? null;
+  const flatMatch = result.rawText.match(/Raw Response JSON:\s*(.+)$/m);
+  if (flatMatch?.[1]) {
+    return flatMatch[1].trim();
+  }
+
+  const treeMatch = result.rawText.match(/^\s*[├└]──\s*(.+?)\s+—\s+Raw Response JSON$/m);
+  return treeMatch?.[1]?.trim() ?? null;
 }
 
 function resolveArtifactPath(artifactDisplayPath: string): string {

--- a/src/utils/__tests__/config-store.test.ts
+++ b/src/utils/__tests__/config-store.test.ts
@@ -41,6 +41,7 @@ describe('config-store', () => {
     expect(config.dapRequestTimeoutMs).toBe(30000);
     expect(config.dapLogEvents).toBe(false);
     expect(config.launchJsonWaitMs).toBe(8000);
+    expect(config.filePathRenderStyle).toBeUndefined();
   });
 
   it('parses env values when provided', async () => {
@@ -54,6 +55,7 @@ describe('config-store', () => {
       XCODEBUILDMCP_ENABLED_WORKFLOWS: 'simulator,logging',
       XCODEBUILDMCP_UI_DEBUGGER_GUARD_MODE: 'warn',
       XCODEBUILDMCP_DEBUGGER_BACKEND: 'lldb',
+      XCODEBUILDMCP_FILE_PATH_RENDER_STYLE: 'list',
     };
 
     await initConfigStore({ cwd, fs: createFs(), env });
@@ -68,25 +70,43 @@ describe('config-store', () => {
     expect(config.enabledWorkflows).toEqual(['simulator', 'logging']);
     expect(config.uiDebuggerGuardMode).toBe('warn');
     expect(config.debuggerBackend).toBe('lldb-cli');
+    expect(config.filePathRenderStyle).toBe('list');
   });
 
   it('prefers overrides over config file values and config over env', async () => {
-    const yaml = ['schemaVersion: 1', 'debug: false', 'dapRequestTimeoutMs: 4000', ''].join('\n');
+    const yaml = [
+      'schemaVersion: 1',
+      'debug: false',
+      'dapRequestTimeoutMs: 4000',
+      'filePathRenderStyle: tree',
+      '',
+    ].join('\n');
     const env = {
       XCODEBUILDMCP_DEBUG: 'true',
       XCODEBUILDMCP_DAP_REQUEST_TIMEOUT_MS: '999',
+      XCODEBUILDMCP_FILE_PATH_RENDER_STYLE: 'list',
     };
 
     await initConfigStore({
       cwd,
       fs: createFs(yaml),
-      overrides: { debug: true, dapRequestTimeoutMs: 12345 },
+      overrides: { debug: true, dapRequestTimeoutMs: 12345, filePathRenderStyle: 'list' },
       env,
     });
 
     const config = getConfig();
     expect(config.debug).toBe(true);
     expect(config.dapRequestTimeoutMs).toBe(12345);
+    expect(config.filePathRenderStyle).toBe('list');
+  });
+
+  it('uses filePathRenderStyle from config before env when no override is provided', async () => {
+    const yaml = ['schemaVersion: 1', 'filePathRenderStyle: tree', ''].join('\n');
+    const env = { XCODEBUILDMCP_FILE_PATH_RENDER_STYLE: 'list' };
+
+    await initConfigStore({ cwd, fs: createFs(yaml), env });
+
+    expect(getConfig().filePathRenderStyle).toBe('tree');
   });
 
   it('reads sentryDisabled from config file', async () => {

--- a/src/utils/__tests__/project-config.test.ts
+++ b/src/utils/__tests__/project-config.test.ts
@@ -97,6 +97,17 @@ describe('project-config', () => {
       expect(result.notices.length).toBeGreaterThan(0);
     });
 
+    it('should load filePathRenderStyle from config', async () => {
+      const yaml = ['schemaVersion: 1', 'filePathRenderStyle: list', ''].join('\n');
+
+      const { fs } = createFsFixture({ exists: true, readFile: yaml });
+      const result = await loadProjectConfig({ fs, cwd });
+
+      if (!result.found) throw new Error('expected config to be found');
+
+      expect(result.config.filePathRenderStyle).toBe('list');
+    });
+
     it('should normalize debuggerBackend and resolve template paths', async () => {
       const yaml = [
         'schemaVersion: 1',
@@ -401,6 +412,7 @@ describe('project-config', () => {
           enabledWorkflows: ['simulator', 'ui-automation'],
           debug: true,
           sentryDisabled: true,
+          filePathRenderStyle: 'list',
           sessionDefaults: {
             workspacePath: './MyApp.xcworkspace',
             scheme: 'MyApp',
@@ -415,12 +427,14 @@ describe('project-config', () => {
         enabledWorkflows?: string[];
         debug?: boolean;
         sentryDisabled?: boolean;
+        filePathRenderStyle?: string;
         sessionDefaults?: Record<string, unknown>;
       };
 
       expect(parsed.enabledWorkflows).toEqual(['simulator', 'ui-automation']);
       expect(parsed.debug).toBe(true);
       expect(parsed.sentryDisabled).toBe(true);
+      expect(parsed.filePathRenderStyle).toBe('list');
       expect(parsed.sessionDefaults?.workspacePath).toBe('./MyApp.xcworkspace');
       expect(parsed.sessionDefaults?.projectPath).toBeUndefined();
     });

--- a/src/utils/__tests__/snapshot-normalize.test.ts
+++ b/src/utils/__tests__/snapshot-normalize.test.ts
@@ -2,21 +2,18 @@ import { describe, it, expect } from 'vitest';
 import { normalizeSnapshotOutput } from '../../snapshot-tests/normalize.ts';
 
 describe('normalizeSnapshotOutput tilde handling', () => {
-  it('normalizes ~/ paths to <HOME>/', () => {
+  it('normalizes XcodeBuildMCP ~/ paths to stable workspace-key placeholders', () => {
     const input =
       'Workspace Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/Weather-abc123def456/logs\n';
     const result = normalizeSnapshotOutput(input);
-    expect(result).toContain(
-      '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-abc123def456/logs',
-    );
-    expect(result).not.toContain('~/');
+    expect(result).toContain('~/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/logs');
+    expect(result).not.toContain('Weather-abc123def456');
   });
 
-  it('normalizes bare ~ (exact home directory) to <HOME>', () => {
+  it('preserves bare ~ outside path-like values', () => {
     const input = 'Home: ~\nDone\n';
     const result = normalizeSnapshotOutput(input);
-    expect(result).toContain('Home: <HOME>');
-    expect(result).not.toMatch(/: ~\n/);
+    expect(result).toContain('Home: ~');
   });
 
   it('does not alter tildes that are part of approximate numbers', () => {
@@ -53,10 +50,10 @@ describe('normalizeSnapshotOutput tilde handling', () => {
     const result = normalizeSnapshotOutput(input);
 
     expect(result).toContain(
-      'Build Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log',
+      'Build Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/logs/build_sim_<TIMESTAMP>_pid<PID>.log',
     );
     expect(result).toContain(
-      'Runtime Logs: <HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/logs/io.app_<TIMESTAMP>_pid<PID>.log',
+      'Runtime Logs: ~/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/logs/io.app_<TIMESTAMP>_pid<PID>.log',
     );
   });
 
@@ -67,7 +64,7 @@ describe('normalizeSnapshotOutput tilde handling', () => {
     const result = normalizeSnapshotOutput(input);
 
     expect(result).toContain(
-      '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult',
+      '~/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/result-bundles/test_macos_<TIMESTAMP>_pid<PID>.xcresult',
     );
     expect(result).not.toContain('Weather-abc123def456');
     expect(result).not.toContain('abcd1234');
@@ -80,7 +77,7 @@ describe('normalizeSnapshotOutput tilde handling', () => {
     const result = normalizeSnapshotOutput(input);
 
     expect(result).toContain(
-      '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/DerivedData/CalculatorApp-<HASH>',
+      '~/Library/Developer/XcodeBuildMCP/workspaces/Weather-<HASH>/DerivedData/CalculatorApp-<HASH>',
     );
     expect(result).not.toContain('Weather-abc123def456');
     expect(result).not.toContain('22d700c6d603');
@@ -93,7 +90,7 @@ describe('normalizeSnapshotOutput tilde handling', () => {
     const result = normalizeSnapshotOutput(input);
 
     expect(result).toContain(
-      '<HOME>/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData\n',
+      '~/Library/Developer/XcodeBuildMCP/workspaces/XcodeBuildMCP-<HASH>/DerivedData\n',
     );
     expect(result).not.toContain('c5da0cbe19a7');
   });

--- a/src/utils/config-store.ts
+++ b/src/utils/config-store.ts
@@ -8,7 +8,8 @@ import {
   type ProjectConfig,
 } from './project-config.ts';
 import type { DebuggerBackendKind } from './debugger/types.ts';
-import type { UiDebuggerGuardMode } from './runtime-config-types.ts';
+import type { FilePathRenderStyle, UiDebuggerGuardMode } from './runtime-config-types.ts';
+import { isFilePathRenderStyle } from './file-path-render-style.ts';
 import { normalizeSessionDefaultsProfileName } from './session-defaults-profile.ts';
 
 export type RuntimeConfigOverrides = Partial<{
@@ -20,6 +21,7 @@ export type RuntimeConfigOverrides = Partial<{
   disableSessionDefaults: boolean;
   disableXcodeAutoSync: boolean;
   showTestTiming: boolean;
+  filePathRenderStyle: FilePathRenderStyle;
   uiDebuggerGuardMode: UiDebuggerGuardMode;
   incrementalBuildsEnabled: boolean;
   dapRequestTimeoutMs: number;
@@ -45,6 +47,7 @@ export type ResolvedRuntimeConfig = {
   disableSessionDefaults: boolean;
   disableXcodeAutoSync: boolean;
   showTestTiming: boolean;
+  filePathRenderStyle?: FilePathRenderStyle;
   uiDebuggerGuardMode: UiDebuggerGuardMode;
   incrementalBuildsEnabled: boolean;
   dapRequestTimeoutMs: number;
@@ -141,6 +144,14 @@ function parseUiDebuggerGuardMode(value: string | undefined): UiDebuggerGuardMod
   return undefined;
 }
 
+function parseFilePathRenderStyle(value: string | undefined): FilePathRenderStyle | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (isFilePathRenderStyle(normalized)) return normalized;
+  log('warn', `Unsupported file path render style '${value}', falling back to defaults.`);
+  return undefined;
+}
+
 function parseDebuggerBackend(value: string | undefined): DebuggerBackendKind | undefined {
   if (!value) return undefined;
   const normalized = value.trim().toLowerCase();
@@ -198,6 +209,12 @@ function readEnvConfig(env: NodeJS.ProcessEnv): RuntimeConfigOverrides {
   );
 
   setIfDefined(config, 'showTestTiming', parseBoolean(env.XCODEBUILDMCP_SHOW_TEST_TIMING));
+
+  setIfDefined(
+    config,
+    'filePathRenderStyle',
+    parseFilePathRenderStyle(env.XCODEBUILDMCP_FILE_PATH_RENDER_STYLE),
+  );
 
   setIfDefined(
     config,
@@ -492,6 +509,12 @@ function resolveConfig(opts: {
       fileConfig: opts.fileConfig,
       envConfig,
       fallback: DEFAULT_CONFIG.showTestTiming,
+    }),
+    filePathRenderStyle: resolveFromLayers<FilePathRenderStyle>({
+      key: 'filePathRenderStyle',
+      overrides: opts.overrides,
+      fileConfig: opts.fileConfig,
+      envConfig,
     }),
     uiDebuggerGuardMode: resolveFromLayers({
       key: 'uiDebuggerGuardMode',

--- a/src/utils/file-path-render-style.ts
+++ b/src/utils/file-path-render-style.ts
@@ -1,0 +1,27 @@
+import type { FilePathRenderStyle } from './runtime-config-types.ts';
+
+export type FilePathRenderRuntime = 'cli' | 'daemon' | 'mcp';
+
+export function isFilePathRenderStyle(value: unknown): value is FilePathRenderStyle {
+  return value === 'tree' || value === 'list';
+}
+
+export function defaultFilePathRenderStyleForRuntime(
+  runtime: FilePathRenderRuntime,
+): FilePathRenderStyle {
+  return runtime === 'mcp' ? 'tree' : 'list';
+}
+
+export function resolveFilePathRenderStyle(options: {
+  explicit?: FilePathRenderStyle;
+  configured?: FilePathRenderStyle;
+  runtime: FilePathRenderRuntime;
+}): FilePathRenderStyle {
+  return (
+    options.explicit ?? options.configured ?? defaultFilePathRenderStyleForRuntime(options.runtime)
+  );
+}
+
+export function normalizeRenderRuntime(runtime: string | undefined): FilePathRenderRuntime {
+  return runtime === 'mcp' || runtime === 'daemon' ? runtime : 'cli';
+}

--- a/src/utils/project-config.ts
+++ b/src/utils/project-config.ts
@@ -6,6 +6,7 @@ import type { SessionDefaults } from './session-store.ts';
 import { log } from './logger.ts';
 import { removeUndefined } from './remove-undefined.ts';
 import { runtimeConfigFileSchema, type RuntimeConfigFile } from './runtime-config-schema.ts';
+import type { FilePathRenderStyle } from './runtime-config-types.ts';
 import { normalizeSessionDefaultsProfileName } from './session-defaults-profile.ts';
 import { resolvePathFromCwd } from './path.ts';
 
@@ -20,6 +21,7 @@ export type ProjectConfig = RuntimeConfigFile & {
   enabledWorkflows?: string[];
   customWorkflows?: Record<string, string[]>;
   debuggerBackend?: 'dap' | 'lldb-cli';
+  filePathRenderStyle?: FilePathRenderStyle;
   [key: string]: unknown;
 };
 
@@ -60,6 +62,7 @@ export type PersistProjectConfigPatchOptions = {
     sentryDisabled?: boolean;
     experimentalWorkflowDiscovery?: boolean;
     disableSessionDefaults?: boolean;
+    filePathRenderStyle?: FilePathRenderStyle;
     sessionDefaults?: Partial<SessionDefaults>;
     setupPreferences?: SetupPreferences | null;
   };
@@ -420,6 +423,7 @@ export async function persistProjectConfigPatch(
     sentryDisabled: options.patch.sentryDisabled,
     experimentalWorkflowDiscovery: options.patch.experimentalWorkflowDiscovery,
     disableSessionDefaults: options.patch.disableSessionDefaults,
+    filePathRenderStyle: options.patch.filePathRenderStyle,
   });
 
   for (const [key, value] of Object.entries(topLevelPatch)) {

--- a/src/utils/renderers/__tests__/cli-text-renderer.test.ts
+++ b/src/utils/renderers/__tests__/cli-text-renderer.test.ts
@@ -11,19 +11,23 @@ vi.mock('../../cli-progress-reporter.ts', () => ({
   createCliProgressReporter: () => reporter,
 }));
 
-function buildOutput(overrides: Partial<StructuredToolOutput['result']>): StructuredToolOutput {
+function buildOutput(
+  overrides: Partial<Extract<StructuredToolOutput['result'], { kind: 'build-result' }>>,
+): StructuredToolOutput {
+  const result: Extract<StructuredToolOutput['result'], { kind: 'build-result' }> = {
+    kind: 'build-result',
+    didError: false,
+    error: null,
+    summary: { status: 'SUCCEEDED' },
+    artifacts: { scheme: 'MyApp', buildLogPath: '/tmp/build.log' },
+    diagnostics: { warnings: [], errors: [] },
+    ...overrides,
+  };
+
   return {
     schema: 'xcodebuildmcp.output.build-result',
     schemaVersion: '1.0.0',
-    result: {
-      kind: 'build-result',
-      didError: false,
-      error: null,
-      summary: { status: 'SUCCEEDED' },
-      artifacts: { scheme: 'MyApp', buildLogPath: '/tmp/build.log' },
-      diagnostics: { warnings: [], errors: [] },
-      ...overrides,
-    } as StructuredToolOutput['result'],
+    result,
   };
 }
 
@@ -517,7 +521,7 @@ describe('cli-text-renderer', () => {
     expect(footerIndex).toBeGreaterThan(summaryIndex);
     expect(nextStepsIndex).toBeGreaterThan(footerIndex);
     expect(output).toContain('\u{2705} Build & Run complete');
-    expect(output).toContain('\u2514 App Path: /tmp/build/MyApp.app');
+    expect(output).toContain('└ App Path: /tmp/build/MyApp.app');
   });
 
   it('replays buffered build failures once when only a header was emitted', () => {
@@ -565,6 +569,25 @@ describe('cli-text-renderer', () => {
     expect(output).toContain('🔍 Get App Path');
     expect(output).toContain('✅ Success');
     expect(output).toContain('└ App Path: /tmp/MyApp.app');
+  });
+
+  it('renders structured output path artifacts as a tree when requested', () => {
+    const output = renderCliTextTranscript({
+      filePathRenderStyle: 'tree',
+      structuredOutput: {
+        schema: 'xcodebuildmcp.output.app-path',
+        schemaVersion: '1.0.0',
+        result: {
+          kind: 'app-path',
+          didError: false,
+          error: null,
+          artifacts: { appPath: '/tmp/MyApp.app' },
+        },
+      },
+    });
+
+    expect(output).toContain('└── /tmp/MyApp.app — App Path');
+    expect(output).not.toContain('└ App Path: /tmp/MyApp.app');
   });
 
   it('renders structured-only non-build diagnostics with a short top-level error summary', () => {
@@ -685,6 +708,36 @@ describe('cli-text-renderer', () => {
     expect(output).toContain('✅ Build succeeded. (⏱️ 5.0s)');
     expect(output).toContain('✅ Build & Run complete');
     expect(output).toContain('App Path: /tmp/build/MyApp.app');
+  });
+
+  it('renders structured-only build-run headers without frontmatter when header details are disabled', () => {
+    const output = renderCliTextTranscript({
+      includeHeaderDetails: false,
+      structuredOutput: {
+        schema: 'xcodebuildmcp.output.build-run-result',
+        schemaVersion: '1.0.0',
+        result: {
+          kind: 'build-run-result',
+          request: {
+            scheme: 'MyApp',
+            projectPath: '/tmp/MyApp.xcodeproj',
+            configuration: 'Debug',
+            platform: 'iOS Simulator',
+          },
+          didError: false,
+          error: null,
+          summary: { status: 'SUCCEEDED', durationMs: 5000 },
+          artifacts: { appPath: '/tmp/build/MyApp.app', buildLogPath: '/tmp/build.log' },
+          diagnostics: { warnings: [], errors: [] },
+        },
+      },
+    });
+
+    expect(output).toContain('🚀 Build & Run');
+    expect(output).not.toContain('Scheme: MyApp');
+    expect(output).not.toContain('Project: /tmp/MyApp.xcodeproj');
+    expect(output).not.toContain('Configuration: Debug');
+    expect(output).toContain('✅ Build succeeded. (⏱️ 5.0s)');
   });
 
   it('renders structured-only test-result with request and no fragments', () => {

--- a/src/utils/renderers/__tests__/event-formatting.test.ts
+++ b/src/utils/renderers/__tests__/event-formatting.test.ts
@@ -26,6 +26,22 @@ describe('event formatting', () => {
     ).toBe('\u{1F680} Build & Run\n\n   Scheme: MyApp');
   });
 
+  it('formats compact header events without params when details are disabled', () => {
+    expect(
+      formatHeaderEvent(
+        {
+          type: 'header',
+          operation: 'Build & Run',
+          params: [
+            { label: 'Scheme', value: 'MyApp' },
+            { label: 'Derived Data', value: '/tmp/DerivedData' },
+          ],
+        },
+        { includeDetails: false },
+      ),
+    ).toBe('\u{1F680} Build & Run');
+  });
+
   it('groups test selection params with human-readable labels in header output', () => {
     expect(
       formatHeaderEvent({
@@ -212,7 +228,7 @@ describe('event formatting', () => {
     const rendered = formatDetailTreeEvent({
       type: 'detail-tree',
       items: [
-        { label: 'App Path', value: '/tmp/build/MyApp.app' },
+        { label: 'App Path', path: '/tmp/build/MyApp.app' },
         { label: 'Bundle ID', value: 'com.example.myapp' },
         { label: 'App ID', value: 'A1B2C3D4' },
         { label: 'Process ID', value: '12345' },
@@ -220,20 +236,44 @@ describe('event formatting', () => {
       ],
     });
 
-    expect(rendered).toContain('  \u251C App Path: /tmp/build/MyApp.app');
-    expect(rendered).toContain('  \u251C Bundle ID: com.example.myapp');
-    expect(rendered).toContain('  \u251C App ID: A1B2C3D4');
-    expect(rendered).toContain('  \u251C Process ID: 12345');
-    expect(rendered).toContain('  \u2514 Launch: Running');
+    expect(rendered).toContain('  ├ Bundle ID: com.example.myapp');
+    expect(rendered).toContain('  ├ App ID: A1B2C3D4');
+    expect(rendered).toContain('  ├ Process ID: 12345');
+    expect(rendered).toContain('  ├ Launch: Running');
+    expect(rendered).toContain('  └ Files:');
+    expect(rendered).toContain('     └── /tmp/build/MyApp.app — App Path');
   });
 
   it('formats detail-tree with single item using end branch', () => {
     expect(
       formatDetailTreeEvent({
         type: 'detail-tree',
-        items: [{ label: 'App Path', value: '/tmp/build/MyApp.app' }],
+        items: [{ label: 'App Path', path: '/tmp/build/MyApp.app' }],
       }),
-    ).toBe('  \u2514 App Path: /tmp/build/MyApp.app');
+    ).toBe(['  └ Files:', '     └── /tmp/build/MyApp.app — App Path'].join('\n'));
+  });
+
+  it('formats detail-tree path items as a labeled list when requested', () => {
+    expect(
+      formatDetailTreeEvent(
+        {
+          type: 'detail-tree',
+          items: [
+            { label: 'Bundle ID', value: 'com.example.myapp' },
+            { label: 'App Path', path: '/tmp/build/MyApp.app' },
+            { label: 'Build Logs', path: '/tmp/logs/build.log' },
+          ],
+        },
+        { filePathRenderStyle: 'list' },
+      ),
+    ).toBe(
+      [
+        '  ├ Bundle ID: com.example.myapp',
+        '  └ Files:',
+        '     ├ App Path: /tmp/build/MyApp.app',
+        '     └ Build Logs: /tmp/logs/build.log',
+      ].join('\n'),
+    );
   });
 
   it('groups test failures by test case within a suite', () => {

--- a/src/utils/renderers/__tests__/path-tree.test.ts
+++ b/src/utils/renderers/__tests__/path-tree.test.ts
@@ -78,6 +78,11 @@ describe('formatPathTree', () => {
   });
 
   it('preserves raw shared ancestry even when a descendant path would display differently alone', () => {
+    const childLines = [
+      `${homeDirectoryName}/Library/Logs/build.log — User Logs`,
+      'other/Library/Logs/build.log — Other Logs',
+    ].sort();
+
     expect(
       formatPathTree(
         [
@@ -86,11 +91,7 @@ describe('formatPathTree', () => {
         ],
         { formatPath: displayPath },
       ),
-    ).toEqual([
-      `└── ${homeParentPath}/`,
-      `    ├── ${homeDirectoryName}/Library/Logs/build.log — User Logs`,
-      '    └── other/Library/Logs/build.log — Other Logs',
-    ]);
+    ).toEqual([`└── ${homeParentPath}/`, `    ├── ${childLines[0]}`, `    └── ${childLines[1]}`]);
   });
 
   it('sorts relative paths before rendering', () => {

--- a/src/utils/renderers/__tests__/path-tree.test.ts
+++ b/src/utils/renderers/__tests__/path-tree.test.ts
@@ -1,0 +1,122 @@
+import { homedir } from 'node:os';
+import { basename, dirname } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { displayPath } from '../../build-preflight.ts';
+import { formatPathTree } from '../path-tree.ts';
+
+const homePath = homedir();
+const homeParentPath = dirname(homePath);
+const homeDirectoryName = basename(homePath);
+const workspaceKey = 'CalculatorApp-9f3a7c2d1b44';
+const derivedDataDirectoryName = 'CalculatorApp-7834e7689e33';
+const buildLogFileName = 'build_run_sim_2026-05-07T12-47-52-599Z_pid24748_31629ebe.log';
+const runtimeLogFileName =
+  'io.sentry.calculatorapp_2026-05-07T12-48-10-840Z_helperpid25309_ownerpid24748_88fd8a4f.log';
+const osLogFileName =
+  'io.sentry.calculatorapp_oslog_2026-05-07T12-48-12-805Z_helperpid25369_ownerpid24748_14da7d85.log';
+const managedWorkspacePath = `${homePath}/Library/Developer/XcodeBuildMCP/workspaces/${workspaceKey}`;
+
+describe('formatPathTree', () => {
+  it('groups paths by their shared ancestor before display formatting', () => {
+    expect(
+      formatPathTree(
+        [
+          {
+            label: 'OSLog',
+            path: `${managedWorkspacePath}/logs/${osLogFileName}`,
+          },
+          {
+            label: 'App Path',
+            path: `${managedWorkspacePath}/DerivedData/${derivedDataDirectoryName}/Build/Products/Debug-iphonesimulator/CalculatorApp.app`,
+          },
+          {
+            label: 'Runtime Logs',
+            path: `${managedWorkspacePath}/logs/${runtimeLogFileName}`,
+          },
+          {
+            label: 'Build Logs',
+            path: `${managedWorkspacePath}/logs/${buildLogFileName}`,
+          },
+        ],
+        { formatPath: displayPath },
+      ),
+    ).toEqual([
+      `└── ~/Library/Developer/XcodeBuildMCP/workspaces/${workspaceKey}/`,
+      `    ├── DerivedData/${derivedDataDirectoryName}/Build/Products/Debug-iphonesimulator/CalculatorApp.app — App Path`,
+      '    └── logs/',
+      `        ├── ${buildLogFileName} — Build Logs`,
+      `        ├── ${runtimeLogFileName} — Runtime Logs`,
+      `        └── ${osLogFileName} — OSLog`,
+    ]);
+  });
+
+  it('renders separate roots when paths do not share a meaningful ancestor', () => {
+    expect(
+      formatPathTree(
+        [
+          {
+            label: 'Build Logs',
+            path: `${managedWorkspacePath}/logs/${buildLogFileName}`,
+          },
+          {
+            label: 'App Path',
+            path: '/Volumes/CustomDerivedData/CalculatorApp/Build/Products/Debug-iphonesimulator/CalculatorApp.app',
+          },
+          {
+            label: 'Runtime Logs',
+            path: `${managedWorkspacePath}/logs/${runtimeLogFileName}`,
+          },
+        ],
+        { formatPath: displayPath },
+      ),
+    ).toEqual([
+      `├── ~/Library/Developer/XcodeBuildMCP/workspaces/${workspaceKey}/logs/`,
+      `│   ├── ${buildLogFileName} — Build Logs`,
+      `│   └── ${runtimeLogFileName} — Runtime Logs`,
+      '└── /Volumes/CustomDerivedData/CalculatorApp/Build/Products/Debug-iphonesimulator/CalculatorApp.app — App Path',
+    ]);
+  });
+
+  it('preserves raw shared ancestry even when a descendant path would display differently alone', () => {
+    expect(
+      formatPathTree(
+        [
+          { label: 'User Logs', path: `${homePath}/Library/Logs/build.log` },
+          { label: 'Other Logs', path: `${homeParentPath}/other/Library/Logs/build.log` },
+        ],
+        { formatPath: displayPath },
+      ),
+    ).toEqual([
+      `└── ${homeParentPath}/`,
+      `    ├── ${homeDirectoryName}/Library/Logs/build.log — User Logs`,
+      '    └── other/Library/Logs/build.log — Other Logs',
+    ]);
+  });
+
+  it('sorts relative paths before rendering', () => {
+    expect(
+      formatPathTree([
+        { label: 'Runtime Logs', path: 'tmp/runtime.log' },
+        { label: 'Build Logs', path: 'tmp/build.log' },
+        { label: 'App Path', path: 'build/Products/App.app' },
+      ]),
+    ).toEqual([
+      '├── build/Products/App.app — App Path',
+      '└── tmp/',
+      '    ├── build.log — Build Logs',
+      '    └── runtime.log — Runtime Logs',
+    ]);
+  });
+
+  it('ignores blank paths', () => {
+    expect(
+      formatPathTree(
+        [
+          { label: 'Blank', path: ' ' },
+          { label: 'Build Logs', path: `${homePath}/Library/Logs/build.log` },
+        ],
+        { formatPath: displayPath },
+      ),
+    ).toEqual(['└── ~/Library/Logs/build.log — Build Logs']);
+  });
+});

--- a/src/utils/renderers/cli-text-renderer.ts
+++ b/src/utils/renderers/cli-text-renderer.ts
@@ -1,5 +1,6 @@
 import type { NextStep } from '../../types/common.ts';
 import type { StructuredToolOutput } from '../../rendering/types.ts';
+import type { FilePathRenderStyle } from '../runtime-config-types.ts';
 import type { AnyFragment, BuildRunPhase } from '../../types/domain-fragments.ts';
 import type { XcodebuildOperation } from '../../types/domain-fragments.ts';
 import type {
@@ -69,12 +70,16 @@ interface CliTextProcessorOptions {
   sink: CliTextSink;
   suppressWarnings: boolean;
   showTestTiming: boolean;
+  filePathRenderStyle: FilePathRenderStyle;
+  includeHeaderDetails: boolean;
 }
 
 interface CliTextRendererOptions {
   interactive: boolean;
   suppressWarnings?: boolean;
   showTestTiming?: boolean;
+  filePathRenderStyle?: FilePathRenderStyle;
+  includeHeaderDetails?: boolean;
 }
 
 export interface CliTextTranscriptInput {
@@ -84,6 +89,8 @@ export interface CliTextTranscriptInput {
   nextStepsRuntime?: 'cli' | 'daemon' | 'mcp';
   suppressWarnings?: boolean;
   showTestTiming?: boolean;
+  filePathRenderStyle?: FilePathRenderStyle;
+  includeHeaderDetails?: boolean;
 }
 
 interface XcodebuildParserState {
@@ -95,7 +102,14 @@ interface XcodebuildParserState {
 type RunStateEvent = Parameters<XcodebuildRunStateHandle['push']>[0];
 
 function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRenderer {
-  const { interactive, sink, suppressWarnings, showTestTiming } = options;
+  const {
+    interactive,
+    sink,
+    suppressWarnings,
+    showTestTiming,
+    filePathRenderStyle,
+    includeHeaderDetails,
+  } = options;
   const groupedCompilerErrors: CompilerErrorRenderItem[] = [];
   const groupedWarnings: CompilerWarningRenderItem[] = [];
   const groupedTestFailures: TestFailureRenderItem[] = [];
@@ -177,7 +191,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       case 'header': {
         diagnosticBaseDir = deriveDiagnosticBaseDir(item);
         hasDurableRuntimeContent = false;
-        writeSection(formatHeaderEvent(item));
+        writeSection(formatHeaderEvent(item, { includeDetails: includeHeaderDetails }));
         lastVisibleEventType = 'header';
         lastStatusLineLevel = null;
         break;
@@ -225,7 +239,7 @@ function createCliTextProcessor(options: CliTextProcessorOptions): TranscriptRen
       }
 
       case 'detail-tree': {
-        writeDurable(formatDetailTreeEvent(item));
+        writeDurable(formatDetailTreeEvent(item, { filePathRenderStyle }));
         lastVisibleEventType = 'detail-tree';
         lastStatusLineLevel = null;
         break;
@@ -489,6 +503,8 @@ export function createCliTextRenderer(options: CliTextRendererOptions): Transcri
     interactive: options.interactive,
     suppressWarnings: options.suppressWarnings ?? false,
     showTestTiming: options.showTestTiming ?? false,
+    filePathRenderStyle: options.filePathRenderStyle ?? 'list',
+    includeHeaderDetails: options.includeHeaderDetails ?? true,
     sink: {
       clearTransient(): void {
         reporter.clear();
@@ -512,6 +528,8 @@ export function renderCliTextTranscript(input: CliTextTranscriptInput = {}): str
     interactive: false,
     suppressWarnings: input.suppressWarnings ?? false,
     showTestTiming: input.showTestTiming ?? false,
+    filePathRenderStyle: input.filePathRenderStyle ?? 'list',
+    includeHeaderDetails: input.includeHeaderDetails ?? true,
     sink: {
       clearTransient(): void {},
       updateTransient(): void {},

--- a/src/utils/renderers/domain-result-text.ts
+++ b/src/utils/renderers/domain-result-text.ts
@@ -2,7 +2,6 @@ import type { NextStep } from '../../types/common.ts';
 import type {
   BasicDiagnostics,
   DebugThread,
-  SessionDefaultsProfile,
   TestDiagnostics,
   ToolDomainResult,
 } from '../../types/domain-results.ts';
@@ -37,9 +36,19 @@ export interface SectionTextBlock {
   blankLineAfterTitle?: boolean;
 }
 
+export interface DetailTreeValueItem {
+  label: string;
+  value: string;
+}
+
+export interface DetailTreePathItem {
+  label: string;
+  path: string;
+}
+
 export interface DetailTreeTextBlock {
   type: 'detail-tree';
-  items: Array<{ label: string; value: string }>;
+  items: Array<DetailTreeValueItem | DetailTreePathItem>;
 }
 
 export interface TableTextBlock {
@@ -293,6 +302,14 @@ function createDetailTree(items: DetailTreeTextBlock['items']): DetailTreeTextBl
   return { type: 'detail-tree', items };
 }
 
+function createPathDetailItem(label: string, path: string): DetailTreePathItem {
+  return { label, path };
+}
+
+function createValueDetailItem(label: string, value: string): DetailTreeValueItem {
+  return { label, value };
+}
+
 function createTable(
   columns: string[],
   rows: Array<Record<string, string>>,
@@ -320,20 +337,6 @@ function formatSessionDefaultsValue(value: unknown): string {
 
 function formatProfileAnnotationFromLabel(profileLabel: string): string {
   return profileLabel === '(default)' ? '(default profile)' : `(${profileLabel} profile)`;
-}
-
-function formatSessionDefaultsTree(profile: SessionDefaultsProfile): string[] {
-  return SESSION_DEFAULT_KEYS.map((key, index) => {
-    const branch = index === SESSION_DEFAULT_KEYS.length - 1 ? '└' : '├';
-    return `  ${branch} ${key}: ${formatSessionDefaultsValue(profile[key])}`;
-  });
-}
-
-function formatSessionDefaultsProfileBlock(
-  profileLabel: string,
-  profile: SessionDefaultsProfile,
-): string {
-  return [`📁 ${profileLabel}`, ...formatSessionDefaultsTree(profile)].join('\n');
 }
 
 function inferSessionDefaultsMode(
@@ -377,7 +380,7 @@ function formatVariable(variable: DebugVariableShape): string {
 function formatVariablesLines(scopes: DebugVariablesScopes): string[] {
   const lines: string[] = [];
 
-  const appendScope = (label: string, values: string[]) => {
+  const appendScope = (label: string, values: string[]): void => {
     lines.push(`${label}:`);
     if (values.length === 0) {
       lines.push('  (no variables)');
@@ -717,7 +720,7 @@ function createAppPathItems(
     ),
   );
   if (appPath) {
-    items.push(createDetailTree([{ label: 'App Path', value: displayPath(appPath) }]));
+    items.push(createDetailTree([createPathDetailItem('App Path', appPath)]));
   }
   return items;
 }
@@ -821,16 +824,16 @@ function createLaunchResultItems(
 
   const details: DetailTreeTextBlock['items'] = [];
   if (result.artifacts.bundleId && isMac) {
-    details.push({ label: 'Bundle ID', value: result.artifacts.bundleId });
+    details.push(createValueDetailItem('Bundle ID', result.artifacts.bundleId));
   }
   if (typeof result.artifacts.processId === 'number') {
-    details.push({ label: 'Process ID', value: String(result.artifacts.processId) });
+    details.push(createValueDetailItem('Process ID', String(result.artifacts.processId)));
   }
   if (result.artifacts.runtimeLogPath) {
-    details.push({ label: 'Runtime Logs', value: displayPath(result.artifacts.runtimeLogPath) });
+    details.push(createPathDetailItem('Runtime Logs', result.artifacts.runtimeLogPath));
   }
   if (result.artifacts.osLogPath) {
-    details.push({ label: 'OSLog', value: displayPath(result.artifacts.osLogPath) });
+    details.push(createPathDetailItem('OSLog', result.artifacts.osLogPath));
   }
   if (details.length > 0) {
     items.push(createDetailTree(details));
@@ -1237,13 +1240,13 @@ function createCaptureResultItems(
     );
     const details: DetailTreeTextBlock['items'] = [];
     if (typeof result.capture.fps === 'number') {
-      details.push({ label: 'FPS', value: String(result.capture.fps) });
+      details.push(createValueDetailItem('FPS', String(result.capture.fps)));
     }
     if (result.capture.sessionId) {
-      details.push({ label: 'Session ID', value: result.capture.sessionId });
+      details.push(createValueDetailItem('Session ID', result.capture.sessionId));
     }
     if (result.capture.outputFile) {
-      details.push({ label: 'Output File', value: displayPath(result.capture.outputFile) });
+      details.push(createPathDetailItem('Output File', result.capture.outputFile));
     }
     if (details.length > 0) {
       items.push(createDetailTree(details));
@@ -1295,11 +1298,13 @@ function createCaptureResultItems(
   items.push(createStatus('success', 'Screenshot captured'));
   const details: DetailTreeTextBlock['items'] = [];
   if (result.artifacts.screenshotPath) {
-    details.push({ label: 'Screenshot', value: displayPath(result.artifacts.screenshotPath) });
+    details.push(createPathDetailItem('Screenshot', result.artifacts.screenshotPath));
   }
   if (result.capture && !('type' in result.capture)) {
-    details.push({ label: 'Format', value: result.capture.format });
-    details.push({ label: 'Size', value: `${result.capture.width}x${result.capture.height}px` });
+    details.push(createValueDetailItem('Format', result.capture.format));
+    details.push(
+      createValueDetailItem('Size', `${result.capture.width}x${result.capture.height}px`),
+    );
   }
   if (details.length > 0) {
     items.push(createDetailTree(details));
@@ -1901,10 +1906,10 @@ export function createBuildLikeTailItems(result: ToolDomainResult): TextRenderab
       if (!('artifacts' in result) || !result.artifacts) return [];
       const items: DetailTreeTextBlock['items'] = [];
       if ('bundleId' in result.artifacts && typeof result.artifacts.bundleId === 'string') {
-        items.push({ label: 'Bundle ID', value: result.artifacts.bundleId });
+        items.push(createValueDetailItem('Bundle ID', result.artifacts.bundleId));
       }
       if ('buildLogPath' in result.artifacts && typeof result.artifacts.buildLogPath === 'string') {
-        items.push({ label: 'Build Logs', value: displayPath(result.artifacts.buildLogPath) });
+        items.push(createPathDetailItem('Build Logs', result.artifacts.buildLogPath));
       }
       return items.length > 0 ? [createDetailTree(items)] : [];
     }
@@ -1918,29 +1923,29 @@ export function createBuildLikeTailItems(result: ToolDomainResult): TextRenderab
             ? result.artifacts.executablePath
             : undefined;
       if (typeof appLikePath === 'string') {
-        items.push({ label: 'App Path', value: displayPath(appLikePath) });
+        items.push(createPathDetailItem('App Path', appLikePath));
       }
       if ('bundleId' in result.artifacts && typeof result.artifacts.bundleId === 'string') {
-        items.push({ label: 'Bundle ID', value: result.artifacts.bundleId });
+        items.push(createValueDetailItem('Bundle ID', result.artifacts.bundleId));
       }
       if ('processId' in result.artifacts && typeof result.artifacts.processId === 'number') {
-        items.push({ label: 'Process ID', value: String(result.artifacts.processId) });
+        items.push(createValueDetailItem('Process ID', String(result.artifacts.processId)));
       }
       if (
         'buildLogPath' in result.artifacts &&
         typeof result.artifacts.buildLogPath === 'string' &&
         !(result.didError && result.summary.target === 'swift-package')
       ) {
-        items.push({ label: 'Build Logs', value: displayPath(result.artifacts.buildLogPath) });
+        items.push(createPathDetailItem('Build Logs', result.artifacts.buildLogPath));
       }
       if (
         'runtimeLogPath' in result.artifacts &&
         typeof result.artifacts.runtimeLogPath === 'string'
       ) {
-        items.push({ label: 'Runtime Logs', value: displayPath(result.artifacts.runtimeLogPath) });
+        items.push(createPathDetailItem('Runtime Logs', result.artifacts.runtimeLogPath));
       }
       if ('osLogPath' in result.artifacts && typeof result.artifacts.osLogPath === 'string') {
-        items.push({ label: 'OSLog', value: displayPath(result.artifacts.osLogPath) });
+        items.push(createPathDetailItem('OSLog', result.artifacts.osLogPath));
       }
       if (items.length === 0) return [];
       const tailItems: TextRenderableItem[] = [
@@ -1961,10 +1966,10 @@ export function createBuildLikeTailItems(result: ToolDomainResult): TextRenderab
       if (!('artifacts' in result) || !result.artifacts) return [];
       const items: DetailTreeTextBlock['items'] = [];
       if ('xcresultPath' in result.artifacts && typeof result.artifacts.xcresultPath === 'string') {
-        items.push({ label: 'Result Bundle', value: displayPath(result.artifacts.xcresultPath) });
+        items.push(createPathDetailItem('Result Bundle', result.artifacts.xcresultPath));
       }
       if ('buildLogPath' in result.artifacts && typeof result.artifacts.buildLogPath === 'string') {
-        items.push({ label: 'Build Logs', value: displayPath(result.artifacts.buildLogPath) });
+        items.push(createPathDetailItem('Build Logs', result.artifacts.buildLogPath));
       }
       return items.length > 0 ? [createDetailTree(items)] : [];
     }
@@ -2006,7 +2011,7 @@ function createRawResponseArtifactItems(pathValue?: string): TextRenderableItem[
         createDetailTree([
           {
             label: 'Raw Response JSON',
-            value: displayPath(pathValue),
+            path: pathValue,
           },
         ]),
       ]

--- a/src/utils/renderers/event-formatting.ts
+++ b/src/utils/renderers/event-formatting.ts
@@ -18,7 +18,9 @@ import type {
   TestProgressRenderItem,
 } from '../../rendering/render-items.ts';
 import type {
+  DetailTreePathItem,
   DetailTreeTextBlock,
+  DetailTreeValueItem,
   FileRefTextBlock,
   NextStepsTextBlock,
   SectionTextBlock,
@@ -26,6 +28,8 @@ import type {
   TableTextBlock,
 } from './domain-result-text.ts';
 import { displayPath } from '../build-preflight.ts';
+import type { FilePathRenderStyle } from '../runtime-config-types.ts';
+import { formatPathTree } from './path-tree.ts';
 import { renderNextStepsSection } from '../responses/next-steps-renderer.ts';
 
 // --- Operation emoji map ---
@@ -104,11 +108,60 @@ export const OPERATION_EMOJI: Record<string, string> = {
 
 // --- Detail tree formatting ---
 
-function formatDetailTreeLines(details: Array<{ label: string; value: string }>): string[] {
+type DetailTreeItem = DetailTreeValueItem | DetailTreePathItem;
+
+function isPathDetailItem(detail: DetailTreeItem): detail is DetailTreePathItem {
+  return 'path' in detail;
+}
+
+function formatValueDetailTreeLines(details: readonly DetailTreeValueItem[]): string[] {
   return details.map((detail, index) => {
     const branch = index === details.length - 1 ? '\u2514' : '\u251C';
     return `  ${branch} ${detail.label}: ${detail.value}`;
   });
+}
+
+export interface DetailTreeFormattingOptions {
+  filePathRenderStyle?: FilePathRenderStyle;
+}
+
+function formatPathListLines(details: readonly DetailTreePathItem[]): string[] {
+  return details.map((detail, index) => {
+    const branch = index === details.length - 1 ? '└' : '├';
+    const displayed = displayPath(detail.path);
+    return detail.label ? `${branch} ${detail.label}: ${displayed}` : `${branch} ${displayed}`;
+  });
+}
+
+function formatDetailTreeLines(
+  details: readonly DetailTreeItem[],
+  options: DetailTreeFormattingOptions = {},
+): string[] {
+  const valueDetails: DetailTreeValueItem[] = [];
+  const pathDetails: DetailTreePathItem[] = [];
+  for (const detail of details) {
+    if (isPathDetailItem(detail)) {
+      pathDetails.push(detail);
+    } else {
+      valueDetails.push(detail);
+    }
+  }
+
+  if (pathDetails.length === 0) {
+    return formatValueDetailTreeLines(valueDetails);
+  }
+
+  const pathLines =
+    options.filePathRenderStyle === 'list'
+      ? formatPathListLines(pathDetails)
+      : formatPathTree(pathDetails, { formatPath: displayPath });
+
+  const lines = valueDetails.map((detail) => `  ├ ${detail.label}: ${detail.value}`);
+  lines.push('  \u2514 Files:');
+  for (const line of pathLines) {
+    lines.push(`     ${line}`);
+  }
+  return lines;
 }
 
 // --- Diagnostic path resolution ---
@@ -218,9 +271,20 @@ function parseHumanDiagnostic(
 
 // --- Canonical event formatters ---
 
-export function formatHeaderEvent(event: HeaderRenderItem): string {
+export interface HeaderFormattingOptions {
+  includeDetails?: boolean;
+}
+
+export function formatHeaderEvent(
+  event: HeaderRenderItem,
+  options: HeaderFormattingOptions = {},
+): string {
   const emoji = OPERATION_EMOJI[event.operation] ?? '\u{2699}\u{FE0F}';
   const lines: string[] = [`${emoji} ${event.operation}`];
+
+  if (options.includeDetails === false) {
+    return lines.join('\n');
+  }
 
   const onlyTestingParams = event.params.filter((param) => param.label === '-only-testing');
   const skipTestingParams = event.params.filter((param) => param.label === '-skip-testing');
@@ -331,8 +395,11 @@ export function formatFileRefEvent(
   return displayed;
 }
 
-export function formatDetailTreeEvent(event: DetailTreeRenderItem | DetailTreeTextBlock): string {
-  return formatDetailTreeLines(event.items).join('\n');
+export function formatDetailTreeEvent(
+  event: DetailTreeRenderItem | DetailTreeTextBlock,
+  options: DetailTreeFormattingOptions = {},
+): string {
+  return formatDetailTreeLines(event.items, options).join('\n');
 }
 
 // --- Xcodebuild-specific formatters ---

--- a/src/utils/renderers/path-tree.ts
+++ b/src/utils/renderers/path-tree.ts
@@ -1,0 +1,170 @@
+export interface PathTreeEntry {
+  path: string;
+  label?: string;
+}
+
+export interface PathTreeFormatOptions {
+  formatPath?: (path: string) => string;
+}
+
+interface PathTreeNode {
+  name: string;
+  rawPath: string;
+  children: Map<string, PathTreeNode>;
+  label?: string;
+}
+
+interface ParsedPath {
+  components: string[];
+  sortablePath: string;
+  label?: string;
+}
+
+function normalizeRawPath(inputPath: string): string {
+  const normalized = inputPath.replace(/\/+/g, '/');
+  return normalized === '/' ? normalized : normalized.replace(/\/$/, '');
+}
+
+function parseRawPath(entry: PathTreeEntry): ParsedPath | null {
+  const normalized = normalizeRawPath(entry.path.trim());
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  if (normalized === '/') {
+    return { components: ['/'], sortablePath: normalized, label: entry.label };
+  }
+
+  const isAbsolute = normalized.startsWith('/');
+  const segments = (isAbsolute ? normalized.slice(1) : normalized).split('/').filter(Boolean);
+  const components = isAbsolute ? ['/', ...segments] : segments;
+  return { components, sortablePath: normalized, label: entry.label };
+}
+
+function createNode(name: string, rawPath: string): PathTreeNode {
+  return { name, rawPath, children: new Map() };
+}
+
+function childRawPath(parentRawPath: string, component: string): string {
+  if (component === '/') {
+    return '/';
+  }
+  if (parentRawPath === '' || parentRawPath === '/') {
+    return `${parentRawPath}${component}`;
+  }
+  return `${parentRawPath}/${component}`;
+}
+
+function addPath(root: PathTreeNode, parsedPath: ParsedPath): void {
+  let node = root;
+  for (const component of parsedPath.components) {
+    const existing = node.children.get(component);
+    if (existing) {
+      node = existing;
+    } else {
+      const child = createNode(component, childRawPath(node.rawPath, component));
+      node.children.set(component, child);
+      node = child;
+    }
+  }
+  node.label = parsedPath.label;
+}
+
+function relativeRawPath(fromPath: string, toPath: string): string {
+  if (fromPath === '/') {
+    return toPath.startsWith('/') ? toPath.slice(1) : toPath;
+  }
+  if (toPath === fromPath) {
+    return '';
+  }
+  if (toPath.startsWith(`${fromPath}/`)) {
+    return toPath.slice(fromPath.length + 1);
+  }
+  return toPath;
+}
+
+function appendDirectorySlash(name: string, hasChildren: boolean): string {
+  return hasChildren && !name.endsWith('/') ? `${name}/` : name;
+}
+
+function formatLeaf(node: PathTreeNode, displayName: string): string {
+  return node.label ? `${displayName} — ${node.label}` : displayName;
+}
+
+function flattenSingleChildChain(node: PathTreeNode): PathTreeNode {
+  let current = node;
+  while (current.children.size === 1 && current.label === undefined) {
+    const onlyChild = current.children.values().next().value;
+    if (!onlyChild) break;
+    current = onlyChild;
+  }
+  return current;
+}
+
+function renderNode(
+  node: PathTreeNode,
+  prefix: string,
+  isLast: boolean,
+  parentRawPath: string | undefined,
+  formatPath: (path: string) => string,
+): string[] {
+  const flattened = flattenSingleChildChain(node);
+  const displayName = appendDirectorySlash(
+    parentRawPath === undefined
+      ? formatPath(flattened.rawPath)
+      : relativeRawPath(parentRawPath, flattened.rawPath),
+    flattened.children.size > 0,
+  );
+  const branch = isLast ? '└── ' : '├── ';
+  const lines = [`${prefix}${branch}${formatLeaf(flattened, displayName)}`];
+  const children = [...flattened.children.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  const childPrefix = `${prefix}${isLast ? '    ' : '│   '}`;
+
+  children.forEach((child, index) => {
+    lines.push(
+      ...renderNode(
+        child,
+        childPrefix,
+        index === children.length - 1,
+        flattened.rawPath,
+        formatPath,
+      ),
+    );
+  });
+
+  return lines;
+}
+
+function topLevelNodes(root: PathTreeNode): PathTreeNode[] {
+  const children = [...root.children.values()];
+  const onlyChild = children.length === 1 ? children[0] : undefined;
+  if (onlyChild && onlyChild.name === '/' && onlyChild.children.size > 1) {
+    return [...onlyChild.children.values()];
+  }
+  return children;
+}
+
+export function formatPathTree(
+  entries: readonly PathTreeEntry[],
+  options: PathTreeFormatOptions = {},
+): string[] {
+  const formatPath = options.formatPath ?? ((path: string): string => path);
+  const root = createNode('', '');
+  const parsedPaths = entries
+    .map(parseRawPath)
+    .filter((entry): entry is ParsedPath => entry !== null)
+    .sort((left, right) => left.sortablePath.localeCompare(right.sortablePath));
+
+  for (const parsedPath of parsedPaths) {
+    addPath(root, parsedPath);
+  }
+
+  const nodes = topLevelNodes(root).sort((left, right) =>
+    left.rawPath.localeCompare(right.rawPath),
+  );
+  return nodes.flatMap((child, index) =>
+    renderNode(child, '', index === nodes.length - 1, undefined, formatPath),
+  );
+}

--- a/src/utils/runtime-config-schema.ts
+++ b/src/utils/runtime-config-schema.ts
@@ -12,6 +12,7 @@ export const runtimeConfigFileSchema = z
     disableSessionDefaults: z.boolean().optional(),
     disableXcodeAutoSync: z.boolean().optional(),
     showTestTiming: z.boolean().optional(),
+    filePathRenderStyle: z.enum(['tree', 'list']).optional(),
     uiDebuggerGuardMode: z.enum(['error', 'warn', 'off']).optional(),
     incrementalBuildsEnabled: z.boolean().optional(),
     dapRequestTimeoutMs: z.number().int().positive().optional(),

--- a/src/utils/runtime-config-types.ts
+++ b/src/utils/runtime-config-types.ts
@@ -1,1 +1,2 @@
 export type UiDebuggerGuardMode = 'error' | 'warn' | 'off';
+export type FilePathRenderStyle = 'tree' | 'list';

--- a/src/utils/typed-tool-factory.ts
+++ b/src/utils/typed-tool-factory.ts
@@ -2,6 +2,8 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import * as z from 'zod';
 import type { ToolHandlerContext } from '../rendering/types.ts';
 import { createRenderSession } from '../rendering/render.ts';
+import { getConfig } from './config-store.ts';
+import { normalizeRenderRuntime, resolveFilePathRenderStyle } from './file-path-render-style.ts';
 import { renderCliTextTranscript } from './renderers/cli-text-renderer.ts';
 import type { CommandExecutor } from './execution/index.ts';
 import type { DomainFragment } from '../types/domain-fragments.ts';
@@ -60,11 +62,17 @@ function setValidationErrorOutput(ctx: ToolHandlerContext, message: string, code
 }
 
 function sessionToTestResult(session: ReturnType<typeof createRenderSession>): ToolTestResult {
+  const runtime = normalizeRenderRuntime(process.env.XCODEBUILDMCP_RUNTIME);
   const text = renderCliTextTranscript({
     items: [],
     structuredOutput: session.getStructuredOutput?.(),
     nextSteps: session.getNextSteps?.(),
     nextStepsRuntime: session.getNextStepsRuntime?.(),
+    includeHeaderDetails: runtime !== 'mcp',
+    filePathRenderStyle: resolveFilePathRenderStyle({
+      configured: getConfig().filePathRenderStyle,
+      runtime,
+    }),
   });
 
   const content: Array<{ type: 'text'; text: string }> = [];


### PR DESCRIPTION
Add configurable file artifact rendering for text output.

CLI text output now defaults to a labeled `Files:` list so paths are easier to scan in terminal output, while MCP text output keeps the compact tree format that is better suited to tool responses. The render style can be overridden through `filePathRenderStyle` in project config, `XCODEBUILDMCP_FILE_PATH_RENDER_STYLE`, or `--file-path-render-style` on CLI tool commands.

This also routes resource rendering through the shared renderer so MCP resources use the same runtime-aware defaults, and updates snapshot normalization for the displayed `~/Library/Developer/XcodeBuildMCP` paths produced by the new output.
