### PR TITLE
ci(warden): Refine PR review checks

### DIFF
--- a/.github/workflows/warden-sweep.yml
+++ b/.github/workflows/warden-sweep.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # contents: write required for sweep to open draft fix PRs
 # issues: write required for the sweep tracking issue

--- a/.github/workflows/warden-sweep.yml
+++ b/.github/workflows/warden-sweep.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     # 06:00 UTC every Monday
-    - cron: "0 6 * * 1"
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 # contents: write required for sweep to open draft fix PRs
 # issues: write required for the sweep tracking issue
@@ -17,12 +21,13 @@ permissions:
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     env:
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
       WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: getsentry/warden@v0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: getsentry/warden@2130c979dec0163048d954d9599504e2d9fa2b07
         with:
           anthropic-api-key: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
 
@@ -79,7 +84,7 @@ jobs:
 
       - name: Upload Warden findings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: warden-findings
           path: ${{ runner.temp }}/warden-findings.json

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # contents: write required for resolving review threads via GraphQL
 # See: https://github.com/orgs/community/discussions/44650
 permissions:
@@ -14,11 +18,12 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
       WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: getsentry/warden@v0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: getsentry/warden@2130c979dec0163048d954d9599504e2d9fa2b07
         with:
           anthropic-api-key: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}

--- a/warden.toml
+++ b/warden.toml
@@ -16,6 +16,8 @@ version = 1
 failOn = "high"
 # reportOn: minimum severity that creates PR annotations
 reportOn = "medium"
+# Avoid noisy no-op PR reporting.
+reportOnSuccess = false
 
 # warden-sweep is a full-repo sweep. PR-trigger is intentionally omitted so
 # it does not run on every PR. It runs:
@@ -41,6 +43,8 @@ fixBranchPrefix = "warden-sweep"
 
 [[skills]]
 name = "xcodebuildmcp-docs-release-review"
+maxTurns = 10
+maxFindings = 5
 paths = [
   "README.md",
   "CHANGELOG.md",
@@ -57,6 +61,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-docs-command-review"
+maxTurns = 8
+maxFindings = 5
 paths = [
   "CHANGELOG.md",
 ]
@@ -67,6 +73,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-packaging-resource-review"
+maxTurns = 10
+maxFindings = 5
 paths = [
   "package.json",
   "scripts/copy-build-assets.js",
@@ -84,6 +92,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-rendering-streaming-review"
+maxTurns = 10
+maxFindings = 5
 paths = [
   "src/rendering/**",
   "src/types/domain-fragments.ts",
@@ -101,6 +111,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-runtime-boundary-review"
+maxTurns = 8
+maxFindings = 5
 paths = [
   "src/runtime/tool-catalog.ts",
   "src/runtime/tool-invoker.ts",
@@ -119,12 +131,15 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-snapshot-fixture-review"
+maxTurns = 10
+maxFindings = 5
 paths = [
   "src/snapshot-tests/contracts.ts",
   "src/snapshot-tests/fixture-io.ts",
   "src/snapshot-tests/__tests__/fixture-io.test.ts",
   "src/snapshot-tests/__tests__/json-normalize.test.ts",
   "src/snapshot-tests/__tests__/json-fixture-schema.test.ts",
+  "src/snapshot-tests/__fixtures__/**",
   "xcodebuildmcp.com/app/docs/_content/testing.mdx",
 ]
 
@@ -134,6 +149,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-structured-output-review"
+maxTurns = 8
+maxFindings = 5
 paths = [
   "schemas/structured-output/**",
   "src/core/structured-output-schema.ts",
@@ -150,6 +167,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-test-boundary-review"
+maxTurns = 15
+maxFindings = 10
 paths = [
   "src/**/__tests__/**",
   "src/test-utils/**",
@@ -168,6 +187,8 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "xcodebuildmcp-tool-contract-review"
+maxTurns = 8
+maxFindings = 5
 paths = [
   "src/mcp/tools/**",
   "src/core/manifest/schema.ts",
@@ -187,19 +208,33 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "wrdn-pii"
-remote = "getsentry/warden-skills"
-paths = ["**/*"]
+remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
+paths = [
+  "src/**/*.ts",
+  "scripts/**/*.{js,mjs,sh,ts}",
+  ".github/workflows/*.yml",
+  ".github/workflows/*.yaml",
+  "README.md",
+  "CHANGELOG.md",
+  "xcodebuildmcp.com/app/docs/_content/**",
+]
 ignorePaths = [
+  "**/*.test.ts",
+  "**/__tests__/**",
+  "**/__fixtures__/**",
+  "**/__snapshots__/**",
   "src/snapshot-tests/__fixtures__/**",
 ]
 
+# Temporarily local-only until the Pi model selector failure seen in PR checks is resolved.
 [[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+type = "local"
 
 [[skills]]
 name = "wrdn-authz"
-remote = "getsentry/warden-skills"
+remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
+maxTurns = 15
+maxFindings = 5
 paths = ["src/**/*.ts"]
 ignorePaths = [
   "**/*.test.ts",
@@ -209,13 +244,23 @@ ignorePaths = [
 ]
 
 [[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+type = "schedule"
 
 [[skills]]
 name = "wrdn-code-execution"
-remote = "getsentry/warden-skills"
-paths = ["src/**/*.ts", "scripts/**/*.{js,mjs,sh,ts}"]
+remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
+maxTurns = 10
+maxFindings = 5
+paths = [
+  "src/cli/**",
+  "src/daemon/**",
+  "src/integrations/**",
+  "src/mcp/tools/**",
+  "src/runtime/tool-invoker.ts",
+  "src/utils/execution/**",
+  "src/utils/xcodemake/**",
+  "scripts/**/*.{js,mjs,sh,ts}",
+]
 ignorePaths = [
   "**/*.test.ts",
   "**/__tests__/**",
@@ -229,7 +274,9 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "wrdn-data-exfil"
-remote = "getsentry/warden-skills"
+remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
+maxTurns = 15
+maxFindings = 5
 paths = ["src/**/*.ts", "scripts/**/*.{js,mjs,sh,ts}"]
 ignorePaths = [
   "**/*.test.ts",
@@ -239,12 +286,13 @@ ignorePaths = [
 ]
 
 [[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+type = "schedule"
 
 [[skills]]
 name = "wrdn-gha-workflows"
-remote = "getsentry/warden-skills"
+remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
+maxTurns = 8
+maxFindings = 5
 paths = [
   ".github/workflows/*.yml",
   ".github/workflows/*.yaml",
@@ -262,8 +310,19 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "find-bugs"
-remote = "getsentry/skills"
-paths = ["src/**/*.ts", "scripts/**/*.{js,mjs,ts}"]
+remote = "getsentry/skills@b10e2db21d3165de1904bdf3fa64285016765fe5"
+maxTurns = 10
+maxFindings = 5
+paths = [
+  "src/cli/**",
+  "src/daemon/**",
+  "src/integrations/**",
+  "src/mcp/tools/**",
+  "src/runtime/**",
+  "src/server/**",
+  "src/utils/execution/**",
+  "scripts/**/*.{js,mjs,ts}",
+]
 ignorePaths = [
   "**/*.test.ts",
   "**/__tests__/**",
@@ -277,7 +336,9 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "code-review"
-remote = "getsentry/skills"
+remote = "getsentry/skills@b10e2db21d3165de1904bdf3fa64285016765fe5"
+maxTurns = 15
+maxFindings = 5
 paths = ["src/**/*.ts"]
 ignorePaths = [
   "**/*.test.ts",
@@ -287,12 +348,13 @@ ignorePaths = [
 ]
 
 [[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+type = "schedule"
 
 [[skills]]
 name = "code-simplifier"
-remote = "getsentry/skills"
+remote = "getsentry/skills@b10e2db21d3165de1904bdf3fa64285016765fe5"
+maxTurns = 10
+maxFindings = 5
 paths = ["src/**/*.ts"]
 ignorePaths = [
   "**/*.test.ts",
@@ -302,5 +364,4 @@ ignorePaths = [
 ]
 
 [[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
+type = "local"

--- a/warden.toml
+++ b/warden.toml
@@ -252,9 +252,13 @@ remote = "getsentry/warden-skills@6f720b5c4894e374f7a09707bae0de60d8b825df"
 maxTurns = 10
 maxFindings = 5
 paths = [
+  "src/cli.ts",
   "src/cli/**",
+  "src/daemon.ts",
   "src/daemon/**",
+  "src/doctor-cli.ts",
   "src/integrations/**",
+  "src/mcp/resources/**",
   "src/mcp/tools/**",
   "src/runtime/tool-invoker.ts",
   "src/utils/execution/**",
@@ -314,9 +318,13 @@ remote = "getsentry/skills@b10e2db21d3165de1904bdf3fa64285016765fe5"
 maxTurns = 10
 maxFindings = 5
 paths = [
+  "src/cli.ts",
   "src/cli/**",
+  "src/daemon.ts",
   "src/daemon/**",
+  "src/doctor-cli.ts",
   "src/integrations/**",
+  "src/mcp/resources/**",
   "src/mcp/tools/**",
   "src/runtime/**",
   "src/server/**",


### PR DESCRIPTION
Refine Warden's PR-time review setup so routine PRs get faster, higher-signal feedback.

This keeps Warden in the PR loop, but narrows it to an explicit fast lane: project-specific checks, one bounded generic bug finder, and targeted security/workflow checks. Broad or low-signal reviews move out of normal PR cadence, and every remaining PR skill gets explicit budgets so neutral/no-op checks do not consume unbounded feedback time.

The PR also adds workflow timeout/concurrency guardrails and pins Warden-related actions/remotes to immutable refs. This should make Warden behavior more reproducible and prevent obsolete runs from continuing after newer commits arrive.

Notes for review:
- `wrdn-pii` is local-only for now because recent PR history showed a Pi model selector failure.
- `find-bugs` stays on PRs, but is narrowed to higher-risk runtime/tooling paths.
- Broad `code-review` moves to scheduled review, and `code-simplifier` becomes local-only cleanup.
