### PR TITLE
test(ui-automation): cover SwiftUI tab identifier surfacing (#442)

### DIFF
--- a/src/mcp/tools/ui-automation/__tests__/runtime-snapshot.test.ts
+++ b/src/mcp/tools/ui-automation/__tests__/runtime-snapshot.test.ts
@@ -167,6 +167,74 @@ describe('runtime snapshot normalization', () => {
     );
   });
 
+  // Regression coverage for issue #442. A `.accessibilityIdentifier(...)` applied to a
+  // SwiftUI `Tab` is not forwarded to the native tab bar item's accessibility element,
+  // so `describe-ui` reports no AXUniqueId/AXIdentifier for the tab (confirmed by
+  // reproducing on a simulator: the identifier string is absent from the entire AX
+  // tree, while an identifier on the tab's content still propagates normally). The
+  // snapshot must still expose the tab for automation via role + label, and must not
+  // invent an identifier or leak the tab's SF Symbol image identifier onto the tab.
+  it('does not surface an identifier for SwiftUI tabs that expose none (issue #442)', () => {
+    const snapshot = createRuntimeSnapshotRecord({
+      simulatorId,
+      uiHierarchy: [
+        createNode({
+          type: 'RadioButton',
+          role: 'AXRadioButton',
+          subrole: 'AXTabButton',
+          role_description: 'tab',
+          AXLabel: 'Wheels',
+          AXValue: '0',
+          frame: { x: 120, y: 780, width: 80, height: 50 },
+          children: [
+            createNode({
+              type: 'Image',
+              role: 'AXImage',
+              role_description: 'image',
+              AXLabel: 'arrow.trianglehead.2.clockwise',
+              AXUniqueId: 'arrow.trianglehead.2.clockwise',
+              frame: { x: 140, y: 786, width: 30, height: 30 },
+            }),
+          ],
+        }),
+      ],
+      nowMs: 1_000,
+    });
+
+    const tab = snapshot.payload.elements.find((element) => element.role === 'tab');
+    expect(tab).toEqual(
+      expect.objectContaining({
+        role: 'tab',
+        label: 'Wheels',
+        value: '0',
+        actions: expect.arrayContaining(['tap']),
+      }),
+    );
+    expect(tab).not.toHaveProperty('identifier');
+  });
+
+  it('surfaces a tab identifier when the platform does expose one (issue #442)', () => {
+    const snapshot = createRuntimeSnapshotRecord({
+      simulatorId,
+      uiHierarchy: [
+        createNode({
+          type: 'RadioButton',
+          role: 'AXRadioButton',
+          subrole: 'AXTabButton',
+          role_description: 'tab',
+          AXLabel: 'Wheels',
+          AXValue: '0',
+          AXUniqueId: 'tab_wheels',
+        }),
+      ],
+      nowMs: 1_000,
+    });
+
+    expect(snapshot.payload.elements.find((element) => element.role === 'tab')).toEqual(
+      expect.objectContaining({ role: 'tab', label: 'Wheels', identifier: 'tab_wheels' }),
+    );
+  });
+
   it('derives deterministic screen hashes from normalized UI content', () => {
     const uiHierarchy = [createNode({ AXLabel: 'Continue' }), createNode({ AXLabel: 'Cancel' })];
 


### PR DESCRIPTION
## Summary

Adds regression coverage for the `SwiftUI.Tab` accessibility-identifier behavior described in #442, and documents (via the tests and this PR) what `snapshot-ui` can and cannot surface for native tabs.

No production behavior changes. `normalizeNode` already reads `AXUniqueId`/`AXIdentifier` when present; the tests lock in that a tab is still exposed for automation by role + label when the platform provides no identifier, and that an identifier is surfaced when it is present.

## Background

#442 reports that an `.accessibilityIdentifier(...)` set on a `SwiftUI.Tab` does not appear on the native tab target emitted by `snapshot-ui`, and asks whether the identifier can be surfaced or whether this is expected SwiftUI/UIKit behavior.

I reproduced it on an iPhone 17 Pro simulator with a minimal app:

```swift
TabView(selection: $selectedTab) {
    SwiftUI.Tab("Wheels", systemImage: "arrow.trianglehead.2.clockwise", value: .wheels) {
        Text("Wheels screen").accessibilityIdentifier("screen_wheels")
    }
    .accessibilityLabel("Wheels")
    .accessibilityIdentifier("tab_wheels")
}
```

Running `axe describe-ui` against it, the tab node is:

```jsonc
{
  "role": "AXRadioButton",
  "role_description": "tab",
  "subrole": "AXTabButton",
  "AXLabel": "Wheels",
  "AXValue": 0,
  "AXUniqueId": null,        // <- no identifier
  "children": [ { "role": "AXImage", "AXUniqueId": "arrow.trianglehead.2.clockwise" } ]
}
```

The `tab_wheels` string is absent from the entire accessibility tree. In contrast, `screen_wheels`/`screen_dashboard` applied to the tab's content does propagate normally. So this is a SwiftUI/UIKit limitation: the identifier applied to a `Tab` is not forwarded to the underlying tab bar item's accessibility element. There is no identifier in the tree for `snapshot-ui` to surface.

## Solution

Two focused unit tests in `runtime-snapshot.test.ts`:

1. A `SwiftUI.Tab`-shaped node with no `AXUniqueId` (matching the reproduced AX shape, including the SF Symbol child image) is still exposed as a `tab` with its label and a `tap` action, and does not gain an invented identifier or leak the child image's symbol identifier.
2. A tab node that does expose an `AXUniqueId` surfaces it as the element `identifier`, confirming the parser already forwards identifiers when the platform provides them.

The practical guidance for tab automation stays: target tabs by `role=tab` plus visible label, which already works.

## Testing

- `npm run typecheck` (after `npm run generate:version`) - pass
- `npm run lint` - pass
- `npm run format:check` - pass
- `npm run build` - pass
- `npm test` (`vitest run`) - 213 files, 2665 tests pass (includes the 2 new tests)
- Manual reproduction on iPhone 17 Pro simulator with bundled AXe `describe-ui`, as shown above

## Notes

- This documents expected platform behavior rather than fixing a parsing bug, so I did not use a closing keyword. If a website docs note ("tab automation should use role + label because SwiftUI does not forward a `Tab` identifier to the tab bar item") would help, I am happy to follow up.
- Test-only change, so no `CHANGELOG.md` entry was added.
