### PR TITLE
fix(mcp): do not await startup lifecycle snapshot on critical path

### DIFF
--- a/src/server/start-mcp-server.ts
+++ b/src/server/start-mcp-server.ts
@@ -189,7 +189,10 @@ export async function startMcpServer(): Promise<void> {
         // Prefer the phase at snapshot-schedule time for metrics; still log the
         // full snapshot object as returned for operational debugging.
         const metricPhase = startupMetricPhase;
-        log('info', `[mcp-lifecycle] start ${JSON.stringify({ ...startupSnapshot, phase: metricPhase })}`);
+        log(
+          'info',
+          `[mcp-lifecycle] start ${JSON.stringify({ ...startupSnapshot, phase: metricPhase })}`,
+        );
         recordMcpLifecycleMetric({
           event: 'start',
           phase: metricPhase,

--- a/src/server/start-mcp-server.ts
+++ b/src/server/start-mcp-server.ts
@@ -170,6 +170,11 @@ export async function startMcpServer(): Promise<void> {
     lifecycle.markPhase('running');
     idleShutdown.start();
 
+    // Capture phase at schedule time so deferred snapshot metrics are not
+    // attributed to a later phase (e.g. deferred-initialization) if markPhase
+    // advances before getSnapshot resolves. See #461 / review note.
+    const startupMetricPhase = 'running' as const;
+
     // Startup snapshot (simulator os_log sessions, peer process sample, etc.) is
     // telemetry-only. Awaiting it blocked the first tools/list by ~10–17s on cold
     // start, which makes short health-probe clients report "tools fetch failed"
@@ -181,10 +186,13 @@ export async function startMcpServer(): Promise<void> {
         if (lifecycle.isShutdownRequested()) {
           return;
         }
-        log('info', `[mcp-lifecycle] start ${JSON.stringify(startupSnapshot)}`);
+        // Prefer the phase at snapshot-schedule time for metrics; still log the
+        // full snapshot object as returned for operational debugging.
+        const metricPhase = startupMetricPhase;
+        log('info', `[mcp-lifecycle] start ${JSON.stringify({ ...startupSnapshot, phase: metricPhase })}`);
         recordMcpLifecycleMetric({
           event: 'start',
-          phase: startupSnapshot.phase,
+          phase: metricPhase,
           uptimeMs: startupSnapshot.uptimeMs,
           rssBytes: startupSnapshot.rssBytes,
           matchingMcpProcessCount: startupSnapshot.matchingMcpProcessCount,
@@ -194,7 +202,7 @@ export async function startMcpServer(): Promise<void> {
         for (const anomaly of startupSnapshot.anomalies) {
           recordMcpLifecycleAnomalyMetric({
             kind: anomaly,
-            phase: startupSnapshot.phase,
+            phase: metricPhase,
           });
         }
         if (startupSnapshot.anomalies.length > 0) {

--- a/src/server/start-mcp-server.ts
+++ b/src/server/start-mcp-server.ts
@@ -169,30 +169,48 @@ export async function startMcpServer(): Promise<void> {
 
     lifecycle.markPhase('running');
     idleShutdown.start();
-    const startupSnapshot = await lifecycle.getSnapshot();
-    log('info', `[mcp-lifecycle] start ${JSON.stringify(startupSnapshot)}`);
-    recordMcpLifecycleMetric({
-      event: 'start',
-      phase: startupSnapshot.phase,
-      uptimeMs: startupSnapshot.uptimeMs,
-      rssBytes: startupSnapshot.rssBytes,
-      matchingMcpProcessCount: startupSnapshot.matchingMcpProcessCount,
-      activeOperationCount: startupSnapshot.activeOperationCount,
-      watcherRunning: startupSnapshot.watcherRunning,
-    });
-    for (const anomaly of startupSnapshot.anomalies) {
-      recordMcpLifecycleAnomalyMetric({
-        kind: anomaly,
-        phase: startupSnapshot.phase,
+
+    // Startup snapshot (simulator os_log sessions, peer process sample, etc.) is
+    // telemetry-only. Awaiting it blocked the first tools/list by ~10–17s on cold
+    // start, which makes short health-probe clients report "tools fetch failed"
+    // even though the transport is already up. Keep the same logging/metrics, but
+    // do not block readiness on the snapshot. See #461.
+    void lifecycle
+      .getSnapshot()
+      .then((startupSnapshot) => {
+        if (lifecycle.isShutdownRequested()) {
+          return;
+        }
+        log('info', `[mcp-lifecycle] start ${JSON.stringify(startupSnapshot)}`);
+        recordMcpLifecycleMetric({
+          event: 'start',
+          phase: startupSnapshot.phase,
+          uptimeMs: startupSnapshot.uptimeMs,
+          rssBytes: startupSnapshot.rssBytes,
+          matchingMcpProcessCount: startupSnapshot.matchingMcpProcessCount,
+          activeOperationCount: startupSnapshot.activeOperationCount,
+          watcherRunning: startupSnapshot.watcherRunning,
+        });
+        for (const anomaly of startupSnapshot.anomalies) {
+          recordMcpLifecycleAnomalyMetric({
+            kind: anomaly,
+            phase: startupSnapshot.phase,
+          });
+        }
+        if (startupSnapshot.anomalies.length > 0) {
+          log(
+            'warn',
+            `[mcp-lifecycle] startup anomalies observed: ${startupSnapshot.anomalies.join(', ')}`,
+            { sentry: true },
+          );
+        }
+      })
+      .catch((error) => {
+        log(
+          'warn',
+          `Startup lifecycle snapshot failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
       });
-    }
-    if (startupSnapshot.anomalies.length > 0) {
-      log(
-        'warn',
-        `[mcp-lifecycle] startup anomalies observed: ${startupSnapshot.anomalies.join(', ')}`,
-        { sentry: true },
-      );
-    }
 
     lifecycle.markPhase('deferred-initialization');
     void bootstrap


### PR DESCRIPTION
## Summary

Fixes #461.

After the stdio transport is up, `startMcpServer()` was still **awaiting** `lifecycle.getSnapshot()` before the server could settle into answering the first `tools/list`. That snapshot work (simulator os_log session enumeration, peer process sample, etc.) is telemetry-only and was delaying the first `tools/list` by ~10–17s on cold start. Short health-probe clients (e.g. Claude Code `claude mcp list`) then report `Connected · tools fetch failed` even though the server is healthy.

## Change

Move the startup snapshot off the critical path:

- Fire-and-forget `lifecycle.getSnapshot()` with the same start metrics / anomaly logging
- Skip logging if shutdown was already requested
- Surface snapshot failures as warnings (same spirit as deferred bootstrap)

This matches the existing deferred-initialization pattern immediately below the old await.

## Why not delete the snapshot

The issue asks to keep the telemetry; only readiness should not block on it. Metrics and anomaly warnings still run asynchronously.

## Test plan

- [ ] `xcodebuildmcp mcp` over stdio: `initialize` then immediate `tools/list` should return without the multi-second cold-start stall
- [ ] Confirm `[mcp-lifecycle] start …` still appears in logs shortly after startup
- [ ] In-session tools (`list_sims`, etc.) still work
- [ ] Startup anomaly warnings (if any) still log

## Notes

- Cannot fully re-time simulator enumeration on this contributor environment; logic change matches the issue’s verified root cause and suggested fix.
- Minimal one-file change.
