### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added Autohand Code MCP client setup documentation ([#471](https://github.com/getsentry/XcodeBuildMCP/pull/471) by [@igorcosta](https://github.com/igorcosta)).
 - Added `extraArgs` as a first-class session-default value. Repo config or runtime defaults can now carry common `xcodebuild` flags (for example `-skipPackagePluginValidation` or `-disableAutomaticPackageResolution`) so they don't need repeating on every build or test call. Per-call `extraArgs` replace matching configured flags or build settings and append after non-matching defaults, while an explicit empty array (`extraArgs: []`) clears the defaults for a single call. The session management tools show, set, sync, and clear `extraArgs` alongside the other defaults.
 
 ## [2.6.2]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ xcodebuildmcp --help
 
 Drop-in config snippets for Cursor, Claude Code, Codex, can be found in the official docs page [MCP Clients](https://xcodebuildmcp.com/docs/clients). Most clients can also run the MCP server on demand via `npx -y xcodebuildmcp@latest mcp` without a global install.
 
+For Autohand Code, add the server from the command line:
+
+```bash
+autohand mcp add xcodebuildmcp npx -y xcodebuildmcp@latest mcp
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ## Requirements
 
 - macOS 14.5 or later


### PR DESCRIPTION
## What changed

Adds Autohand Code to the README's MCP client setup, using XcodeBuildMCP's documented on-demand command: `npx -y xcodebuildmcp@latest mcp`.

The note also includes the project-scoped option and links to the current Autohand Code CLI documentation.

## Verification

- Checked the command against the current Autohand Code MCP CLI
- Ran `git diff --check`

This is a documentation-only change.
