### PR TITLE
fix(macos): prevent stop_mac_app from terminating unrelated processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `suppressWarnings` being ignored in settled build, build-run, and test output. The flag was honored only while streaming, so warnings still reached the final MCP tool response ([#447](https://github.com/getsentry/XcodeBuildMCP/issues/447)).
 - Fixed iOS scaffold orientation and device-family settings, LLDB command isolation and argument escaping, run-destination parsing without an active scheme, concurrent working-directory mutations, blocking physical-device name lookup, and unverified `xcodemake` downloads ([#459](https://github.com/getsentry/XcodeBuildMCP/issues/459)).
 - Fixed simulator UI launching and keyboard controls to prefer Xcode 27's Device Hub when available, with Simulator.app as the legacy fallback.
+- Fixed `stop_mac_app` app-name targeting so it no longer terminates unrelated processes whose command lines contain the app name, and reject unsafe process IDs before execution ([#306](https://github.com/getsentry/XcodeBuildMCP/issues/306)).
 
 ## [2.6.2]
 

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -24,6 +24,8 @@ describe('stop_mac_app plugin', () => {
       expect(schema.processId.safeParse(0).success).toBe(false);
       expect(schema.processId.safeParse(-1).success).toBe(false);
       expect(schema.processId.safeParse(1.5).success).toBe(false);
+      expect(schema.processId.safeParse(Number.NaN).success).toBe(false);
+      expect(schema.processId.safeParse(Number.MAX_SAFE_INTEGER + 1).success).toBe(false);
     });
   });
 
@@ -34,6 +36,20 @@ describe('stop_mac_app plugin', () => {
       expect(result.isError).toBe(true);
       expect(allText(result)).toContain('appName or processId');
     });
+
+    it.each([0, -1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 1])(
+      'should reject unsafe process ID %s at the execution boundary',
+      async (processId) => {
+        const calls: string[][] = [];
+        const executor = createMockExecutor({ onExecute: (command) => calls.push(command) });
+
+        const result = await runLogic(() => stop_mac_appLogic({ processId }, executor));
+
+        expect(result.isError).toBe(true);
+        expect(allText(result)).toContain('processId must be a positive safe integer');
+        expect(calls).toHaveLength(0);
+      },
+    );
   });
 
   describe('Command Generation', () => {

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -88,8 +88,7 @@ describe('stop_mac_app plugin', () => {
       );
 
       expect(calls).toHaveLength(1);
-      expect(calls[0]).toEqual(['pkill', '-x', '--', 'Brimday']);
-      expect(calls[0]).not.toContain('-f');
+      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?Brimday( |$)']);
     });
 
     it('should preserve long app executable names', async () => {
@@ -107,7 +106,7 @@ describe('stop_mac_app plugin', () => {
         ),
       );
 
-      expect(calls[0]).toEqual(['pkill', '-x', '--', 'ThisIsAVeryLongApplicationName']);
+      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?ThisIsAVeryLongApplicationName( |$)']);
     });
 
     it('should treat app names as literal process names', async () => {
@@ -125,7 +124,7 @@ describe('stop_mac_app plugin', () => {
         ),
       );
 
-      expect(calls[0]).toEqual(['pkill', '-x', '--', '-Example\\.\\*\\[Test\\]']);
+      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?-Example\\.\\*\\[Test\\]( |$)']);
     });
 
     it('should prioritize processId over appName', async () => {

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -72,7 +72,7 @@ describe('stop_mac_app plugin', () => {
       expect(calls[0]).toEqual(['kill', '1234']);
     });
 
-    it('should avoid matching app names in unrelated process arguments', async () => {
+    it('should target app names by literal process name', async () => {
       const calls: string[][] = [];
       const mockExecutor = createMockExecutor({
         onExecute: (command) => calls.push(command),
@@ -88,7 +88,7 @@ describe('stop_mac_app plugin', () => {
       );
 
       expect(calls).toHaveLength(1);
-      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?Brimday( |$)']);
+      expect(calls[0]).toEqual(['killall', '--', 'Brimday']);
     });
 
     it('should preserve long app executable names', async () => {
@@ -106,7 +106,7 @@ describe('stop_mac_app plugin', () => {
         ),
       );
 
-      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?ThisIsAVeryLongApplicationName( |$)']);
+      expect(calls[0]).toEqual(['killall', '--', 'ThisIsAVeryLongApplicationName']);
     });
 
     it('should treat app names as literal process names', async () => {
@@ -124,7 +124,7 @@ describe('stop_mac_app plugin', () => {
         ),
       );
 
-      expect(calls[0]).toEqual(['pkill', '-f', '--', '^(.*/)?-Example\\.\\*\\[Test\\]( |$)']);
+      expect(calls[0]).toEqual(['killall', '--', '-Example.*[Test]']);
     });
 
     it('should prioritize processId over appName', async () => {

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -91,7 +91,7 @@ describe('stop_mac_app plugin', () => {
       expect(calls[0]).toEqual(['killall', '--', 'Brimday']);
     });
 
-    it('should preserve long app executable names', async () => {
+    it('should pass long app executable names to killall', async () => {
       const calls: string[][] = [];
       const mockExecutor = createMockExecutor({
         onExecute: (command) => calls.push(command),

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { schema, handler, stop_mac_appLogic } from '../stop_mac_app.ts';
-import { allText, runLogic } from '../../../../test-utils/test-helpers.ts';
+import {
+  allText,
+  createMockToolHandlerContext,
+  runLogic,
+} from '../../../../test-utils/test-helpers.ts';
 import { createMockExecutor, createNoopExecutor } from '../../../../test-utils/mock-executors.ts';
 
 describe('stop_mac_app plugin', () => {
@@ -42,11 +46,18 @@ describe('stop_mac_app plugin', () => {
       async (processId) => {
         const calls: string[][] = [];
         const executor = createMockExecutor({ onExecute: (command) => calls.push(command) });
+        const { ctx, result, run } = createMockToolHandlerContext();
 
-        const result = await runLogic(() => stop_mac_appLogic({ processId }, executor));
+        await run(() => stop_mac_appLogic({ processId }, executor));
 
-        expect(result.isError).toBe(true);
-        expect(allText(result)).toContain('processId must be a positive safe integer');
+        expect(result.isError()).toBe(true);
+        expect(result.text()).toContain('processId must be a positive safe integer');
+        const structuredResult = ctx.structuredOutput?.result;
+        expect(structuredResult?.kind).toBe('stop-result');
+        if (structuredResult?.kind !== 'stop-result') {
+          throw new Error('Expected stop-result structured output.');
+        }
+        expect(structuredResult.artifacts).toEqual({ appName: '' });
         expect(calls).toHaveLength(0);
       },
     );

--- a/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
+++ b/src/mcp/tools/macos/__tests__/stop_mac_app.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { schema, handler, stop_mac_appLogic } from '../stop_mac_app.ts';
 import { allText, runLogic } from '../../../../test-utils/test-helpers.ts';
+import { createMockExecutor, createNoopExecutor } from '../../../../test-utils/mock-executors.ts';
 
 describe('stop_mac_app plugin', () => {
   describe('Export Field Validation (Literal)', () => {
@@ -17,15 +18,18 @@ describe('stop_mac_app plugin', () => {
 
       // Test invalid inputs
       expect(schema.appName.safeParse(null).success).toBe(false);
+      expect(schema.appName.safeParse('').success).toBe(false);
       expect(schema.processId.safeParse('not-number').success).toBe(false);
       expect(schema.processId.safeParse(null).success).toBe(false);
+      expect(schema.processId.safeParse(0).success).toBe(false);
+      expect(schema.processId.safeParse(-1).success).toBe(false);
+      expect(schema.processId.safeParse(1.5).success).toBe(false);
     });
   });
 
   describe('Input Validation', () => {
     it('should return exact validation error for missing parameters', async () => {
-      const mockExecutor = async () => ({ success: true, output: '', process: {} as any });
-      const result = await runLogic(() => stop_mac_appLogic({}, mockExecutor));
+      const result = await runLogic(() => stop_mac_appLogic({}, createNoopExecutor()));
 
       expect(result.isError).toBe(true);
       expect(allText(result)).toContain('appName or processId');
@@ -34,11 +38,10 @@ describe('stop_mac_app plugin', () => {
 
   describe('Command Generation', () => {
     it('should generate correct command for process ID', async () => {
-      const calls: any[] = [];
-      const mockExecutor = async (command: string[]) => {
-        calls.push({ command });
-        return { success: true, output: '', process: {} as any };
-      };
+      const calls: string[][] = [];
+      const mockExecutor = createMockExecutor({
+        onExecute: (command) => calls.push(command),
+      });
 
       await runLogic(() =>
         stop_mac_appLogic(
@@ -50,35 +53,70 @@ describe('stop_mac_app plugin', () => {
       );
 
       expect(calls).toHaveLength(1);
-      expect(calls[0].command).toEqual(['kill', '1234']);
+      expect(calls[0]).toEqual(['kill', '1234']);
     });
 
-    it('should generate correct command for app name', async () => {
-      const calls: any[] = [];
-      const mockExecutor = async (command: string[]) => {
-        calls.push({ command });
-        return { success: true, output: '', process: {} as any };
-      };
+    it('should avoid matching app names in unrelated process arguments', async () => {
+      const calls: string[][] = [];
+      const mockExecutor = createMockExecutor({
+        onExecute: (command) => calls.push(command),
+      });
 
       await runLogic(() =>
         stop_mac_appLogic(
           {
-            appName: 'Calculator',
+            appName: 'Brimday',
           },
           mockExecutor,
         ),
       );
 
       expect(calls).toHaveLength(1);
-      expect(calls[0].command).toEqual(['pkill', '-f', 'Calculator']);
+      expect(calls[0]).toEqual(['pkill', '-x', '--', 'Brimday']);
+      expect(calls[0]).not.toContain('-f');
+    });
+
+    it('should preserve long app executable names', async () => {
+      const calls: string[][] = [];
+      const mockExecutor = createMockExecutor({
+        onExecute: (command) => calls.push(command),
+      });
+
+      await runLogic(() =>
+        stop_mac_appLogic(
+          {
+            appName: 'ThisIsAVeryLongApplicationName',
+          },
+          mockExecutor,
+        ),
+      );
+
+      expect(calls[0]).toEqual(['pkill', '-x', '--', 'ThisIsAVeryLongApplicationName']);
+    });
+
+    it('should treat app names as literal process names', async () => {
+      const calls: string[][] = [];
+      const mockExecutor = createMockExecutor({
+        onExecute: (command) => calls.push(command),
+      });
+
+      await runLogic(() =>
+        stop_mac_appLogic(
+          {
+            appName: '-Example.*[Test]',
+          },
+          mockExecutor,
+        ),
+      );
+
+      expect(calls[0]).toEqual(['pkill', '-x', '--', '-Example\\.\\*\\[Test\\]']);
     });
 
     it('should prioritize processId over appName', async () => {
-      const calls: any[] = [];
-      const mockExecutor = async (command: string[]) => {
-        calls.push({ command });
-        return { success: true, output: '', process: {} as any };
-      };
+      const calls: string[][] = [];
+      const mockExecutor = createMockExecutor({
+        onExecute: (command) => calls.push(command),
+      });
 
       await runLogic(() =>
         stop_mac_appLogic(
@@ -91,13 +129,13 @@ describe('stop_mac_app plugin', () => {
       );
 
       expect(calls).toHaveLength(1);
-      expect(calls[0].command).toEqual(['kill', '1234']);
+      expect(calls[0]).toEqual(['kill', '1234']);
     });
   });
 
   describe('Response Processing', () => {
     it('should return exact successful stop response by app name', async () => {
-      const mockExecutor = async () => ({ success: true, output: '', process: {} as any });
+      const mockExecutor = createMockExecutor({});
 
       const result = await runLogic(() =>
         stop_mac_appLogic(
@@ -112,7 +150,7 @@ describe('stop_mac_app plugin', () => {
     });
 
     it('should return exact successful stop response with both parameters (processId takes precedence)', async () => {
-      const mockExecutor = async () => ({ success: true, output: '', process: {} as any });
+      const mockExecutor = createMockExecutor({});
 
       const result = await runLogic(() =>
         stop_mac_appLogic(
@@ -128,9 +166,7 @@ describe('stop_mac_app plugin', () => {
     });
 
     it('should handle execution errors', async () => {
-      const mockExecutor = async () => {
-        throw new Error('Process not found');
-      };
+      const mockExecutor = createMockExecutor(new Error('Process not found'));
 
       const result = await runLogic(() =>
         stop_mac_appLogic(

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -83,7 +83,12 @@ export function createStopMacAppExecutor(
       const command =
         params.processId !== undefined
           ? ['kill', String(params.processId)]
-          : ['pkill', '-x', '--', escapeExtendedRegularExpression(params.appName!)];
+          : [
+              'pkill',
+              '-f',
+              '--',
+              `^(.*/)?${escapeExtendedRegularExpression(params.appName!)}( |$)`,
+            ];
       const result = await executor(command, 'Stop macOS App');
 
       if (!result.success) {

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -59,19 +59,21 @@ export function createStopMacAppExecutor(
   executor: CommandExecutor,
 ): NonStreamingExecutor<StopMacAppParams, StopMacAppResult> {
   return async (params) => {
-    const artifacts = createStopMacAppArtifacts(params);
-
     if (!params.appName && params.processId === undefined) {
-      return buildStopFailure(artifacts, 'Either appName or processId must be provided.');
+      return buildStopFailure({ appName: '' }, 'Either appName or processId must be provided.');
     }
 
     if (
       params.processId !== undefined &&
       (!Number.isSafeInteger(params.processId) || params.processId <= 0)
     ) {
-      return buildStopFailure(artifacts, 'processId must be a positive safe integer.');
+      return buildStopFailure(
+        { appName: params.appName ?? '' },
+        'processId must be a positive safe integer.',
+      );
     }
 
+    const artifacts = createStopMacAppArtifacts(params);
     const target = params.processId !== undefined ? `PID ${params.processId}` : params.appName!;
     log('info', `Stopping macOS app: ${target}`);
 

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -14,12 +14,16 @@ import {
 } from '../../../utils/app-lifecycle-results.ts';
 
 const stopMacAppSchema = z.object({
-  appName: z.string().optional(),
-  processId: z.number().optional(),
+  appName: z.string().min(1).optional(),
+  processId: z.number().int().positive().optional(),
 });
 
 type StopMacAppParams = z.infer<typeof stopMacAppSchema>;
 type StopMacAppResult = StopResultDomainResult;
+
+function escapeExtendedRegularExpression(value: string): string {
+  return value.replace(/[\\.^$*+?()[\]{}|]/g, '\\$&');
+}
 
 export async function stop_mac_appLogic(
   params: StopMacAppParams,
@@ -60,14 +64,14 @@ export function createStopMacAppExecutor(
       return buildStopFailure(artifacts, 'Either appName or processId must be provided.');
     }
 
-    const target = params.processId ? `PID ${params.processId}` : params.appName!;
+    const target = params.processId !== undefined ? `PID ${params.processId}` : params.appName!;
     log('info', `Stopping macOS app: ${target}`);
 
     try {
       const command =
         params.processId !== undefined
           ? ['kill', String(params.processId)]
-          : ['pkill', '-f', params.appName!];
+          : ['pkill', '-x', '--', escapeExtendedRegularExpression(params.appName!)];
       const result = await executor(command, 'Stop macOS App');
 
       if (!result.success) {

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -64,6 +64,13 @@ export function createStopMacAppExecutor(
       return buildStopFailure(artifacts, 'Either appName or processId must be provided.');
     }
 
+    if (
+      params.processId !== undefined &&
+      (!Number.isSafeInteger(params.processId) || params.processId <= 0)
+    ) {
+      return buildStopFailure(artifacts, 'processId must be a positive safe integer.');
+    }
+
     const target = params.processId !== undefined ? `PID ${params.processId}` : params.appName!;
     log('info', `Stopping macOS app: ${target}`);
 

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -15,7 +15,12 @@ import {
 
 const stopMacAppSchema = z.object({
   appName: z.string().min(1).optional(),
-  processId: z.number().int().positive().optional(),
+  processId: z
+    .number()
+    .int()
+    .positive()
+    .refine(Number.isSafeInteger, 'processId must be a positive safe integer.')
+    .optional(),
 });
 
 type StopMacAppParams = z.infer<typeof stopMacAppSchema>;

--- a/src/mcp/tools/macos/stop_mac_app.ts
+++ b/src/mcp/tools/macos/stop_mac_app.ts
@@ -26,10 +26,6 @@ const stopMacAppSchema = z.object({
 type StopMacAppParams = z.infer<typeof stopMacAppSchema>;
 type StopMacAppResult = StopResultDomainResult;
 
-function escapeExtendedRegularExpression(value: string): string {
-  return value.replace(/[\\.^$*+?()[\]{}|]/g, '\\$&');
-}
-
 export async function stop_mac_appLogic(
   params: StopMacAppParams,
   executor: CommandExecutor,
@@ -83,12 +79,7 @@ export function createStopMacAppExecutor(
       const command =
         params.processId !== undefined
           ? ['kill', String(params.processId)]
-          : [
-              'pkill',
-              '-f',
-              '--',
-              `^(.*/)?${escapeExtendedRegularExpression(params.appName!)}( |$)`,
-            ];
+          : ['killall', '--', params.appName!];
       const result = await executor(command, 'Stop macOS App');
 
       if (!result.success) {

--- a/src/smoke-tests/__tests__/e2e-mcp-device-macos.test.ts
+++ b/src/smoke-tests/__tests__/e2e-mcp-device-macos.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
       'xctrace list devices': { success: true, output: 'No devices found.' },
       open: { success: true, output: '' },
       kill: { success: true, output: '' },
-      pkill: { success: true, output: '' },
+      killall: { success: true, output: '' },
       'defaults read': { success: true, output: 'io.sentry.MyApp' },
       PlistBuddy: { success: true, output: 'io.sentry.MyApp' },
       xcresulttool: { success: true, output: '{}' },
@@ -328,7 +328,7 @@ describe('MCP Device and macOS Tool Invocation (e2e)', () => {
       expect(commandStrs.some((c) => c.includes('kill') && c.includes('54321'))).toBe(true);
     });
 
-    it('stop_mac_app captures pkill command with appName', async () => {
+    it('stop_mac_app captures killall command with appName', async () => {
       harness.resetCapturedCommands();
       const result = await harness.client.callTool({
         name: 'stop_mac_app',
@@ -338,7 +338,7 @@ describe('MCP Device and macOS Tool Invocation (e2e)', () => {
       expectContent(result);
 
       const commandStrs = harness.capturedCommands.map((c) => c.command.join(' '));
-      expect(commandStrs.some((c) => c.includes('MyMacApp'))).toBe(true);
+      expect(commandStrs.some((c) => c === 'killall -- MyMacApp')).toBe(true);
     });
 
     it('get_mac_app_path captures xcodebuild showBuildSettings command', async () => {


### PR DESCRIPTION
## Problem

`stop_mac_app` stops a macOS application after XcodeBuildMCP launches it. A caller can target one process by ID, or target running processes by the application's executable name.

Name-based stops previously searched every process's full command line for the supplied name. Stopping an app such as `Brimday` could therefore also terminate tmux, a shell, an editor, or an agent process that merely contained `Brimday` in its arguments. In the reported case this detached the developer's tmux session and interrupted the workflow instead of only stopping the app.

The process-ID path also accepted unsafe values when internal callers invoked the execution logic without going through the public schema. PID `0` is especially dangerous because `kill` interprets it as the caller's entire process group.

## Fix

Name-based stops now use macOS `killall` with the application executable name. `killall` selects processes by their process name rather than searching their command-line arguments, so a matching project path, tmux session, shell command, or other later argument cannot select an unrelated process. The `--` separator prevents an application name beginning with `-` from being interpreted as an option, and long executable names remain supported.

The public schema and the execution boundary now both reject empty application names and process IDs that are non-positive, fractional, non-finite, or outside JavaScript's safe-integer range before invoking a system command. Invalid process IDs are removed from failure artifacts so those error responses still satisfy the published structured-output schema.

The external interface is unchanged. A process ID still targets one process and takes precedence when both inputs are present. An application name still stops every process whose executable has exactly that name.

## Regression protection

Focused tests cover name-based command construction, long executable names, names containing option or regular-expression characters, process-ID precedence, and every rejected process-ID class. The invalid-ID tests also prove that no system command is executed and that the emitted failure artifacts contain no invalid process ID. The smoke harness verifies the exact command exposed through the MCP tool boundary.

The selection behavior was additionally verified against real macOS processes: a target with a long executable name was stopped successfully, while another process carrying `/tmp/<target-name>` only as a later argument remained running. An executable name beginning with `-` was also stopped successfully through the option boundary.

The full unit suite passes with 2,903 tests, together with structured-output schema tests, fixture schema validation, type checking, the production build, formatting, and linting. Snapshot and smoke suites were not run because repository policy requires separate approval.

Fixes #306.
