### PR TITLE
ci(warden): Use OpenRouter for sweep

### DIFF
--- a/.github/workflows/warden-sweep.yml
+++ b/.github/workflows/warden-sweep.yml
@@ -24,12 +24,11 @@ jobs:
     timeout-minutes: 120
     env:
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_OPENROUTER_API_KEY: ${{ secrets.WARDEN_OPENROUTER_API_KEY }}
       WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: getsentry/warden@2130c979dec0163048d954d9599504e2d9fa2b07
-        with:
-          anthropic-api-key: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+      - uses: getsentry/warden@v0
 
       - name: Summarize Warden results
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed simulator UI launching and keyboard controls to prefer Xcode 27's Device Hub when available, with Simulator.app as the legacy fallback.
 - Fixed `stop_mac_app` app-name targeting so it no longer terminates unrelated processes whose command lines contain the app name, and reject unsafe process IDs before execution ([#306](https://github.com/getsentry/XcodeBuildMCP/issues/306)).
 - Fixed incremental `xcodemake` builds when DerivedData uses an absolute path by updating the pinned wrapper and delegating Makefile reuse to it so its argument and freshness checks are always applied ([#466](https://github.com/getsentry/XcodeBuildMCP/issues/466)).
+- Fixed the scheduled Warden sweep to authenticate through OpenRouter and track the current v0 action release ([#483](https://github.com/getsentry/XcodeBuildMCP/issues/483)).
 
 ## [2.6.2]
 


### PR DESCRIPTION
The scheduled Warden sweep now reads the organization-managed OpenRouter key from the job environment and follows `getsentry/warden@v0` instead of a fixed action commit. The existing schedule, model selection, write permissions, and result reporting remain unchanged.

Fixes #483
