### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/com-xcodebuildmcp-xcodebuildmcp)](https://mcpindex.ai/server/com-xcodebuildmcp-xcodebuildmcp)
+
 <img src="assets/banner.png" alt="XcodeBuild MCP" width="600"/>
 
 A Model Context Protocol (MCP) server and CLI that provides tools for agent use when working on iOS and macOS projects.


### PR DESCRIPTION
Hey, ran XcodeBuildMCP through mcpindex's screening (description-level check for injection/manipulation patterns, nothing deeper). Came back clean, so added the badge to your README. It's advisory, not a security certification. Close this if it's not useful to you.